### PR TITLE
feat: idempotency keys for send()

### DIFF
--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -429,6 +429,8 @@ export function createNotifyKit<
     let reject!: (e: unknown) => void;
     const result = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
 
+    // fn runs as both fulfilled/rejected handler: each queued operation executes
+    // regardless of its predecessor's outcome (errors don't abort the queue).
     const newChain = entry.chain.then(fn, fn).then(resolve, reject);
     entry.chain = newChain;
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -431,7 +431,7 @@ export function createNotifyKit<
     chain.then(cleanup);
     // Safety net: evict stale entries if fn() never settles.
     const timer = setTimeout(cleanup, LOCK_TIMEOUT_MS);
-    chain.then(() => clearTimeout(timer));
+    chain.finally(() => clearTimeout(timer));
     return result;
   }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -706,10 +706,9 @@ export function createNotifyKit<
             if (age < ttl) {
               const replay = await buildIdempotentReplay(existing);
               if (replay) return replay;
-            } else {
-              await database.notifications.clearIdempotencyKey(existing.id);
-              return sendInner(rawInput);
             }
+            await database.notifications.clearIdempotencyKey(existing.id);
+            return withIdempotencyLock(lockKey, () => sendInner(rawInput));
           }
         }
         throw err;

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -418,20 +418,30 @@ export function createNotifyKit<
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends
   // with the same key from racing past the findByIdempotencyKey check.
-  const idempotencyLocks = new Map<string, Promise<unknown>>();
+  const idempotencyLocks = new Map<string, { chain: Promise<unknown>; pending: number }>();
   const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
   function withIdempotencyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    const prev = idempotencyLocks.get(key) ?? Promise.resolve();
+    const entry = idempotencyLocks.get(key) ?? { chain: Promise.resolve(), pending: 0 };
+    entry.pending++;
+    if (!idempotencyLocks.has(key)) idempotencyLocks.set(key, entry);
+
     let resolve!: (v: T) => void;
     let reject!: (e: unknown) => void;
     const result = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
-    const chain = prev.then(fn, fn).then(resolve, reject);
-    idempotencyLocks.set(key, chain);
-    const cleanup = () => { if (idempotencyLocks.get(key) === chain) idempotencyLocks.delete(key); };
-    chain.then(cleanup);
-    // Safety net: evict stale entries if fn() never settles.
+
+    const newChain = entry.chain.then(fn, fn).then(resolve, reject);
+    entry.chain = newChain;
+
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      entry.pending--;
+      if (entry.pending === 0) idempotencyLocks.delete(key);
+    };
     const timer = setTimeout(cleanup, LOCK_TIMEOUT_MS);
-    chain.finally(() => clearTimeout(timer));
+    newChain.finally(() => { clearTimeout(timer); cleanup(); });
+
     return result;
   }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -601,6 +601,39 @@ export function createNotifyKit<
     return JSON.stringify(["idem", notificationId, recipientId, userKey]);
   }
 
+  async function buildIdempotentReplay(existing: NotificationRecord): Promise<SendResult> {
+    const [existingDeliveries, existingInboxItems] = await Promise.all([
+      database.deliveries.listByNotificationRecordId(existing.id),
+      database.inbox.listByNotificationRecordId(existing.id),
+    ]);
+    const skipped: SkippedDelivery[] = existingDeliveries
+      .filter((d) => d.status === "skipped")
+      .map((d) => ({
+        channel: d.channel,
+        reason: (d.skipReason ?? "idempotent_replay") as SkipReason,
+        details: d.skipDetails,
+      }));
+    return {
+      notification: existing,
+      inboxItems: existingInboxItems,
+      deliveries: existingDeliveries,
+      skippedChannels: skipped.map((s) => s.channel),
+      skipped,
+      deferredChannels: existingDeliveries
+        .filter((d) => d.skipReason === "quiet_hours_deferred")
+        .map((d) => d.channel),
+      digested: false,
+      rateLimited: existingDeliveries.some((d) => d.skipReason === "rate_limited"),
+      idempotent: true,
+    };
+  }
+
+  function isUniqueConstraintError(err: unknown): boolean {
+    if (!(err instanceof Error)) return false;
+    const msg = err.message.toLowerCase();
+    return msg.includes("unique constraint") || msg.includes("duplicate key") || msg.includes("unique_violation");
+  }
+
   function storageKey(parts: readonly string[]): string {
     return JSON.stringify(parts);
   }
@@ -658,7 +691,16 @@ export function createNotifyKit<
     const input = rawInput as { notificationId: string; recipientId: string; idempotencyKey?: string };
     if (input.idempotencyKey) {
       const lockKey = `${input.notificationId}:${input.recipientId}:${input.idempotencyKey}`;
-      return withIdempotencyLock(lockKey, () => sendInner(rawInput));
+      const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
+      try {
+        return await withIdempotencyLock(lockKey, () => sendInner(rawInput));
+      } catch (err) {
+        if (isUniqueConstraintError(err)) {
+          const existing = await database.notifications.findByIdempotencyKey(compositeKey);
+          if (existing) return buildIdempotentReplay(existing);
+        }
+        throw err;
+      }
     }
     return sendInner(rawInput);
   }
@@ -732,32 +774,7 @@ export function createNotifyKit<
         const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
         const age = Date.now() - existing.createdAt.getTime();
         if (age < ttl) {
-          const [existingDeliveries, existingInboxItems] = await Promise.all([
-            database.deliveries.listByNotificationRecordId(existing.id),
-            database.inbox.listByNotificationRecordId(existing.id),
-          ]);
-          const skipped: SkippedDelivery[] = existingDeliveries
-            .filter((d) => d.status === "skipped")
-            .map((d) => ({
-              channel: d.channel,
-              reason: (d.skipReason ?? "idempotent_replay") as SkipReason,
-              details: d.skipDetails,
-            }));
-          // digested is always false here: digest sends never create a
-          // NotificationRecord, so findByIdempotencyKey can only find non-digest sends.
-          return {
-            notification: existing,
-            inboxItems: existingInboxItems,
-            deliveries: existingDeliveries,
-            skippedChannels: skipped.map((s) => s.channel),
-            skipped,
-            deferredChannels: existingDeliveries
-              .filter((d) => d.skipReason === "quiet_hours_deferred")
-              .map((d) => d.channel),
-            digested: false,
-            rateLimited: existingDeliveries.some((d) => d.skipReason === "rate_limited"),
-            idempotent: true,
-          };
+          return buildIdempotentReplay(existing);
         }
       }
     }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -598,7 +598,7 @@ export function createNotifyKit<
     notificationId: string,
     recipientId: string,
   ): string {
-    return `idem:${notificationId}:${recipientId}:${userKey}`;
+    return JSON.stringify(["idem", notificationId, recipientId, userKey]);
   }
 
   function storageKey(parts: readonly string[]): string {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -715,14 +715,13 @@ export function createNotifyKit<
     }
     const scope = resolveScope(input, recipient);
 
+    const compositeIdempotencyKey = input.idempotencyKey
+      ? idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId)
+      : undefined;
+
     // Idempotency key dedup — if key exists and is within TTL, replay.
-    if (input.idempotencyKey) {
-      const compositeKey = idempotencyCompositeKey(
-        input.idempotencyKey,
-        input.notificationId,
-        input.recipientId,
-      );
-      const existing = await database.notifications.findByIdempotencyKey(compositeKey);
+    if (compositeIdempotencyKey) {
+      const existing = await database.notifications.findByIdempotencyKey(compositeIdempotencyKey);
       if (existing) {
         const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
         const age = Date.now() - existing.createdAt.getTime();
@@ -754,10 +753,6 @@ export function createNotifyKit<
         }
       }
     }
