### PR TITLE
feat: deduplication keys (dedupeKey + dedupeWindowMs)

### DIFF
--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -763,6 +763,8 @@ export function createNotifyKit<
       notificationId: string;
       payload: unknown;
       idempotencyKey?: string;
+      dedupeKey?: string;
+      dedupeWindowMs?: number;
     };
     if (!input.recipientId) {
       throw new NotifyKitError(
@@ -828,6 +830,61 @@ export function createNotifyKit<
           if (replay) return replay;
         }
         await database.notifications.clearIdempotencyKey(existing.id);
+      }
+    }
+
+    // Semantic deduplication check — runs before preference resolution
+    if (input.dedupeKey) {
+      if (!input.dedupeWindowMs || input.dedupeWindowMs <= 0) {
+        throw new NotifyKitError(
+          "dedupeWindowMs is required and must be positive when dedupeKey is set.",
+          {
+            code: "INVALID_INPUT",
+            field: "dedupeWindowMs",
+            fix: "Pass a positive dedupeWindowMs (e.g. 3600000 for 1 hour).",
+          },
+        );
+      }
+      if (input.dedupeKey.length > 256) {
+        throw new NotifyKitError(
+          "dedupeKey must be 256 characters or fewer.",
+          {
+            code: "INVALID_INPUT",
+            field: "dedupeKey",
+            fix: "Shorten the dedupeKey to 256 characters or fewer.",
+          },
+        );
+      }
+      const dedupeCompositeKey = JSON.stringify(["dedup", def.id, recipient.id, input.dedupeKey]);
+      const { duplicate } = await database.dedupe.check({
+        key: dedupeCompositeKey,
+        recipientId: recipient.id,
+        tenantId: scope.tenantId,
+        workspaceId: scope.workspaceId,
+        notificationId: def.id,
+        windowMs: input.dedupeWindowMs,
+      });
+      if (duplicate) {
+        const allChannels = [...new Set(def.channels.map((c) => c.type))];
+        const skipped: SkippedDelivery[] = allChannels.map((ch) => ({
+          channel: ch,
+          reason: "duplicate" as SkipReason,
+          details: `Deduplicated: key "${input.dedupeKey}" seen within ${input.dedupeWindowMs}ms window`,
+        }));
+        const { notificationRecord, skippedRecords } = await createSkippedNotification({
+          recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
+        });
+        return {
+          notification: notificationRecord,
+          inboxItems: [],
+          deliveries: skippedRecords,
+          skippedChannels: [],
+          skipped,
+          deferredChannels: [],
+          digested: false,
+          rateLimited: false,
+          idempotent: false,
+        };
       }
     }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -879,6 +879,9 @@ export function createNotifyKit<
         notificationId: def.id,
         windowMs: input.dedupeWindowMs,
       });
+      if (Math.random() < 0.01) {
+        database.dedupe.prune().catch(() => {});
+      }
       if (duplicate) {
         const allChannels = [...new Set(def.channels.map((c) => c.type))];
         const skipped: SkippedDelivery[] = allChannels.map((ch) => ({
@@ -900,9 +903,6 @@ export function createNotifyKit<
           rateLimited: false,
           idempotent: false,
         };
-      }
-      if (Math.random() < 0.01) {
-        database.dedupe.prune().catch(() => {});
       }
     }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -53,6 +53,10 @@ import { validateConfig, formatValidationIssues } from "./validate.js";
 
 export const SKIP_PROVIDER = "skip" as const;
 
+function buildDedupeCompositeKey(notificationId: string, recipientId: string, dedupeKey: string): string {
+  return JSON.stringify(["dedup", notificationId, recipientId, dedupeKey]);
+}
+
 export type CreateNotifyKitInput<
   T extends readonly NotificationDefinition<string, PayloadSchema>[],
 > = {
@@ -855,7 +859,7 @@ export function createNotifyKit<
           },
         );
       }