-
-    const compositeIdempotencyKey = input.idempotencyKey
-      ? idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId)
-      : undefined;
 
     const resolutionCtx = await buildResolutionCtx(recipient, def, scope);
     const prefResult = resolvePreferences(resolutionCtx);

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -421,12 +421,15 @@ export function createNotifyKit<
   const idempotencyLocks = new Map<string, Promise<unknown>>();
   function withIdempotencyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
     const prev = idempotencyLocks.get(key) ?? Promise.resolve();
-    const next = prev.then(fn, fn);
-    idempotencyLocks.set(key, next);
-    next.finally(() => {
-      if (idempotencyLocks.get(key) === next) idempotencyLocks.delete(key);
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const result = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+    const chain = prev.then(fn, fn).then(resolve, reject);
+    idempotencyLocks.set(key, chain);
+    chain.then(() => {
+      if (idempotencyLocks.get(key) === chain) idempotencyLocks.delete(key);
     });
-    return next;
+    return result;
   }
 
   const pendingFlushes = new Set<Promise<void>>();

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -693,6 +693,16 @@ export function createNotifyKit<
   async function send(rawInput: SendInput<T>): Promise<SendResult> {
     const input = rawInput as { notificationId: string; recipientId: string; idempotencyKey?: string };
     if (input.idempotencyKey) {
+      if (input.idempotencyKey.length > 256) {
+        throw new NotifyKitError(
+          "idempotencyKey must be 256 characters or fewer.",
+          {
+            code: "INVALID_INPUT",
+            field: "idempotencyKey",
+            fix: "Shorten the idempotencyKey to 256 characters or fewer.",
+          },
+        );
+      }
       const lockKey = `${input.notificationId}:${input.recipientId}:${input.idempotencyKey}`;
       const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
       try {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -601,11 +601,14 @@ export function createNotifyKit<
     return JSON.stringify(["idem", notificationId, recipientId, userKey]);
   }
 
-  async function buildIdempotentReplay(existing: NotificationRecord): Promise<SendResult> {
+  async function buildIdempotentReplay(existing: NotificationRecord): Promise<SendResult | null> {
     const [existingDeliveries, existingInboxItems] = await Promise.all([
       database.deliveries.listByNotificationRecordId(existing.id),
       database.inbox.listByNotificationRecordId(existing.id),
     ]);
+    if (existingDeliveries.length === 0 && existingInboxItems.length === 0) {
+      return null;
+    }
     const skipped: SkippedDelivery[] = existingDeliveries
       .filter((d) => d.status === "skipped")
       .map((d) => ({
@@ -701,10 +704,12 @@ export function createNotifyKit<
             const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
             const age = Date.now() - existing.createdAt.getTime();
             if (age < ttl) {
-              return buildIdempotentReplay(existing);
+              const replay = await buildIdempotentReplay(existing);
+              if (replay) return replay;
+            } else {
+              await database.notifications.clearIdempotencyKey(existing.id);
+              return sendInner(rawInput);
             }
-            await database.notifications.clearIdempotencyKey(existing.id);
-            return sendInner(rawInput);
           }
         }
         throw err;
@@ -782,7 +787,8 @@ export function createNotifyKit<
         const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
         const age = Date.now() - existing.createdAt.getTime();
         if (age < ttl) {
-          return buildIdempotentReplay(existing);
+          const replay = await buildIdempotentReplay(existing);
+          if (replay) return replay;
         }
         await database.notifications.clearIdempotencyKey(existing.id);
       }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -716,7 +716,7 @@ export function createNotifyKit<
       const lockKey = `${input.notificationId}:${input.recipientId}:${input.idempotencyKey}`;
       const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
       try {
-        return await withIdempotencyLock(lockKey, () => sendInner(rawInput));
+        return await withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
       } catch (err) {
         if (isUniqueConstraintError(err)) {
           const existing = await database.notifications.findByIdempotencyKey(compositeKey);
@@ -728,7 +728,7 @@ export function createNotifyKit<
               if (replay) return replay;
             }
             await database.notifications.clearIdempotencyKey(existing.id);
-            return withIdempotencyLock(lockKey, () => sendInner(rawInput));
+            return withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
           }
         }
         throw err;
@@ -737,7 +737,7 @@ export function createNotifyKit<
     return sendInner(rawInput);
   }
 
-  async function sendInner(rawInput: SendInput<T>): Promise<SendResult> {
+  async function sendInner(rawInput: SendInput<T>, preComputedCompositeKey?: string): Promise<SendResult> {
     const input = rawInput as {
       recipientId: string;
       tenantId?: string;
@@ -795,9 +795,9 @@ export function createNotifyKit<
     }
     const scope = resolveScope(input, recipient);
 
-    const compositeIdempotencyKey = input.idempotencyKey
+    const compositeIdempotencyKey = preComputedCompositeKey ?? (input.idempotencyKey
       ? idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId)
-      : undefined;
+      : undefined);
 
     // Idempotency key dedup — if key exists and is within TTL, replay.
     if (compositeIdempotencyKey) {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -697,7 +697,15 @@ export function createNotifyKit<
       } catch (err) {
         if (isUniqueConstraintError(err)) {
           const existing = await database.notifications.findByIdempotencyKey(compositeKey);
-          if (existing) return buildIdempotentReplay(existing);
+          if (existing) {
+            const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
+            const age = Date.now() - existing.createdAt.getTime();
+            if (age < ttl) {
+              return buildIdempotentReplay(existing);
+            }
+            await database.notifications.clearIdempotencyKey(existing.id);
+            return sendInner(rawInput);
+          }
         }
         throw err;
       }
@@ -776,6 +784,7 @@ export function createNotifyKit<
         if (age < ttl) {
           return buildIdempotentReplay(existing);
         }
+        await database.notifications.clearIdempotencyKey(existing.id);
       }
     }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -641,13 +641,16 @@ export function createNotifyKit<
     };
   }
 