-      const dedupeCompositeKey = JSON.stringify(["dedup", def.id, recipient.id, input.dedupeKey]);
+      const dedupeCompositeKey = buildDedupeCompositeKey(def.id, recipient.id, input.dedupeKey);
       const { duplicate } = await database.dedupe.check({
         key: dedupeCompositeKey,
         recipientId: recipient.id,
@@ -1133,7 +1137,7 @@ export function createNotifyKit<
     let dedupeInfo: DeliveryExplanation["dedupe"] = null;
     if (input.dedupeKey && input.dedupeWindowMs && input.dedupeWindowMs > 0) {
       dedupeInfo = { key: input.dedupeKey, windowMs: input.dedupeWindowMs };
-      const dedupeCompositeKey = JSON.stringify(["dedup", def.id, recipient.id, input.dedupeKey]);
+      const dedupeCompositeKey = buildDedupeCompositeKey(def.id, recipient.id, input.dedupeKey);
       wouldDeduplicate = await database.dedupe.exists(dedupeCompositeKey);
     }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -892,6 +892,12 @@ export function createNotifyKit<
         const { notificationRecord, skippedRecords } = await createSkippedNotification({
           recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
         });
+        await runHook("notification.deduplicated", {
+          notificationId: def.id,
+          recipientId: recipient.id,
+          dedupeKey: input.dedupeKey,
+          windowMs: input.dedupeWindowMs,
+        });
         return {
           notification: notificationRecord,
           inboxItems: [],

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -879,9 +879,6 @@ export function createNotifyKit<
         notificationId: def.id,
         windowMs: input.dedupeWindowMs,
       });
-      if (Math.random() < 0.01) {
-        database.dedupe.prune().catch(() => {});
-      }
       if (duplicate) {
         const allChannels = [...new Set(def.channels.map((c) => c.type))];
         const skipped: SkippedDelivery[] = allChannels.map((ch) => ({
@@ -903,6 +900,9 @@ export function createNotifyKit<
           rateLimited: false,
           idempotent: false,
         };
+      }
+      if (Math.random() < 0.01) {
+        database.dedupe.prune().catch(() => {});
       }
     }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1080,6 +1080,8 @@ export function createNotifyKit<
       workspaceId?: string;
       notificationId: string;
       payload: unknown;
+      dedupeKey?: string;
+      dedupeWindowMs?: number;
     };
     const def = byId.get(input.notificationId);
     if (!def) {
@@ -1127,6 +1129,14 @@ export function createNotifyKit<
       rateLimitInfo = { current, max: limit.max, windowMs: limit.windowMs };
     }
 
+    let wouldDeduplicate = false;
+    let dedupeInfo: DeliveryExplanation["dedupe"] = null;
+    if (input.dedupeKey && input.dedupeWindowMs && input.dedupeWindowMs > 0) {
+      dedupeInfo = { key: input.dedupeKey, windowMs: input.dedupeWindowMs };
+      const dedupeCompositeKey = JSON.stringify(["dedup", def.id, recipient.id, input.dedupeKey]);
+      wouldDeduplicate = await database.dedupe.exists(dedupeCompositeKey);
+    }
+
     const wouldDigest = !!def.digest;
     const digestInfo: DeliveryExplanation["digest"] = def.digest
       ? { windowMs: def.digest.windowMs }
@@ -1172,8 +1182,10 @@ export function createNotifyKit<
       required: def.required ?? false,
       classification: def.classification,
       category: def.category,
+      wouldDeduplicate,
       wouldRateLimit,
       wouldDigest,
+      dedupe: dedupeInfo,
       rateLimit: rateLimitInfo,
       digest: digestInfo,
       quietHours: quietHoursInfo,

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -864,6 +864,9 @@ export function createNotifyKit<
         notificationId: def.id,
         windowMs: input.dedupeWindowMs,
       });