-  function isUniqueConstraintError(err: unknown, indexHint?: string): boolean {
+  function isUniqueConstraintError(err: unknown): boolean {
     if (!(err instanceof Error)) return false;
     const msg = err.message.toLowerCase();
-    const isUnique = msg.includes("unique constraint") || msg.includes("duplicate key") || msg.includes("unique_violation");
-    if (!isUnique) return false;
-    if (indexHint && !msg.includes(indexHint.toLowerCase())) return false;
-    return true;
+    return msg.includes("unique constraint") || msg.includes("duplicate key") || msg.includes("unique_violation");
+  }
+
+  function isIdempotencyKeyConstraintError(err: unknown): boolean {
+    if (!isUniqueConstraintError(err)) return false;
+    const msg = (err as Error).message.toLowerCase();
+    return msg.includes("idempotency_key");
   }
 
   function storageKey(parts: readonly string[]): string {
@@ -721,7 +724,7 @@ export function createNotifyKit<
       try {
         return await withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
       } catch (err) {
-        if (isUniqueConstraintError(err, "idempotency_key")) {
+        if (isIdempotencyKeyConstraintError(err) || isUniqueConstraintError(err)) {
           const existing = await database.notifications.findByIdempotencyKey(compositeKey);
           if (existing) {
             const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -740,6 +740,8 @@ export function createNotifyKit<
               reason: (d.skipReason ?? "idempotent_replay") as SkipReason,
               details: d.skipDetails,
             }));
+          // digested is always false here: digest sends never create a
+          // NotificationRecord, so findByIdempotencyKey can only find non-digest sends.
           return {
             notification: existing,
             inboxItems: existingInboxItems,

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -653,6 +653,16 @@ export function createNotifyKit<
     return msg.includes("idempotency_key");
   }
 
+  const digestIdempotencyWarned = new Set<string>();
+  function warnIdempotencyKeyIgnoredForDigest(notificationId: string): void {
+    if (digestIdempotencyWarned.has(notificationId)) return;
+    digestIdempotencyWarned.add(notificationId);
+    console.warn(
+      `[notifykit] [${notificationId}] idempotencyKey is ignored for digested notifications. ` +
+      `The key has no effect when digest is configured.`,
+    );
+  }
+
   function storageKey(parts: readonly string[]): string {
     return JSON.stringify(parts);
   }
@@ -911,6 +921,9 @@ export function createNotifyKit<
     }
 
     if (def.digest) {
+      if (input.idempotencyKey) {
+        warnIdempotencyKeyIgnoredForDigest(def.id);
+      }
       const digest = def.digest;
       const groupKey =
         digest.key?.({

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -641,10 +641,13 @@ export function createNotifyKit<
     };
   }
 
-  function isUniqueConstraintError(err: unknown): boolean {
+  function isUniqueConstraintError(err: unknown, indexHint?: string): boolean {
     if (!(err instanceof Error)) return false;
     const msg = err.message.toLowerCase();
-    return msg.includes("unique constraint") || msg.includes("duplicate key") || msg.includes("unique_violation");
+    const isUnique = msg.includes("unique constraint") || msg.includes("duplicate key") || msg.includes("unique_violation");
+    if (!isUnique) return false;
+    if (indexHint && !msg.includes(indexHint.toLowerCase())) return false;
+    return true;
   }
 
   function storageKey(parts: readonly string[]): string {
@@ -718,7 +721,7 @@ export function createNotifyKit<
       try {
         return await withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
       } catch (err) {
-        if (isUniqueConstraintError(err)) {
+        if (isUniqueConstraintError(err, "idempotency_key")) {
           const existing = await database.notifications.findByIdempotencyKey(compositeKey);
           if (existing) {
             const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -652,9 +652,9 @@ export function createNotifyKit<
   }
 
   async function send(rawInput: SendInput<T>): Promise<SendResult> {
-    const rawKey = (rawInput as { idempotencyKey?: string }).idempotencyKey;
-    if (rawKey) {
-      const lockKey = `${(rawInput as { notificationId: string }).notificationId}:${(rawInput as { recipientId: string }).recipientId}:${rawKey}`;
+    const input = rawInput as { notificationId: string; recipientId: string; idempotencyKey?: string };
+    if (input.idempotencyKey) {
+      const lockKey = `${input.notificationId}:${input.recipientId}:${input.idempotencyKey}`;
       return withIdempotencyLock(lockKey, () => sendInner(rawInput));
     }
     return sendInner(rawInput);

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -419,6 +419,7 @@ export function createNotifyKit<
   // Per-key serialization for idempotency checks. Prevents concurrent sends
   // with the same key from racing past the findByIdempotencyKey check.
   const idempotencyLocks = new Map<string, Promise<unknown>>();
+  const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
   function withIdempotencyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
     const prev = idempotencyLocks.get(key) ?? Promise.resolve();
     let resolve!: (v: T) => void;
@@ -426,9 +427,11 @@ export function createNotifyKit<
     const result = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
     const chain = prev.then(fn, fn).then(resolve, reject);
     idempotencyLocks.set(key, chain);
-    chain.then(() => {
-      if (idempotencyLocks.get(key) === chain) idempotencyLocks.delete(key);
-    });
+    const cleanup = () => { if (idempotencyLocks.get(key) === chain) idempotencyLocks.delete(key); };
+    chain.then(cleanup);
+    // Safety net: evict stale entries if fn() never settles.
+    const timer = setTimeout(cleanup, LOCK_TIMEOUT_MS);
+    chain.then(() => clearTimeout(timer));
     return result;
   }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -108,6 +108,11 @@ export type CreateNotifyKitInput<
    * Use `memoryRealtimeAdapter()` for single-process deployments.
    */
   realtime?: RealtimeAdapter;
+  /**
+   * TTL for idempotency keys in milliseconds. If a duplicate send arrives
+   * after this window, it is treated as a new send. Default: 24 hours.
+   */
+  idempotencyKeyTtlMs?: number;
 };
 
 export type SendResult = {
@@ -144,6 +149,11 @@ export type SendResult = {
    * hook fires but no actual delivery is attempted.
    */
   rateLimited: boolean;
+  /**
+   * True if this result was returned from an idempotent replay — the
+   * original send's result was returned without re-processing.
+   */
+  idempotent: boolean;
 };
 
 export type NotifyKit<
@@ -406,6 +416,19 @@ export function createNotifyKit<
     }
   }
 
+  // Per-key serialization for idempotency checks. Prevents concurrent sends
+  // with the same key from racing past the findByIdempotencyKey check.
+  const idempotencyLocks = new Map<string, Promise<unknown>>();
+  function withIdempotencyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = idempotencyLocks.get(key) ?? Promise.resolve();
+    const next = prev.then(fn, fn);
+    idempotencyLocks.set(key, next);
+    next.finally(() => {
+      if (idempotencyLocks.get(key) === next) idempotencyLocks.delete(key);
+    });
+    return next;
+  }
+
   const pendingFlushes = new Set<Promise<void>>();
   type ScheduledFlush = {
     timer: ReturnType<typeof setTimeout>;
@@ -535,6 +558,7 @@ export function createNotifyKit<
     def: NotificationDefinition<string, PayloadSchema>;
     payload: Record<string, unknown>;
     skipped: SkippedDelivery[];
+    idempotencyKey?: string;
   }): Promise<{ notificationRecord: NotificationRecord; skippedRecords: DeliveryRecord[] }> {
     const notificationRecord = await database.notifications.create({
       recipientId: ctx.recipient.id,
@@ -544,6 +568,7 @@ export function createNotifyKit<
       payload: ctx.payload,
       payloadSchema: { ...ctx.def.payload },
       definitionVersion: ctx.def.version,
+      idempotencyKey: ctx.idempotencyKey,
     });
     await runHook("notification.created", {
       notification: notificationRecord,
@@ -560,6 +585,14 @@ export function createNotifyKit<
       ctx.skipped.map((s) => persistSkip({ ...base, channel: s.channel, reason: s.reason, details: s.details })),
     );
     return { notificationRecord, skippedRecords };
+  }
+
+  function idempotencyCompositeKey(
+    userKey: string,
+    notificationId: string,
+    recipientId: string,
+  ): string {
+    return `idem:${notificationId}:${recipientId}:${userKey}`;
   }
 
   function storageKey(parts: readonly string[]): string {
@@ -616,12 +649,22 @@ export function createNotifyKit<
   }
 
   async function send(rawInput: SendInput<T>): Promise<SendResult> {
+    const rawKey = (rawInput as { idempotencyKey?: string }).idempotencyKey;
+    if (rawKey) {
+      const lockKey = `${(rawInput as { notificationId: string }).notificationId}:${(rawInput as { recipientId: string }).recipientId}:${rawKey}`;
+      return withIdempotencyLock(lockKey, () => sendInner(rawInput));
+    }
+    return sendInner(rawInput);
+  }
+
+  async function sendInner(rawInput: SendInput<T>): Promise<SendResult> {
     const input = rawInput as {
       recipientId: string;
       tenantId?: string;
       workspaceId?: string;
       notificationId: string;
       payload: unknown;
+      idempotencyKey?: string;
     };
     if (!input.recipientId) {
       throw new NotifyKitError(
@@ -672,6 +715,50 @@ export function createNotifyKit<
     }
     const scope = resolveScope(input, recipient);
 
+    // Idempotency key dedup — if key exists and is within TTL, replay.
+    if (input.idempotencyKey) {
+      const compositeKey = idempotencyCompositeKey(
+        input.idempotencyKey,
+        input.notificationId,
+        input.recipientId,
+      );
+      const existing = await database.notifications.findByIdempotencyKey(compositeKey);
+      if (existing) {
+        const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
+        const age = Date.now() - existing.createdAt.getTime();
+        if (age < ttl) {
+          const [existingDeliveries, existingInboxItems] = await Promise.all([
+            database.deliveries.listByNotificationRecordId(existing.id),
+            database.inbox.listByNotificationRecordId(existing.id),
+          ]);
+          const skipped: SkippedDelivery[] = existingDeliveries
+            .filter((d) => d.status === "skipped")
+            .map((d) => ({
+              channel: d.channel,
+              reason: (d.skipReason ?? "idempotent_replay") as SkipReason,
+              details: d.skipDetails,
+            }));
+          return {
+            notification: existing,
+            inboxItems: existingInboxItems,
+            deliveries: existingDeliveries,
+            skippedChannels: skipped.map((s) => s.channel),
+            skipped,
+            deferredChannels: existingDeliveries
+              .filter((d) => d.skipReason === "quiet_hours_deferred")
+              .map((d) => d.channel),
+            digested: false,
+            rateLimited: existingDeliveries.some((d) => d.skipReason === "rate_limited"),
+            idempotent: true,
+          };
+        }
+      }
+    }
+
+    const compositeIdempotencyKey = input.idempotencyKey
+      ? idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId)
+      : undefined;
+
     const resolutionCtx = await buildResolutionCtx(recipient, def, scope);
     const prefResult = resolvePreferences(resolutionCtx);
     const hasAnyAllowed = prefResult.channels.some((ch) => ch.allowed);
@@ -697,7 +784,7 @@ export function createNotifyKit<
         details: ch.reason,
       }));
       const { notificationRecord, skippedRecords } = await createSkippedNotification({
-        recipient, scope, def, payload, skipped,
+        recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
       });
       await runHook("notification.suppressed", {
         notificationId: def.id,
@@ -714,6 +801,7 @@ export function createNotifyKit<
         deferredChannels: [],
         digested: false,
         rateLimited: false,
+        idempotent: false,
       };
     }
 
@@ -741,7 +829,7 @@ export function createNotifyKit<
           details: `Rate limit exceeded: ${limit.max} per ${limit.windowMs}ms`,
         }));
         const { notificationRecord, skippedRecords } = await createSkippedNotification({
-          recipient, scope, def, payload, skipped,
+          recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
         });
         await runHook("notification.rate_limited", {
           notificationId: def.id,
@@ -757,6 +845,7 @@ export function createNotifyKit<
           deferredChannels: [],
           digested: false,
           rateLimited: true,
+          idempotent: false,
         };
       }
     }