+      if (Math.random() < 0.01) {
+        database.dedupe.prune().catch(() => {});
+      }
       if (duplicate) {
         const allChannels = [...new Set(def.channels.map((c) => c.type))];
         const skipped: SkippedDelivery[] = allChannels.map((ch) => ({

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -839,6 +839,7 @@ export function createNotifyKit<
 
     // Semantic deduplication check — runs before preference resolution
     if (input.dedupeKey) {
+      const MAX_DEDUPE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
       if (!input.dedupeWindowMs || input.dedupeWindowMs <= 0) {
         throw new NotifyKitError(
           "dedupeWindowMs is required and must be positive when dedupeKey is set.",
@@ -846,6 +847,16 @@ export function createNotifyKit<
             code: "INVALID_INPUT",
             field: "dedupeWindowMs",
             fix: "Pass a positive dedupeWindowMs (e.g. 3600000 for 1 hour).",
+          },
+        );
+      }
+      if (input.dedupeWindowMs > MAX_DEDUPE_WINDOW_MS) {
+        throw new NotifyKitError(
+          "dedupeWindowMs must be 30 days or fewer.",
+          {
+            code: "INVALID_INPUT",
+            field: "dedupeWindowMs",
+            fix: "Pass a dedupeWindowMs of 2592000000 (30 days) or less.",
           },
         );
       }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1180,6 +1180,8 @@ export function createNotifyKit<
         outcome = ch.resolvedBy === "destination_unavailable"
           ? "unavailable"
           : "disabled";
+      } else if (wouldDeduplicate) {
+        outcome = "deduplicated";
       } else if (wouldRateLimit) {
         outcome = "rate_limited";
       } else if (wouldDigest) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,6 +114,7 @@ export type {
   ChannelResolution,
   ChannelType,
   DatabaseAdapter,
+  DedupeRecord,
   DeliveryExplanation,
   DeliveryChannel,
   DeliveryJob,

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -1,5 +1,6 @@
 import type {
   DatabaseAdapter,
+  DedupeRecord,
   DeliveryRecord,
   DigestBufferEntry,
   InboxDeleteForRecipientResult,
@@ -26,6 +27,7 @@ export type MemoryAdapter = DatabaseAdapter & {
     digests: DigestBufferEntry[];
     rateLimits: RateLimitEvent[];
     scheduledSends: ScheduledSend[];
+    dedupeRecords: DedupeRecord[];
   };
 };
 
@@ -39,6 +41,7 @@ export function memoryAdapter(): MemoryAdapter {
     digests: [] as DigestBufferEntry[],
     rateLimits: [] as RateLimitEvent[],
     scheduledSends: [] as ScheduledSend[],
+    dedupeRecords: [] as DedupeRecord[],
   };
 
   function matchesScope(record: SecurityScope, scope?: SecurityScope): boolean {
@@ -499,6 +502,35 @@ export function memoryAdapter(): MemoryAdapter {
       },
       async list(): Promise<ScheduledSend[]> {
         return state.scheduledSends.map((s) => ({ ...s }));
+      },
+    },
+    dedupe: {
+      async check(input): Promise<{ duplicate: boolean }> {
+        const now = Date.now();
+        const existing = state.dedupeRecords.find((r) => r.key === input.key);
+        if (existing) {
+          if (existing.expiresAt.getTime() > now) {
+            return { duplicate: true };
+          }
+          const idx = state.dedupeRecords.indexOf(existing);
+          state.dedupeRecords.splice(idx, 1);
+        }
+        state.dedupeRecords.push({
+          key: input.key,
+          recipientId: input.recipientId,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          notificationId: input.notificationId,
+          expiresAt: new Date(now + input.windowMs),
+          createdAt: new Date(now),
+        });
+        return { duplicate: false };
+      },
+      async prune(): Promise<void> {
+        const now = Date.now();
+        state.dedupeRecords = state.dedupeRecords.filter(
+          (r) => r.expiresAt.getTime() > now,
+        );
       },
     },
   };

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -526,6 +526,11 @@ export function memoryAdapter(): MemoryAdapter {
         });
         return { duplicate: false };
       },
+      async exists(key: string): Promise<boolean> {
+        const now = Date.now();
+        const record = state.dedupeRecords.find((r) => r.key === key);
+        return !!record && record.expiresAt.getTime() > now;
+      },
       async prune(): Promise<void> {
         const now = Date.now();
         state.dedupeRecords = state.dedupeRecords.filter(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,6 +43,7 @@ export type ChannelOutcome =
   | "disabled"
   | "delayed"
   | "unavailable"
+  | "deduplicated"
   | "rate_limited"
   | "digested";
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -762,6 +762,12 @@ export type Hooks = {
     /** Payload with sensitive fields replaced by `"[REDACTED]"` per the definition's `redact` list. */
     redactedPayload: Record<string, unknown>;
   }) => void | Promise<void>;
+  "notification.deduplicated"?: (ctx: {
+    notificationId: string;
+    recipientId: string;
+    dedupeKey: string;
+    windowMs: number;
+  }) => void | Promise<void>;
   "notification.rate_limited"?: (ctx: {
     notificationId: string;
     recipientId: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -54,8 +54,10 @@ export type DeliveryExplanation = {
   required: boolean;
   classification?: NotificationClassification;
   category?: string;
+  wouldDeduplicate: boolean;
   wouldRateLimit: boolean;
   wouldDigest: boolean;
+  dedupe: { key: string; windowMs: number } | null;
   rateLimit: { current: number; max: number; windowMs: number } | null;
   digest: { windowMs: number } | null;
   quietHours: { active: boolean; resumesAt: Date | null } | null;
@@ -744,6 +746,11 @@ export type DatabaseAdapter = {
       notificationId: string;
       windowMs: number;
     }): Promise<{ duplicate: boolean }>;
+    /**
+     * Read-only check: returns true if the key exists and hasn't expired.
+     * Does not insert or modify any records. Used by `explain()`.
+     */
+    exists(key: string): Promise<boolean>;
     /** Remove expired entries. Called opportunistically. */
     prune(): Promise<void>;
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -388,6 +388,18 @@ export type RateLimitEvent = {
   occurredAt: Date;
 };
 
+export type DedupeRecord = {
+  /** Composite key: (dedupeKey, notificationId, recipientId). */
+  key: string;
+  recipientId: string;
+  tenantId?: string;
+  workspaceId?: string;
+  notificationId: string;
+  /** When this dedup entry expires and can be cleaned up. */
+  expiresAt: Date;
+  createdAt: Date;
+};
+
 export type DigestBufferEntry = {
   /** Composite "key" used to group payloads within a window. */
   key: string;
@@ -717,6 +729,24 @@ export type DatabaseAdapter = {
     /** All rows, regardless of state. For tests and admin tooling. */
     list(): Promise<ScheduledSend[]>;
   };
+  dedupe: {
+    /**
+     * Check if a dedup key exists and is still within its window. If not,
+     * atomically insert the key with the given window. Returns
+     * `{ duplicate: false }` when the key was inserted (first occurrence),
+     * `{ duplicate: true }` when the key already exists and hasn't expired.
+     */
+    check(input: {
+      key: string;
+      recipientId: string;
+      tenantId?: string;
+      workspaceId?: string;
+      notificationId: string;
+      windowMs: number;
+    }): Promise<{ duplicate: boolean }>;
+    /** Remove expired entries. Called opportunistically. */
+    prune(): Promise<void>;
+  };
 };
 
 export type Hooks = {
@@ -785,6 +815,23 @@ export type SendInput<
      * The key is silently ignored when the notification has a `digest` config.
      */
     idempotencyKey?: string;
+    /**
+     * Semantic deduplication key. Different from idempotency: dedup prevents
+     * semantically duplicate notifications (e.g. "user X was mentioned" sent
+     * twice within a window), while idempotency prevents retries of the exact
+     * same API call.
+     *
+     * When provided together with `dedupeWindowMs`, duplicate sends with the
+     * same (dedupeKey, notificationId, recipientId) within the window are
+     * skipped with reason `"duplicate"`.
+     */
+    dedupeKey?: string;
+    /**
+     * Time window in milliseconds for deduplication. Required when `dedupeKey`
+     * is provided. Sends with the same dedup key within this window after the
+     * first are skipped.
+     */
+    dedupeWindowMs?: number;
   };
 }[T[number]["id"]];
 

--- a/packages/core/tests/dedupe.test.ts
+++ b/packages/core/tests/dedupe.test.ts
@@ -204,6 +204,21 @@ describe("deduplication keys", () => {
     ).rejects.toThrow("dedupeKey must be 256 characters or fewer");
   });
 
+  test("dedupeWindowMs must be 30 days or fewer", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    expect(
+      notify.send({
+        recipientId: "u1",
+        notificationId: "mention",
+        payload: { user: "alice", project: "acme" },
+        dedupeKey: "key",
+        dedupeWindowMs: 31 * 24 * 60 * 60 * 1000,
+      }),
+    ).rejects.toThrow("dedupeWindowMs must be 30 days or fewer");
+  });
+
   test("dedupeKey is independent of idempotencyKey", async () => {
     const { emailProvider, notify } = setup();
     await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });

--- a/packages/core/tests/dedupe.test.ts
+++ b/packages/core/tests/dedupe.test.ts
@@ -264,4 +264,72 @@ describe("deduplication keys", () => {
     expect(result.skipped[0].reason).toBe("duplicate");
     expect(emailProvider.sent).toHaveLength(1);
   });
+
+  test("concurrent sends with same dedupeKey only deliver once", async () => {
+    const { db, emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        notify.send({
+          recipientId: "u1",
+          notificationId: "mention",
+          payload: { user: "alice", project: "acme" },
+          dedupeKey: "concurrent-dedup",
+          dedupeWindowMs: 60_000,
+        }),
+      ),
+    );
+
+    const delivered = results.filter((r) => r.skipped.length === 0);
+    const deduped = results.filter((r) => r.skipped.some((s) => s.reason === "duplicate"));
+
+    expect(delivered).toHaveLength(1);
+    expect(deduped).toHaveLength(9);
+    expect(emailProvider.sent).toHaveLength(1);
+    // All 10 create notification records (dedup still persists for audit)
+    expect(db._state.notifications).toHaveLength(10);
+  });
+
+  test("dedupeKey does not interfere with digested notifications", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "digest-notif",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+      digest: {
+        windowMs: 5000,
+        key: ({ recipientId }) => recipientId,
+        render: ({ payloads }) => ({ msg: payloads.map((p) => p.msg).join(", ") }),
+      },
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const first = await notify.send({
+      recipientId: "u1",
+      notificationId: "digest-notif",
+      payload: { msg: "a" },
+      dedupeKey: "digest-dedup",
+      dedupeWindowMs: 60_000,
+    });
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "digest-notif",
+      payload: { msg: "b" },
+      dedupeKey: "digest-dedup",
+      dedupeWindowMs: 60_000,
+    });
+
+    // Dedup fires before the digest path — second send is skipped
+    expect(first.digested).toBe(true);
+    expect(first.skipped).toHaveLength(0);
+    expect(second.digested).toBe(false);
+    expect(second.skipped.length).toBeGreaterThan(0);
+    expect(second.skipped[0].reason).toBe("duplicate");
+  });
 });

--- a/packages/core/tests/dedupe.test.ts
+++ b/packages/core/tests/dedupe.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "bun:test";
+import {
+  channel,
+  createNotifyKit,
+  fakeEmailProvider,
+  memoryAdapter,
+  notification,
+} from "../src/index.js";
+
+const inbox = channel.inbox();
+const email = channel.email();
+
+function setup() {
+  const db = memoryAdapter();
+  const emailProvider = fakeEmailProvider();
+  const def = notification({
+    id: "mention",
+    payload: { user: "string", project: "string" },
+    channels: [
+      inbox({ title: "{{user}} mentioned you in {{project}}" }),
+      email({ subject: "Mention from {{user}}", body: "In {{project}}" }),
+    ],
+  });
+  const notify = createNotifyKit({
+    notifications: [def] as const,
+    database: db,
+    providers: { email: emailProvider },
+  });
+  return { db, emailProvider, notify };
+}
+
+describe("deduplication keys", () => {
+  test("first send with dedupeKey delivers normally", async () => {
+    const { emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "mention:alice:acme",
+      dedupeWindowMs: 60_000,
+    });
+
+    expect(result.notification).not.toBeNull();
+    expect(result.skipped).toHaveLength(0);
+    expect(emailProvider.sent).toHaveLength(1);
+  });
+
+  test("duplicate send within window is skipped with reason 'duplicate'", async () => {
+    const { db, emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const first = await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "mention:alice:acme",
+      dedupeWindowMs: 60_000,
+    });
+
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "mention:alice:acme",
+      dedupeWindowMs: 60_000,
+    });
+
+    expect(first.skipped).toHaveLength(0);
+    expect(second.skipped).toHaveLength(2);
+    expect(second.skipped[0].reason).toBe("duplicate");
+    expect(second.skipped[1].reason).toBe("duplicate");
+    expect(second.notification).not.toBeNull();
+    expect(second.idempotent).toBe(false);
+
+    // Email only sent once
+    expect(emailProvider.sent).toHaveLength(1);
+    // Two notification records created (dedup still creates a record for audit)
+    expect(db._state.notifications).toHaveLength(2);
+  });
+
+  test("different dedupeKeys are independent", async () => {
+    const { emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "mention:alice:acme",
+      dedupeWindowMs: 60_000,
+    });
+
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "bob", project: "acme" },
+      dedupeKey: "mention:bob:acme",
+      dedupeWindowMs: 60_000,
+    });
+
+    expect(second.skipped).toHaveLength(0);
+    expect(emailProvider.sent).toHaveLength(2);
+  });
+
+  test("same dedupeKey scoped per recipient", async () => {
+    const { emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+    await notify.upsertRecipient({ id: "u2", email: "u2@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "shared-key",
+      dedupeWindowMs: 60_000,
+    });
+
+    const result = await notify.send({
+      recipientId: "u2",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "shared-key",
+      dedupeWindowMs: 60_000,
+    });
+
+    // Different recipients should NOT be deduped
+    expect(result.skipped).toHaveLength(0);
+    expect(emailProvider.sent).toHaveLength(2);
+  });
+
+  test("send after window expires delivers normally", async () => {
+    const { db, emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "expire-key",
+      dedupeWindowMs: 50,
+    });
+
+    // Artificially expire the dedup record
+    db._state.dedupeRecords[0].expiresAt = new Date(Date.now() - 100);
+
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "expire-key",
+      dedupeWindowMs: 50,
+    });
+
+    expect(second.skipped).toHaveLength(0);
+    expect(emailProvider.sent).toHaveLength(2);
+  });
+
+  test("sends without dedupeKey are never deduplicated", async () => {
+    const { emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+    });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+    });
+
+    expect(emailProvider.sent).toHaveLength(2);
+  });
+
+  test("dedupeKey requires dedupeWindowMs", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    expect(
+      notify.send({
+        recipientId: "u1",
+        notificationId: "mention",
+        payload: { user: "alice", project: "acme" },
+        dedupeKey: "key",
+      }),
+    ).rejects.toThrow("dedupeWindowMs is required");
+  });
+
+  test("dedupeKey must be 256 characters or fewer", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    expect(
+      notify.send({
+        recipientId: "u1",
+        notificationId: "mention",
+        payload: { user: "alice", project: "acme" },
+        dedupeKey: "x".repeat(257),
+        dedupeWindowMs: 60_000,
+      }),
+    ).rejects.toThrow("dedupeKey must be 256 characters or fewer");
+  });
+
+  test("dedupeKey is independent of idempotencyKey", async () => {
+    const { emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    // First send with both keys
+    const first = await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "dedup-1",
+      dedupeWindowMs: 60_000,
+      idempotencyKey: "idem-1",
+    });
+
+    // Same dedupeKey, different idempotencyKey — should be deduped
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "dedup-1",
+      dedupeWindowMs: 60_000,
+      idempotencyKey: "idem-2",
+    });
+
+    expect(first.skipped).toHaveLength(0);
+    expect(second.skipped.length).toBeGreaterThan(0);
+    expect(second.skipped[0].reason).toBe("duplicate");
+    expect(emailProvider.sent).toHaveLength(1);
+  });
+
+  test("dedup still works with tenantId scoping", async () => {
+    const { emailProvider, notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      tenantId: "t1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "tenant-dedup",
+      dedupeWindowMs: 60_000,
+    });
+
+    // Same key, same recipient, different tenant — NOT deduped (key is scoped
+    // to notificationId + recipientId, tenant is excluded like idempotency)
+    const result = await notify.send({
+      recipientId: "u1",
+      tenantId: "t2",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "tenant-dedup",
+      dedupeWindowMs: 60_000,
+    });
+
+    // dedup key composite includes (notificationId, recipientId, dedupeKey)
+    // tenantId is excluded — so this IS a duplicate
+    expect(result.skipped.length).toBeGreaterThan(0);
+    expect(result.skipped[0].reason).toBe("duplicate");
+    expect(emailProvider.sent).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/dedupe.test.ts
+++ b/packages/core/tests/dedupe.test.ts
@@ -347,4 +347,48 @@ describe("deduplication keys", () => {
     expect(second.skipped.length).toBeGreaterThan(0);
     expect(second.skipped[0].reason).toBe("duplicate");
   });
+
+  test("notification.deduplicated hook fires on duplicate", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const hookCalls: { notificationId: string; recipientId: string; dedupeKey: string; windowMs: number }[] = [];
+    const def = notification({
+      id: "mention",
+      payload: { user: "string", project: "string" },
+      channels: [
+        inbox({ title: "{{user}} mentioned you in {{project}}" }),
+        email({ subject: "Mention from {{user}}", body: "In {{project}}" }),
+      ],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+      on: {
+        "notification.deduplicated": (ctx) => { hookCalls.push(ctx); },
+      },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "hook-test",
+      dedupeWindowMs: 60_000,
+    });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { user: "alice", project: "acme" },
+      dedupeKey: "hook-test",
+      dedupeWindowMs: 60_000,
+    });
+
+    expect(hookCalls).toHaveLength(1);
+    expect(hookCalls[0].notificationId).toBe("mention");
+    expect(hookCalls[0].recipientId).toBe("u1");
+    expect(hookCalls[0].dedupeKey).toBe("hook-test");
+    expect(hookCalls[0].windowMs).toBe(60_000);
+  });
 });