@@ -809,6 +898,7 @@ export function createNotifyKit<
         deferredChannels: [],
         digested: true,
         rateLimited: false,
+        idempotent: false,
       };
     }
 
@@ -829,7 +919,7 @@ export function createNotifyKit<
     }
 
     if (deferChannels.length > 0) {
-      const result = await deliver(recipient, def, payload, { deferChannels, scope, prefResult });
+      const result = await deliver(recipient, def, payload, { deferChannels, scope, prefResult, idempotencyKey: compositeIdempotencyKey });
       const scheduledFor = nextQuietHoursEnd(recipient.quietHours!);
       const record = await database.scheduledSends.create({
         recipientId: recipient.id,
@@ -845,7 +935,7 @@ export function createNotifyKit<
       return result;
     }
 
-    return deliver(recipient, def, payload, { scope, prefResult });
+    return deliver(recipient, def, payload, { scope, prefResult, idempotencyKey: compositeIdempotencyKey });
   }
 
   async function explain(rawInput: SendInput<T>): Promise<DeliveryExplanation> {
@@ -1375,6 +1465,8 @@ export function createNotifyKit<
     onlyChannels?: ChannelType[];
     /** Pre-resolved preference result from send(). Avoids re-fetching. */
     prefResult?: PreferenceExplanation;
+    /** Composite idempotency key to store on the notification record. */
+    idempotencyKey?: string;
   };
 
   async function deliver(
@@ -1407,6 +1499,7 @@ export function createNotifyKit<
         payload,
         payloadSchema: { ...def.payload },
         definitionVersion: def.version,
+        idempotencyKey: options.idempotencyKey,
       }));
     if (!options.existingNotification) {
       await runHook("notification.created", {
@@ -1674,6 +1767,7 @@ export function createNotifyKit<
       deferredChannels,
       digested: false,
       rateLimited: false,
+      idempotent: false,
     };
   }
 

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -114,10 +114,14 @@ export function memoryAdapter(): MemoryAdapter {
           payload: input.payload,
           payloadSchema: input.payloadSchema,
           definitionVersion: input.definitionVersion,
+          idempotencyKey: input.idempotencyKey,
           createdAt: new Date(),
         };
         state.notifications.push(record);
         return record;
+      },
+      async findByIdempotencyKey(key: string): Promise<NotificationRecord | null> {
+        return state.notifications.find((n) => n.idempotencyKey === key) ?? null;
       },
     },
     inbox: {
@@ -155,6 +159,9 @@ export function memoryAdapter(): MemoryAdapter {
           .slice()
           .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
         return limit !== undefined ? items.slice(0, limit) : items;
+      },
+      async listByNotificationRecordId(notificationRecordId: string): Promise<InboxItem[]> {
+        return state.inboxItems.filter((i) => i.notificationRecordId === notificationRecordId);
       },
       async markReadForRecipient(
         inboxItemId: string,
@@ -277,6 +284,9 @@ export function memoryAdapter(): MemoryAdapter {
       },
       async findById(id: string): Promise<DeliveryRecord | null> {
         return state.deliveries.find((d) => d.id === id) ?? null;
+      },
+      async listByNotificationRecordId(notificationRecordId: string): Promise<DeliveryRecord[]> {
+        return state.deliveries.filter((d) => d.notificationRecordId === notificationRecordId);
       },
       async update(id, patch): Promise<DeliveryRecord | null> {
         const existing = state.deliveries.find((d) => d.id === id);

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -123,6 +123,10 @@ export function memoryAdapter(): MemoryAdapter {
       async findByIdempotencyKey(key: string): Promise<NotificationRecord | null> {
         return state.notifications.find((n) => n.idempotencyKey === key) ?? null;
       },
+      async clearIdempotencyKey(id: string): Promise<void> {
+        const record = state.notifications.find((n) => n.id === id);
+        if (record) record.idempotencyKey = undefined;
+      },
     },
     inbox: {
       async create(input): Promise<InboxItem> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -295,6 +295,12 @@ export type NotificationRecord = {
   payloadSchema?: Record<string, string>;
   /** Definition version at send time. Matches `NotificationDefinition.version`. */
   definitionVersion?: number;
+  /**
+   * Composite idempotency key stored when the caller passes `idempotencyKey`
+   * to `send()`. Combines (key, notificationId, recipientId) so the same
+   * user-provided key is scoped per notification type and recipient.
+   */
+  idempotencyKey?: string;
   createdAt: Date;
 };
 
@@ -557,6 +563,7 @@ export type DatabaseAdapter = {
   };
   notifications: {
     create(input: Omit<NotificationRecord, "id" | "createdAt">): Promise<NotificationRecord>;
+    findByIdempotencyKey(key: string): Promise<NotificationRecord | null>;
   };
   inbox: {
     create(
@@ -568,6 +575,7 @@ export type DatabaseAdapter = {
       filter?: InboxListFilter,
       limit?: number,
     ): Promise<InboxItem[]>;
+    listByNotificationRecordId(notificationRecordId: string): Promise<InboxItem[]>;
     markReadForRecipient(
       inboxItemId: string,
       recipientId: string,
@@ -604,6 +612,7 @@ export type DatabaseAdapter = {
       },
     ): Promise<DeliveryRecord>;
     findById(id: string): Promise<DeliveryRecord | null>;
+    listByNotificationRecordId(notificationRecordId: string): Promise<DeliveryRecord[]>;
     update(
       id: string,
       patch: Partial<Omit<DeliveryRecord, "id" | "createdAt">>,
@@ -761,6 +770,12 @@ export type SendInput<
     workspaceId?: string;
     notificationId: K["id"];
     payload: InferSchema<K["payload"]>;
+    /**
+     * Optional idempotency key. When provided, duplicate `send()` calls with
+     * the same key + notificationId + recipientId within the TTL window return
+     * the original result without re-processing.
+     */
+    idempotencyKey?: string;
   };
 }[T[number]["id"]];
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -774,6 +774,10 @@ export type SendInput<
      * Optional idempotency key. When provided, duplicate `send()` calls with
      * the same key + notificationId + recipientId within the TTL window return
      * the original result without re-processing.
+     *
+     * Not supported for digested notifications — digest sends buffer payloads
+     * without creating a notification record, so there is nothing to deduplicate.
+     * The key is silently ignored when the notification has a `digest` config.
      */
     idempotencyKey?: string;
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -775,6 +775,10 @@ export type SendInput<
      * the same key + notificationId + recipientId within the TTL window return
      * the original result without re-processing.
      *
+     * The composite key is scoped to (key, notificationId, recipientId) — tenantId
+     * is intentionally excluded. The same logical send retried with a different
+     * tenant context is still considered a duplicate.
+     *
      * Not supported for digested notifications — digest sends buffer payloads
      * without creating a notification record, so there is nothing to deduplicate.
      * The key is silently ignored when the notification has a `digest` config.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -564,6 +564,7 @@ export type DatabaseAdapter = {
   notifications: {
     create(input: Omit<NotificationRecord, "id" | "createdAt">): Promise<NotificationRecord>;
     findByIdempotencyKey(key: string): Promise<NotificationRecord | null>;
+    clearIdempotencyKey(id: string): Promise<void>;
   };
   inbox: {
     create(

--- a/packages/core/tests/idempotency.test.ts
+++ b/packages/core/tests/idempotency.test.ts
@@ -253,4 +253,43 @@ describe("idempotency keys", () => {
     expect(second.skipped.length).toBeGreaterThan(0);
     expect(second.inboxItems).toHaveLength(1);
   });
+
+  test("idempotencyKey is silently ignored for digested notifications", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "digest-notif",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+      digest: {
+        windowMs: 5000,
+        key: ({ recipientId }) => recipientId,
+        render: ({ payloads }) => ({ msg: payloads.map((p) => p.msg).join(", ") }),
+      },
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const first = await notify.send({
+      recipientId: "u1",
+      notificationId: "digest-notif",
+      payload: { msg: "a" },
+      idempotencyKey: "digest-key",
+    });
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "digest-notif",
+      payload: { msg: "b" },
+      idempotencyKey: "digest-key",
+    });
+
+    // Both sends are buffered into the digest — idempotency key has no effect
+    expect(first.digested).toBe(true);
+    expect(first.idempotent).toBe(false);
+    expect(second.digested).toBe(true);
+    expect(second.idempotent).toBe(false);
+  });
 });

--- a/packages/core/tests/idempotency.test.ts
+++ b/packages/core/tests/idempotency.test.ts
@@ -334,4 +334,18 @@ describe("idempotency keys", () => {
     expect(result.deliveries.length).toBeGreaterThan(0);
     expect(emailProvider.sent).toHaveLength(1);
   });
+
+  test("rejects idempotencyKey longer than 256 characters", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    expect(
+      notify.send({
+        recipientId: "u1",
+        notificationId: "alert",
+        payload: { msg: "hi" },
+        idempotencyKey: "x".repeat(257),
+      }),
+    ).rejects.toThrow("idempotencyKey must be 256 characters or fewer");
+  });
 });