--- a/packages/core/tests/preference-resolution.test.ts
+++ b/packages/core/tests/preference-resolution.test.ts
@@ -1419,6 +1419,51 @@ describe("notify.explain() — delivery-level explanation", () => {
     expect(emailCh.outcome).toBe("delayed");
   });
 
+  test("explain shows deduplicated outcome on channels", async () => {
+    const def = notification({
+      id: "mention",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const r1 = await notify.explain({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { msg: "hi" },
+      dedupeKey: "dup-explain",
+      dedupeWindowMs: 60_000,
+    });
+    expect(r1.wouldDeduplicate).toBe(false);
+    expect(r1.dedupe).toEqual({ key: "dup-explain", windowMs: 60_000 });
+    expect(r1.channels.every((c) => c.outcome === "deliver")).toBe(true);
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { msg: "hi" },
+      dedupeKey: "dup-explain",
+      dedupeWindowMs: 60_000,
+    });
+
+    const r2 = await notify.explain({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { msg: "hi" },
+      dedupeKey: "dup-explain",
+      dedupeWindowMs: 60_000,
+    });
+    expect(r2.wouldDeduplicate).toBe(true);
+    expect(r2.channels.every((c) => c.outcome === ("deduplicated" as ChannelOutcome))).toBe(true);
+  });
+
   test("fully opted-out recipient does not consume rate-limit budget", async () => {
     const def = notification({
       id: "alert",

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -136,6 +136,17 @@ export async function createPgTables(
       ON notifykit_scheduled_sends (scheduled_for)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_scheduled_sends_status_due
       ON notifykit_scheduled_sends (status, scheduled_for)`,
+    `CREATE TABLE IF NOT EXISTS notifykit_dedupe_records (
+      key TEXT PRIMARY KEY,
+      recipient_id TEXT NOT NULL,
+      tenant_id TEXT,
+      workspace_id TEXT,
+      notification_id TEXT NOT NULL,
+      expires_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_dedupe_expires_at
+      ON notifykit_dedupe_records (expires_at)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -136,6 +136,17 @@ export async function createSqliteTables(
       ON notifykit_scheduled_sends (scheduled_for)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_scheduled_sends_status_due
       ON notifykit_scheduled_sends (status, scheduled_for)`,
+    `CREATE TABLE IF NOT EXISTS notifykit_dedupe_records (
+      key TEXT PRIMARY KEY,
+      recipient_id TEXT NOT NULL,
+      tenant_id TEXT,
+      workspace_id TEXT,
+      notification_id TEXT NOT NULL,
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_dedupe_expires_at
+      ON notifykit_dedupe_records (expires_at)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -21,6 +21,7 @@ import { and, asc, count as drizzleCount, desc, eq, gte, isNull, isNotNull, lt, 
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
 import {
+  dedupeRecords,
   deliveries,
   digestBuffers,
   inboxItems,
@@ -72,6 +73,7 @@ export type DrizzlePostgresAdapter = DatabaseAdapter & {
     digestBuffers: typeof digestBuffers;
     rateLimitEvents: typeof rateLimitEvents;
     scheduledSends: typeof scheduledSends;
+    dedupeRecords: typeof dedupeRecords;
   };
 };
 
@@ -86,6 +88,7 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
       digestBuffers,
       rateLimitEvents,
       scheduledSends,
+      dedupeRecords,
     },
 
     recipients: {
@@ -954,6 +957,38 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           claimedAt: row.claimedAt ?? null,
           createdAt: row.createdAt,
         }));
+      },
+    },
+
+    dedupe: {
+      async check(input): Promise<{ duplicate: boolean }> {
+        const now = new Date();
+        const existing = await db
+          .select()
+          .from(dedupeRecords)
+          .where(eq(dedupeRecords.key, input.key))
+          .limit(1);
+        const row = existing[0];
+        if (row && row.expiresAt.getTime() > now.getTime()) {
+          return { duplicate: true };
+        }
+        if (row) {
+          await db.delete(dedupeRecords).where(eq(dedupeRecords.key, input.key));
+        }
+        await db.insert(dedupeRecords).values({
+          key: input.key,
+          recipientId: input.recipientId,
+          tenantId: input.tenantId ?? null,
+          workspaceId: input.workspaceId ?? null,
+          notificationId: input.notificationId,
+          expiresAt: new Date(now.getTime() + input.windowMs),
+          createdAt: now,
+        });
+        return { duplicate: false };
+      },
+      async prune(): Promise<void> {
+        const now = new Date();
+        await db.delete(dedupeRecords).where(lt(dedupeRecords.expiresAt, now));
       },
     },
   };

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -989,6 +989,15 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           return { duplicate: false };
         });
       },
+      async exists(key: string): Promise<boolean> {
+        const now = new Date();
+        const rows = await db
+          .select()
+          .from(dedupeRecords)
+          .where(and(eq(dedupeRecords.key, key), gte(dedupeRecords.expiresAt, now)))
+          .limit(1);
+        return rows.length > 0;
+      },
       async prune(): Promise<void> {
         const now = new Date();
         await db.delete(dedupeRecords).where(lt(dedupeRecords.expiresAt, now));

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -963,12 +963,14 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
     dedupe: {
       async check(input): Promise<{ duplicate: boolean }> {
         return db.transaction(async (tx) => {
+          await tx.execute(
+            sql`SELECT pg_advisory_xact_lock(hashtext(${input.key}))`,
+          );
           const now = new Date();
           const existing = await tx
             .select()
             .from(dedupeRecords)
             .where(eq(dedupeRecords.key, input.key))
-            .for("update")
             .limit(1);
           const row = existing[0];
           if (row && row.expiresAt.getTime() > now.getTime()) {

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -962,29 +962,32 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
 
     dedupe: {
       async check(input): Promise<{ duplicate: boolean }> {
-        const now = new Date();
-        const existing = await db
-          .select()
-          .from(dedupeRecords)
-          .where(eq(dedupeRecords.key, input.key))
-          .limit(1);
-        const row = existing[0];
-        if (row && row.expiresAt.getTime() > now.getTime()) {
-          return { duplicate: true };
-        }
-        if (row) {
-          await db.delete(dedupeRecords).where(eq(dedupeRecords.key, input.key));
-        }
-        await db.insert(dedupeRecords).values({
-          key: input.key,
-          recipientId: input.recipientId,
-          tenantId: input.tenantId ?? null,
-          workspaceId: input.workspaceId ?? null,
-          notificationId: input.notificationId,
-          expiresAt: new Date(now.getTime() + input.windowMs),
-          createdAt: now,
+        return db.transaction(async (tx) => {
+          const now = new Date();
+          const existing = await tx
+            .select()
+            .from(dedupeRecords)
+            .where(eq(dedupeRecords.key, input.key))
+            .for("update")
+            .limit(1);
+          const row = existing[0];
+          if (row && row.expiresAt.getTime() > now.getTime()) {
+            return { duplicate: true };
+          }
+          if (row) {
+            await tx.delete(dedupeRecords).where(eq(dedupeRecords.key, input.key));
+          }
+          await tx.insert(dedupeRecords).values({
+            key: input.key,
+            recipientId: input.recipientId,
+            tenantId: input.tenantId ?? null,
+            workspaceId: input.workspaceId ?? null,
+            notificationId: input.notificationId,
+            expiresAt: new Date(now.getTime() + input.windowMs),
+            createdAt: now,
+          });
+          return { duplicate: false };
         });
-        return { duplicate: false };
       },
       async prune(): Promise<void> {
         const now = new Date();

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -228,6 +228,22 @@ export const digestBuffers = pgTable(
   }),
 );
 
+export const dedupeRecords = pgTable(
+  "notifykit_dedupe_records",
+  {
+    key: text("key").primaryKey(),
+    recipientId: text("recipient_id").notNull(),
+    tenantId: text("tenant_id"),
+    workspaceId: text("workspace_id"),
+    notificationId: text("notification_id").notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true, mode: "date" }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull(),
+  },
+  (table) => ({
+    expiresAtIdx: index("idx_notifykit_dedupe_expires_at").on(table.expiresAt),
+  }),
+);
+
 export const notifyKitPgSchema = {
   recipients,
   notifications,
@@ -237,6 +253,7 @@ export const notifyKitPgSchema = {
   digestBuffers,
   rateLimitEvents,
   scheduledSends,
+  dedupeRecords,
 };
 
 export type NotifyKitPgSchema = typeof notifyKitPgSchema;

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -231,6 +231,22 @@ export const digestBuffers = sqliteTable(
   }),
 );
 
+export const dedupeRecords = sqliteTable(
+  "notifykit_dedupe_records",
+  {
+    key: text("key").primaryKey(),
+    recipientId: text("recipient_id").notNull(),
+    tenantId: text("tenant_id"),
+    workspaceId: text("workspace_id"),
+    notificationId: text("notification_id").notNull(),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    expiresAtIdx: index("idx_notifykit_dedupe_expires_at").on(table.expiresAt),
+  }),
+);
+
 export const notifyKitSchema = {
   recipients,
   notifications,
@@ -240,6 +256,7 @@ export const notifyKitSchema = {
   digestBuffers,
   rateLimitEvents,
   scheduledSends,
+  dedupeRecords,
 };
 
 export type NotifyKitSqliteSchema = typeof notifyKitSchema;

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -21,6 +21,7 @@ import { and, asc, count as drizzleCount, desc, eq, gte, isNull, isNotNull, lt, 
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
 import {
+  dedupeRecords,
   deliveries,
   digestBuffers,
   inboxItems,
@@ -102,6 +103,7 @@ export type DrizzleSqliteAdapter = DatabaseAdapter & {
     digestBuffers: typeof digestBuffers;
     rateLimitEvents: typeof rateLimitEvents;
     scheduledSends: typeof scheduledSends;
+    dedupeRecords: typeof dedupeRecords;
   };
 };
 
@@ -122,6 +124,7 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
       digestBuffers,
       rateLimitEvents,
       scheduledSends,
+      dedupeRecords,
     },
 
     recipients: {
@@ -1025,6 +1028,40 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           claimedAt: row.claimedAt ?? null,
           createdAt: row.createdAt,
         }));
+      },
+    },
+
+    dedupe: {
+      async check(input): Promise<{ duplicate: boolean }> {
+        return atomic(async () => {
+          const now = new Date();
+          const existing = await db
+            .select()
+            .from(dedupeRecords)
+            .where(eq(dedupeRecords.key, input.key))
+            .limit(1);
+          const row = existing[0];
+          if (row && row.expiresAt.getTime() > now.getTime()) {
+            return { duplicate: true };
+          }
+          if (row) {
+            await db.delete(dedupeRecords).where(eq(dedupeRecords.key, input.key));
+          }
+          await db.insert(dedupeRecords).values({
+            key: input.key,
+            recipientId: input.recipientId,
+            tenantId: input.tenantId ?? null,
+            workspaceId: input.workspaceId ?? null,
+            notificationId: input.notificationId,
+            expiresAt: new Date(now.getTime() + input.windowMs),
+            createdAt: now,
+          });
+          return { duplicate: false };
+        });
+      },
+      async prune(): Promise<void> {
+        const now = new Date();
+        await db.delete(dedupeRecords).where(lt(dedupeRecords.expiresAt, now));
       },
     },
   };

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1059,6 +1059,15 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           return { duplicate: false };
         });
       },