--- a/packages/core/tests/idempotency.test.ts
+++ b/packages/core/tests/idempotency.test.ts
@@ -292,4 +292,46 @@ describe("idempotency keys", () => {
     expect(second.digested).toBe(true);
     expect(second.idempotent).toBe(false);
   });
+
+  test("incomplete notification record (no deliveries) is not replayed", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [
+        inbox({ title: "{{msg}}" }),
+        email({ subject: "{{msg}}", body: "Body: {{msg}}" }),
+      ],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    // Simulate an incomplete record (created but delivery never finished)
+    const compositeKey = JSON.stringify(["idem", "alert", "u1", "incomplete-key"]);
+    db._state.notifications.push({
+      id: "orphan-record",
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "old" },
+      idempotencyKey: compositeKey,
+      createdAt: new Date(),
+    });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "new" },
+      idempotencyKey: "incomplete-key",
+    });
+
+    // Should NOT replay the incomplete record — should process fresh
+    expect(result.idempotent).toBe(false);
+    expect(result.deliveries.length).toBeGreaterThan(0);
+    expect(emailProvider.sent).toHaveLength(1);
+  });
 });

--- a/packages/core/tests/idempotency.test.ts
+++ b/packages/core/tests/idempotency.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test } from "bun:test";
+import {
+  channel,
+  createNotifyKit,
+  fakeEmailProvider,
+  memoryAdapter,
+  notification,
+} from "../src/index.js";
+
+const inbox = channel.inbox();
+const email = channel.email();
+
+function setup(opts?: { ttlMs?: number }) {
+  const db = memoryAdapter();
+  const emailProvider = fakeEmailProvider();
+  const def = notification({
+    id: "alert",
+    payload: { msg: "string" },
+    channels: [
+      inbox({ title: "{{msg}}" }),
+      email({ subject: "{{msg}}", body: "Body: {{msg}}" }),
+    ],
+  });
+  const notify = createNotifyKit({
+    notifications: [def] as const,
+    database: db,
+    providers: { email: emailProvider },
+    idempotencyKeyTtlMs: opts?.ttlMs,
+  });
+  return { db, emailProvider, notify };
+}
+
+describe("idempotency keys", () => {
+  test("duplicate send with same key returns original result without re-processing", async () => {
+    const { db, emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const first = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hello" },
+      idempotencyKey: "key-1",
+    });
+
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hello" },
+      idempotencyKey: "key-1",
+    });
+
+    expect(first.idempotent).toBe(false);
+    expect(second.idempotent).toBe(true);
+    expect(second.notification!.id).toBe(first.notification!.id);
+    expect(second.deliveries.length).toBe(first.deliveries.length);
+    expect(second.inboxItems.length).toBe(first.inboxItems.length);
+
+    // Only one notification record created
+    expect(db._state.notifications).toHaveLength(1);
+    // Only one set of deliveries
+    expect(db._state.inboxItems).toHaveLength(1);
+    // Email sent only once
+    expect(emailProvider.sent).toHaveLength(1);
+  });
+
+  test("different keys produce separate notifications", async () => {
+    const { db, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const first = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "a" },
+      idempotencyKey: "key-a",
+    });
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "b" },
+      idempotencyKey: "key-b",
+    });
+
+    expect(first.idempotent).toBe(false);
+    expect(second.idempotent).toBe(false);
+    expect(first.notification!.id).not.toBe(second.notification!.id);
+    expect(db._state.notifications).toHaveLength(2);
+  });
+
+  test("same key scoped per recipient — different recipients are independent", async () => {
+    const { db, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+    await notify.upsertRecipient({ id: "u2", email: "u2@test.com" });
+
+    const r1 = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "x" },
+      idempotencyKey: "shared-key",
+    });
+    const r2 = await notify.send({
+      recipientId: "u2",
+      notificationId: "alert",
+      payload: { msg: "x" },
+      idempotencyKey: "shared-key",
+    });
+
+    expect(r1.idempotent).toBe(false);
+    expect(r2.idempotent).toBe(false);
+    expect(db._state.notifications).toHaveLength(2);
+  });
+
+  test("expired key allows re-send after TTL", async () => {
+    const { db, notify } = setup({ ttlMs: 50 });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "first" },
+      idempotencyKey: "expire-key",
+    });
+
+    // Artificially age the notification record past the TTL
+    db._state.notifications[0].createdAt = new Date(Date.now() - 100);
+
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "second" },
+      idempotencyKey: "expire-key",
+    });
+
+    expect(second.idempotent).toBe(false);
+    expect(db._state.notifications).toHaveLength(2);
+  });
+
+  test("sends without idempotencyKey are never deduplicated", async () => {
+    const { db, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "a" },
+    });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "a" },
+    });
+
+    expect(db._state.notifications).toHaveLength(2);
+  });
+
+  test("concurrent sends with same key only process once", async () => {
+    const { db, emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        notify.send({
+          recipientId: "u1",
+          notificationId: "alert",
+          payload: { msg: "concurrent" },
+          idempotencyKey: "concurrent-key",
+        }),
+      ),
+    );
+
+    const originals = results.filter((r) => !r.idempotent);
+    const replays = results.filter((r) => r.idempotent);
+
+    // Exactly one original (the first to write wins)
+    expect(originals).toHaveLength(1);
+    expect(replays).toHaveLength(9);
+
+    // All replays reference the same notification
+    const id = originals[0].notification!.id;
+    for (const r of replays) {
+      expect(r.notification!.id).toBe(id);
+    }
+
+    // Only one email sent
+    expect(emailProvider.sent).toHaveLength(1);
+    expect(db._state.notifications).toHaveLength(1);
+  });
+
+  test("idempotent replay preserves skipped/deferred state", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "prefs-test",
+      payload: { msg: "string" },
+      channels: [
+        inbox({ title: "{{msg}}" }),
+        email({ subject: "{{msg}}", body: "Body: {{msg}}" }),
+      ],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "u1" });
+    // Disable email via preferences — only inbox delivers
+    await notify.preferences.update({
+      recipientId: "u1",
+      notificationId: "prefs-test",
+      channels: { email: false },
+    });
+
+    const first = await notify.send({
+      recipientId: "u1",
+      notificationId: "prefs-test",
+      payload: { msg: "test" },
+      idempotencyKey: "pref-key",
+    });
+
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "prefs-test",
+      payload: { msg: "test" },
+      idempotencyKey: "pref-key",
+    });
+
+    expect(second.idempotent).toBe(true);
+    expect(second.skipped.length).toBeGreaterThan(0);
+    expect(second.inboxItems).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/idempotency.test.ts
+++ b/packages/core/tests/idempotency.test.ts
@@ -109,6 +109,33 @@ describe("idempotency keys", () => {
     expect(db._state.notifications).toHaveLength(2);
   });
 