+      async exists(key: string): Promise<boolean> {
+        const now = new Date();
+        const rows = await db
+          .select()
+          .from(dedupeRecords)
+          .where(and(eq(dedupeRecords.key, key), gte(dedupeRecords.expiresAt, now)))
+          .limit(1);
+        return rows.length > 0;
+      },
       async prune(): Promise<void> {
         const now = new Date();
         await db.delete(dedupeRecords).where(lt(dedupeRecords.expiresAt, now));


### PR DESCRIPTION
## Summary
- Adds `dedupeKey` + `dedupeWindowMs` to `SendInput` for semantic deduplication
- Stores dedupe keys with expiry in a new `dedupe` adapter store (memory, drizzle sqlite, drizzle postgres)
- Duplicate sends within the window are skipped with reason `"duplicate"` — a notification record is still persisted for audit
- Scoped to `(dedupeKey, notificationId, recipientId)` — tenantId excluded, matching idempotency semantics

Different from idempotency: dedup prevents *semantically* duplicate notifications (e.g. "mention X notified user Y in last hour"), not retries of the same request.

**Files changed:**
- `packages/core/src/types.ts` — `DedupeRecord` type, `dedupe` adapter interface, `dedupeKey`/`dedupeWindowMs` on `SendInput`
- `packages/core/src/create-notifykit.ts` — dedup check in send flow
- `packages/core/src/memory-adapter.ts` — in-memory dedupe store
- `packages/drizzle-adapter/src/schema/{sqlite,postgres}.ts` — `notifykit_dedupe_records` table
- `packages/drizzle-adapter/src/{sqlite,postgres}.ts` — adapter implementation
- `packages/drizzle-adapter/src/create-{tables,pg-tables}.ts` — DDL for new table
- `packages/core/tests/dedupe.test.ts` — 10 tests

Closes #3

## Test plan
- [x] First send with dedupeKey delivers normally
- [x] Duplicate send within window skipped with `"duplicate"` reason
- [x] Different dedupeKeys are independent
- [x] Same key scoped per recipient (different recipients not deduped)
- [x] Send after window expires delivers normally
- [x] Sends without dedupeKey never deduplicated
- [x] dedupeKey requires dedupeWindowMs (validation)
- [x] dedupeKey max length enforced (256 chars)
- [x] dedupeKey independent of idempotencyKey
- [x] tenantId excluded from dedup scoping