+  test("same key deduplicates regardless of tenantId on send", async () => {
+    const { db, notify } = setup();
+    // Recipient without a fixed tenant — accepts any tenantId on send
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const r1 = await notify.send({
+      recipientId: "u1",
+      tenantId: "t1",
+      notificationId: "alert",
+      payload: { msg: "x" },
+      idempotencyKey: "tenant-key",
+    });
+    const r2 = await notify.send({
+      recipientId: "u1",
+      tenantId: "t2",
+      notificationId: "alert",
+      payload: { msg: "x" },
+      idempotencyKey: "tenant-key",
+    });
+
+    // Idempotency key is scoped to (key, notificationId, recipientId) — NOT tenant.
+    // The same logical send retried with a different tenant context is still a dupe.
+    expect(r1.idempotent).toBe(false);
+    expect(r2.idempotent).toBe(true);
+    expect(db._state.notifications).toHaveLength(1);
+  });
+
   test("expired key allows re-send after TTL", async () => {
     const { db, notify } = setup({ ttlMs: 50 });
     await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -31,10 +31,13 @@ export async function createPgTables(
       payload JSONB NOT NULL,
       payload_schema JSONB,
       definition_version INTEGER,
+      idempotency_key TEXT,
       created_at TIMESTAMPTZ NOT NULL
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_recipient
       ON notifykit_notifications (recipient_id)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
+      ON notifykit_notifications (idempotency_key)`,
     `CREATE TABLE IF NOT EXISTS notifykit_inbox_items (
       id TEXT PRIMARY KEY,
       notification_record_id TEXT NOT NULL,
@@ -149,6 +152,7 @@ export async function createPgTables(
     `ALTER TABLE notifykit_notifications ADD COLUMN IF NOT EXISTS workspace_id TEXT`,
     `ALTER TABLE notifykit_notifications ADD COLUMN IF NOT EXISTS payload_schema JSONB`,
     `ALTER TABLE notifykit_notifications ADD COLUMN IF NOT EXISTS definition_version INTEGER`,
+    `ALTER TABLE notifykit_notifications ADD COLUMN IF NOT EXISTS idempotency_key TEXT`,
     `ALTER TABLE notifykit_inbox_items ADD COLUMN IF NOT EXISTS tenant_id TEXT`,
     `ALTER TABLE notifykit_inbox_items ADD COLUMN IF NOT EXISTS workspace_id TEXT`,
     `ALTER TABLE notifykit_deliveries ADD COLUMN IF NOT EXISTS tenant_id TEXT`,

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -36,8 +36,8 @@ export async function createPgTables(
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_recipient
       ON notifykit_notifications (recipient_id)`,
-    `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
-      ON notifykit_notifications (idempotency_key)`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
+      ON notifykit_notifications (idempotency_key) WHERE idempotency_key IS NOT NULL`,
     `CREATE TABLE IF NOT EXISTS notifykit_inbox_items (
       id TEXT PRIMARY KEY,
       notification_record_id TEXT NOT NULL,

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -36,8 +36,6 @@ export async function createPgTables(
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_recipient
       ON notifykit_notifications (recipient_id)`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
-      ON notifykit_notifications (idempotency_key) WHERE idempotency_key IS NOT NULL`,
     `CREATE TABLE IF NOT EXISTS notifykit_inbox_items (
       id TEXT PRIMARY KEY,
       notification_record_id TEXT NOT NULL,
@@ -153,6 +151,8 @@ export async function createPgTables(
     `ALTER TABLE notifykit_notifications ADD COLUMN IF NOT EXISTS payload_schema JSONB`,
     `ALTER TABLE notifykit_notifications ADD COLUMN IF NOT EXISTS definition_version INTEGER`,
     `ALTER TABLE notifykit_notifications ADD COLUMN IF NOT EXISTS idempotency_key TEXT`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
+      ON notifykit_notifications (idempotency_key) WHERE idempotency_key IS NOT NULL`,
     `ALTER TABLE notifykit_inbox_items ADD COLUMN IF NOT EXISTS tenant_id TEXT`,
     `ALTER TABLE notifykit_inbox_items ADD COLUMN IF NOT EXISTS workspace_id TEXT`,
     `ALTER TABLE notifykit_deliveries ADD COLUMN IF NOT EXISTS tenant_id TEXT`,

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -56,6 +56,8 @@ export async function createPgTables(
       ON notifykit_inbox_items (recipient_id, archived_at, created_at)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_inbox_recipient_unread
       ON notifykit_inbox_items (recipient_id, read_at, archived_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_inbox_notification_record
+      ON notifykit_inbox_items (notification_record_id)`,
     `CREATE TABLE IF NOT EXISTS notifykit_deliveries (
       id TEXT PRIMARY KEY,
       notification_record_id TEXT NOT NULL,

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -31,10 +31,13 @@ export async function createSqliteTables(
       payload TEXT NOT NULL,
       payload_schema TEXT,
       definition_version INTEGER,
+      idempotency_key TEXT,
       created_at INTEGER NOT NULL
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_recipient
       ON notifykit_notifications (recipient_id)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
+      ON notifykit_notifications (idempotency_key)`,
     `CREATE TABLE IF NOT EXISTS notifykit_inbox_items (
       id TEXT PRIMARY KEY,
       notification_record_id TEXT NOT NULL,
@@ -149,6 +152,7 @@ export async function createSqliteTables(
     `ALTER TABLE notifykit_notifications ADD COLUMN workspace_id TEXT`,
     `ALTER TABLE notifykit_notifications ADD COLUMN payload_schema TEXT`,
     `ALTER TABLE notifykit_notifications ADD COLUMN definition_version INTEGER`,
+    `ALTER TABLE notifykit_notifications ADD COLUMN idempotency_key TEXT`,
     `ALTER TABLE notifykit_inbox_items ADD COLUMN tenant_id TEXT`,
     `ALTER TABLE notifykit_inbox_items ADD COLUMN workspace_id TEXT`,
     `ALTER TABLE notifykit_deliveries ADD COLUMN tenant_id TEXT`,

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -36,8 +36,6 @@ export async function createSqliteTables(
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_recipient
       ON notifykit_notifications (recipient_id)`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
-      ON notifykit_notifications (idempotency_key) WHERE idempotency_key IS NOT NULL`,
     `CREATE TABLE IF NOT EXISTS notifykit_inbox_items (
       id TEXT PRIMARY KEY,
       notification_record_id TEXT NOT NULL,
@@ -153,6 +151,8 @@ export async function createSqliteTables(
     `ALTER TABLE notifykit_notifications ADD COLUMN payload_schema TEXT`,
     `ALTER TABLE notifykit_notifications ADD COLUMN definition_version INTEGER`,
     `ALTER TABLE notifykit_notifications ADD COLUMN idempotency_key TEXT`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
+      ON notifykit_notifications (idempotency_key) WHERE idempotency_key IS NOT NULL`,
     `ALTER TABLE notifykit_inbox_items ADD COLUMN tenant_id TEXT`,
     `ALTER TABLE notifykit_inbox_items ADD COLUMN workspace_id TEXT`,
     `ALTER TABLE notifykit_deliveries ADD COLUMN tenant_id TEXT`,

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -36,8 +36,8 @@ export async function createSqliteTables(
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_recipient
       ON notifykit_notifications (recipient_id)`,
-    `CREATE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
-      ON notifykit_notifications (idempotency_key)`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_notifykit_notifications_idempotency_key
+      ON notifykit_notifications (idempotency_key) WHERE idempotency_key IS NOT NULL`,
     `CREATE TABLE IF NOT EXISTS notifykit_inbox_items (
       id TEXT PRIMARY KEY,
       notification_record_id TEXT NOT NULL,

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -56,6 +56,8 @@ export async function createSqliteTables(
       ON notifykit_inbox_items (recipient_id, archived_at, created_at)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_inbox_recipient_unread
       ON notifykit_inbox_items (recipient_id, read_at, archived_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_inbox_notification_record
+      ON notifykit_inbox_items (notification_record_id)`,
     `CREATE TABLE IF NOT EXISTS notifykit_deliveries (
       id TEXT PRIMARY KEY,
       notification_record_id TEXT NOT NULL,

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -191,6 +191,7 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           payload: input.payload,
           payloadSchema: input.payloadSchema,
           definitionVersion: input.definitionVersion,
+          idempotencyKey: input.idempotencyKey,
           createdAt: new Date(),
         };
         await db.insert(notifications).values({
@@ -199,8 +200,30 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           workspaceId: record.workspaceId ?? null,
           payloadSchema: record.payloadSchema ?? null,
           definitionVersion: record.definitionVersion ?? null,
+          idempotencyKey: record.idempotencyKey ?? null,
         });
         return record;
+      },
+      async findByIdempotencyKey(key: string): Promise<NotificationRecord | null> {
+        const rows = await db
+          .select()
+          .from(notifications)
+          .where(eq(notifications.idempotencyKey, key))
+          .limit(1);
+        const row = rows[0];
+        if (!row) return null;
+        return {
+          id: row.id,
+          recipientId: row.recipientId,
+          tenantId: row.tenantId ?? undefined,
+          workspaceId: row.workspaceId ?? undefined,
+          notificationId: row.notificationId,
+          payload: row.payload,
+          payloadSchema: row.payloadSchema ?? undefined,
+          definitionVersion: row.definitionVersion ?? undefined,
+          idempotencyKey: row.idempotencyKey ?? undefined,
+          createdAt: row.createdAt,
+        };
       },
     },
 
@@ -259,6 +282,14 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .orderBy(desc(inboxItems.createdAt));
         const cap = Math.min(limit ?? 200, 1000);
         const rows = await query.limit(cap);
+        return rows.map(rowToInboxItem);
+      },
+
+      async listByNotificationRecordId(notificationRecordId: string): Promise<InboxItem[]> {
+        const rows = await db
+          .select()
+          .from(inboxItems)
+          .where(eq(inboxItems.notificationRecordId, notificationRecordId));
         return rows.map(rowToInboxItem);
       },
 
@@ -468,6 +499,13 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .limit(1);
         const row = rows[0];
         return row ? rowToDelivery(row) : null;
+      },
+      async listByNotificationRecordId(notificationRecordId: string): Promise<DeliveryRecord[]> {
+        const rows = await db
+          .select()
+          .from(deliveries)
+          .where(eq(deliveries.notificationRecordId, notificationRecordId));
+        return rows.map(rowToDelivery);
       },
 
       async update(id, patch): Promise<DeliveryRecord | null> {

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -225,6 +225,12 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           createdAt: row.createdAt,
         };
       },
+      async clearIdempotencyKey(id: string): Promise<void> {
+        await db
+          .update(notifications)
+          .set({ idempotencyKey: null })
+          .where(eq(notifications.id, id));
+      },
     },
 
     inbox: {

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -45,11 +45,16 @@ export const notifications = pgTable(
     payloadSchema: jsonb("payload_schema").$type<Record<string, string>>(),
     /** @since 0.1 – migration: ALTER TABLE notifykit_notifications ADD COLUMN definition_version INTEGER; */
     definitionVersion: integer("definition_version"),
+    /** @since 0.2 – migration: ALTER TABLE notifykit_notifications ADD COLUMN idempotency_key TEXT; */
+    idempotencyKey: text("idempotency_key"),
     createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull(),
   },
   (table) => ({
     recipientIdx: index("idx_notifykit_notifications_recipient").on(
       table.recipientId,
+    ),
+    idempotencyKeyIdx: index("idx_notifykit_notifications_idempotency_key").on(
+      table.idempotencyKey,
     ),
   }),
 );

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -89,6 +89,9 @@ export const inboxItems = pgTable(
       table.readAt,
       table.archivedAt,
     ),
+    notificationRecordIdx: index("idx_notifykit_inbox_notification_record").on(
+      table.notificationRecordId,
+    ),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -7,6 +7,7 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 // Foreign keys are intentionally omitted. Deliveries and notifications are
@@ -53,7 +54,7 @@ export const notifications = pgTable(
     recipientIdx: index("idx_notifykit_notifications_recipient").on(
       table.recipientId,
     ),
-    idempotencyKeyIdx: index("idx_notifykit_notifications_idempotency_key").on(
+    idempotencyKeyIdx: uniqueIndex("idx_notifykit_notifications_idempotency_key").on(
       table.idempotencyKey,
     ),
   }),

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -54,9 +54,9 @@ export const notifications = pgTable(
     recipientIdx: index("idx_notifykit_notifications_recipient").on(
       table.recipientId,
     ),
-    idempotencyKeyIdx: uniqueIndex("idx_notifykit_notifications_idempotency_key").on(
-      table.idempotencyKey,
-    ),
+    idempotencyKeyIdx: uniqueIndex("idx_notifykit_notifications_idempotency_key")
+      .on(table.idempotencyKey)
+      .where(sql`idempotency_key IS NOT NULL`),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -92,6 +92,9 @@ export const inboxItems = sqliteTable(
       table.readAt,
       table.archivedAt,
     ),
+    notificationRecordIdx: index("idx_notifykit_inbox_notification_record").on(
+      table.notificationRecordId,
+    ),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -55,9 +55,9 @@ export const notifications = sqliteTable(
     recipientIdx: index("idx_notifykit_notifications_recipient").on(
       table.recipientId,
     ),
-    idempotencyKeyIdx: uniqueIndex("idx_notifykit_notifications_idempotency_key").on(
-      table.idempotencyKey,
-    ),
+    idempotencyKeyIdx: uniqueIndex("idx_notifykit_notifications_idempotency_key")
+      .on(table.idempotencyKey)
+      .where(sql`idempotency_key IS NOT NULL`),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -46,11 +46,16 @@ export const notifications = sqliteTable(
       .$type<Record<string, string>>(),
     /** @since 0.1 – migration: ALTER TABLE notifykit_notifications ADD COLUMN definition_version INTEGER; */
     definitionVersion: integer("definition_version"),
+    /** @since 0.2 – migration: ALTER TABLE notifykit_notifications ADD COLUMN idempotency_key TEXT; */
+    idempotencyKey: text("idempotency_key"),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   },
   (table) => ({
     recipientIdx: index("idx_notifykit_notifications_recipient").on(
       table.recipientId,
+    ),
+    idempotencyKeyIdx: index("idx_notifykit_notifications_idempotency_key").on(
+      table.idempotencyKey,
     ),
   }),
 );

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -5,6 +5,7 @@ import {
   primaryKey,
   sqliteTable,
   text,
+  uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
 // Foreign keys are intentionally omitted. Deliveries and notifications are
@@ -54,7 +55,7 @@ export const notifications = sqliteTable(
     recipientIdx: index("idx_notifykit_notifications_recipient").on(
       table.recipientId,
     ),
-    idempotencyKeyIdx: index("idx_notifykit_notifications_idempotency_key").on(
+    idempotencyKeyIdx: uniqueIndex("idx_notifykit_notifications_idempotency_key").on(
       table.idempotencyKey,
     ),
   }),

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -227,6 +227,7 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           payload: input.payload,
           payloadSchema: input.payloadSchema,
           definitionVersion: input.definitionVersion,
+          idempotencyKey: input.idempotencyKey,
           createdAt: new Date(),
         };
         await db.insert(notifications).values({
@@ -235,8 +236,30 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           workspaceId: record.workspaceId ?? null,
           payloadSchema: record.payloadSchema ?? null,
           definitionVersion: record.definitionVersion ?? null,
+          idempotencyKey: record.idempotencyKey ?? null,
         });
         return record;
+      },
+      async findByIdempotencyKey(key: string): Promise<NotificationRecord | null> {
+        const rows = await db
+          .select()
+          .from(notifications)
+          .where(eq(notifications.idempotencyKey, key))
+          .limit(1);
+        const row = rows[0];
+        if (!row) return null;
+        return {
+          id: row.id,
+          recipientId: row.recipientId,
+          tenantId: row.tenantId ?? undefined,
+          workspaceId: row.workspaceId ?? undefined,
+          notificationId: row.notificationId,
+          payload: row.payload,
+          payloadSchema: row.payloadSchema ?? undefined,
+          definitionVersion: row.definitionVersion ?? undefined,
+          idempotencyKey: row.idempotencyKey ?? undefined,
+          createdAt: row.createdAt,
+        };
       },
     },
 
@@ -295,6 +318,14 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .orderBy(desc(inboxItems.createdAt));
         const cap = Math.min(limit ?? 200, 1000);
         const rows = await query.limit(cap);
+        return rows.map(rowToInboxItem);
+      },
+
+      async listByNotificationRecordId(notificationRecordId: string): Promise<InboxItem[]> {
+        const rows = await db
+          .select()
+          .from(inboxItems)
+          .where(eq(inboxItems.notificationRecordId, notificationRecordId));
         return rows.map(rowToInboxItem);
       },
 
@@ -504,6 +535,13 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .limit(1);
         const row = rows[0];
         return row ? rowToDelivery(row) : null;
+      },
+      async listByNotificationRecordId(notificationRecordId: string): Promise<DeliveryRecord[]> {
+        const rows = await db
+          .select()
+          .from(deliveries)
+          .where(eq(deliveries.notificationRecordId, notificationRecordId));
+        return rows.map(rowToDelivery);
       },
       async update(id, patch): Promise<DeliveryRecord | null> {
         const ALLOWED = ["status", "providerMessageId", "error", "attempts", "sentAt", "failedAt", "skipReason", "skipDetails"] as const;

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -261,6 +261,12 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           createdAt: row.createdAt,
         };
       },
+      async clearIdempotencyKey(id: string): Promise<void> {
+        await db
+          .update(notifications)
+          .set({ idempotencyKey: null })
+          .where(eq(notifications.id, id));
+      },
     },
 
     inbox: {


### PR DESCRIPTION
## Summary
- Adds optional `idempotencyKey` to `SendInput` — duplicate sends with the same key + notificationId + recipientId within a configurable TTL (default 24h) return the original `SendResult` without re-processing
- Stores composite key on `NotificationRecord`, with indexed lookup via `findByIdempotencyKey()` on all adapters (memory, drizzle-sqlite, drizzle-postgres)
- Per-key mutex serializes concurrent sends so only one write wins under contention
- New `idempotent: boolean` field on `SendResult` distinguishes replays from originals

## Files changed
- `packages/core/src/types.ts` — `SendInput.idempotencyKey`, `NotificationRecord.idempotencyKey`, adapter interface additions
- `packages/core/src/create-notifykit.ts` — dedup logic, per-key lock, `idempotencyKeyTtlMs` config, `SendResult.idempotent`
- `packages/core/src/memory-adapter.ts` — `findByIdempotencyKey`, `listByNotificationRecordId`
- `packages/drizzle-adapter/src/{sqlite,postgres}.ts` — adapter methods
- `packages/drizzle-adapter/src/schema/{sqlite,postgres}.ts` — `idempotency_key` column + index
- `packages/drizzle-adapter/src/create-{tables,pg-tables}.ts` — DDL + backfill migration

## Test plan
- [x] Duplicate send returns original result without re-processing
- [x] Different keys produce independent notifications
- [x] Same key scoped per recipient — different recipients are independent
- [x] Expired TTL allows re-send
- [x] Sends without key are never deduplicated
- [x] Concurrent sends with same key only process once (10 concurrent → 1 original + 9 replays)
- [x] Idempotent replay preserves skipped/deferred state
- [x] All 649 existing tests still pass

Closes #2