### PR TITLE
feat: debug timeline for every notification

### DIFF
--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -490,7 +490,9 @@ export function createNotifyKit<
     pendingTimelineWrites.add(p);
     try { await p; } finally { pendingTimelineWrites.delete(p); }
     if (timelineRetentionMs > 0 && Math.random() < 0.01) {
-      timelineAdapter.prune(new Date(Date.now() - timelineRetentionMs)).catch(onTimelineError);
+      const pruneP = timelineAdapter.prune(new Date(Date.now() - timelineRetentionMs)).then(() => {}).catch(onTimelineError);
+      pendingTimelineWrites.add(pruneP);
+      pruneP.finally(() => pendingTimelineWrites.delete(pruneP));
     }
   }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -33,6 +33,8 @@ import type {
   SkipReason,
   SkippedDelivery,
   SmsProvider,
+  TimelineEvent,
+  TimelineEventType,
   UpdatePreferenceInput,
   UpsertRecipientInput,
   WebhookProvider,
@@ -330,6 +332,15 @@ export type NotifyKit<
     payload: Record<string, unknown>,
   ): Record<string, unknown>;
   /**
+   * Retrieve the debug timeline for a notification. Returns lifecycle events
+   * in chronological order showing every decision, side effect, and provider
+   * interaction. Optionally filter to a specific delivery.
+   */
+  timeline(
+    notificationRecordId: string,
+    options?: { deliveryId?: string },
+  ): Promise<TimelineEvent[]>;
+  /**
    * The realtime adapter passed to `createNotifyKit`, or `undefined` if none
    * was provided. Exposed so handlers and transports can subscribe clients;
    * core inbox mutations publish their own realtime events.
@@ -418,6 +429,35 @@ export function createNotifyKit<
         ? err
         : new Error(`Hook "${String(name)}" threw a non-error value.`);
     }
+  }
+
+  function recordTimeline(
+    ctx: {
+      notificationRecordId: string;
+      recipientId: string;
+      tenantId?: string;
+      workspaceId?: string;
+      notificationId: string;
+    },
+    event: TimelineEventType,
+    message: string,
+    extra?: { deliveryId?: string; channel?: ChannelType; provider?: string; metadata?: Record<string, unknown> },
+  ): void {
+    database.timeline.append([{
+      notificationRecordId: ctx.notificationRecordId,
+      deliveryId: extra?.deliveryId,
+      recipientId: ctx.recipientId,
+      tenantId: ctx.tenantId,
+      workspaceId: ctx.workspaceId,
+      notificationId: ctx.notificationId,
+      channel: extra?.channel,
+      provider: extra?.provider,
+      event,
+      message,
+      metadata: extra?.metadata,
+    }]).catch((err) => {
+      console.error("[notifykit] timeline append error:", err);
+    });
   }
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends
@@ -819,6 +859,16 @@ export function createNotifyKit<
     }
     const scope = resolveScope(input, recipient);
 
+    // Timeline context used for early events (before notificationRecord exists).
+    // The real notificationRecordId is patched in once the record is created.
+    const tlCtx = {
+      notificationRecordId: "",
+      recipientId: recipient.id,
+      tenantId: scope.tenantId,
+      workspaceId: scope.workspaceId,
+      notificationId: def.id,
+    };
+
     const compositeIdempotencyKey = preComputedCompositeKey ?? (input.idempotencyKey
       ? idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId)
       : undefined);
@@ -831,7 +881,10 @@ export function createNotifyKit<
         const age = Date.now() - existing.createdAt.getTime();
         if (age < ttl) {
           const replay = await buildIdempotentReplay(existing);
-          if (replay) return replay;
+          if (replay) {
+            recordTimeline({ ...tlCtx, notificationRecordId: existing.id }, "idempotent.replay", `Idempotent replay of notification ${existing.id}`);
+            return replay;
+          }
         }
         await database.notifications.clearIdempotencyKey(existing.id);
       }
@@ -892,6 +945,9 @@ export function createNotifyKit<
         const { notificationRecord, skippedRecords } = await createSkippedNotification({
           recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
         });
+        recordTimeline({ ...tlCtx, notificationRecordId: notificationRecord.id }, "deduplicated", `Duplicate send blocked: key "${input.dedupeKey}" within ${input.dedupeWindowMs}ms window`, {
+          metadata: { dedupeKey: input.dedupeKey, windowMs: input.dedupeWindowMs },
+        });
         await runHook("notification.deduplicated", {
           notificationId: def.id,
           recipientId: recipient.id,
@@ -939,6 +995,11 @@ export function createNotifyKit<
       const { notificationRecord, skippedRecords } = await createSkippedNotification({
         recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
       });
+      const suppressCtx = { ...tlCtx, notificationRecordId: notificationRecord.id };
+      recordTimeline(suppressCtx, "preferences.resolved", `All channels disabled by preferences`);
+      recordTimeline(suppressCtx, "notification.suppressed", `Notification suppressed: no deliverable channels`, {
+        metadata: { skippedChannels },
+      });
       await runHook("notification.suppressed", {
         notificationId: def.id,
         recipientId: recipient.id,
@@ -983,6 +1044,9 @@ export function createNotifyKit<
         }));
         const { notificationRecord, skippedRecords } = await createSkippedNotification({
           recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
+        });
+        recordTimeline({ ...tlCtx, notificationRecordId: notificationRecord.id }, "rate_limited", `Rate limit exceeded: ${limit.max} per ${limit.windowMs}ms`, {
+          metadata: { max: limit.max, windowMs: limit.windowMs, scope: rateLimitScope },
         });
         await runHook("notification.rate_limited", {
           notificationId: def.id,
@@ -1678,6 +1742,21 @@ export function createNotifyKit<
       });
     }
 
+    const deliverTlCtx = {
+      notificationRecordId: notificationRecord.id,
+      recipientId: recipient.id,
+      tenantId: scope.tenantId,
+      workspaceId: scope.workspaceId,
+      notificationId: def.id,
+    };
+    if (!options.existingNotification) {
+      recordTimeline(deliverTlCtx, "payload.validated", "Payload validated successfully");
+      recordTimeline(deliverTlCtx, "recipient.resolved", `Recipient "${recipient.id}" resolved`, {
+        metadata: { email: recipient.email ? "present" : "absent", phone: recipient.phone ? "present" : "absent" },
+      });
+      recordTimeline(deliverTlCtx, "preferences.resolved", `Preference resolution complete: ${explanation.channels.filter((c) => c.allowed).map((c) => c.channel).join(", ") || "none"} enabled`);
+    }
+
     const inboxItems: InboxItem[] = [];
     const deliveries: DeliveryRecord[] = [];
     const skippedChannels: ChannelType[] = [];
@@ -1695,8 +1774,8 @@ export function createNotifyKit<
       if (onlySet && !onlySet.has(ch.type)) continue;
       if (deferSet.has(ch.type)) {
         deferredChannels.push(ch.type);
-        // Deferred channels are tracked in deliveries, but not result.skipped[].
         pendingSkips.push({ channel: ch.type, reason: "quiet_hours_deferred", details: "Deferred until quiet hours end" });
+        recordTimeline(deliverTlCtx, "quiet_hours.deferred", `Channel "${ch.type}" deferred until quiet hours end`, { channel: ch.type });
         continue;
       }
       if (!isChannelAllowed(ch.type)) {
@@ -1705,6 +1784,10 @@ export function createNotifyKit<
         const skipReason = resolvedByToSkipReason(entry?.resolvedBy);
         const skipDetails = entry?.reason;
         queueSkip(ch.type, skipReason, skipDetails);
+        recordTimeline(deliverTlCtx, "channel.skipped", `Channel "${ch.type}" skipped: ${skipDetails ?? skipReason}`, {
+          channel: ch.type,
+          metadata: { reason: skipReason, details: skipDetails },
+        });
         if (def.fallback && !isLegacyFallback(def.fallback)) {
           const trigger: FallbackTrigger =
             entry?.resolvedBy === "destination_unavailable"
@@ -1728,6 +1811,7 @@ export function createNotifyKit<
             : undefined,
         });
         inboxItems.push(item);
+        recordTimeline(deliverTlCtx, "inbox.created", `Inbox item created: "${item.title}"`, { channel: "inbox" });
         await runHook("inbox.created", { inboxItem: item });
         await publishRealtime(recipient.id, scope, {
           type: "inbox.created",
@@ -1740,6 +1824,7 @@ export function createNotifyKit<
         if (!recipient.email) {
           skippedChannels.push("email");
           queueSkip("email", "missing_address", "Recipient has no email address");
+          recordTimeline(deliverTlCtx, "channel.skipped", `Channel "email" skipped: recipient has no email address`, { channel: "email", metadata: { reason: "missing_address" } });
           if (def.fallback && !isLegacyFallback(def.fallback)) {
             pendingFallbacks.push({ trigger: "missing_address", fromChannel: "email" });
           }
@@ -1772,6 +1857,7 @@ export function createNotifyKit<
           body,
           attempts: 0,
         });
+        recordTimeline(deliverTlCtx, "delivery.created", `Email delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "email", provider: provider.id });
 
         const job: DeliveryJob = {
           deliveryId: delivery.id,
@@ -1821,6 +1907,7 @@ export function createNotifyKit<
           body: JSON.stringify(payload),
           attempts: 0,
         });
+        recordTimeline(deliverTlCtx, "delivery.created", `Webhook delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "webhook", provider: provider.id });
 
         const job: DeliveryJob = {
           deliveryId: delivery.id,
@@ -1845,6 +1932,7 @@ export function createNotifyKit<
         if (!recipient.phone) {
           skippedChannels.push("sms");
           queueSkip("sms", "missing_address", "Recipient has no phone number");
+          recordTimeline(deliverTlCtx, "channel.skipped", `Channel "sms" skipped: recipient has no phone number`, { channel: "sms", metadata: { reason: "missing_address" } });
           if (def.fallback && !isLegacyFallback(def.fallback)) {
             pendingFallbacks.push({ trigger: "missing_address", fromChannel: "sms" });
           }
@@ -1866,6 +1954,7 @@ export function createNotifyKit<
           body,
           attempts: 0,
         });
+        recordTimeline(deliverTlCtx, "delivery.created", `SMS delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "sms", provider: provider.id });
 
         const job: DeliveryJob = {
           deliveryId: delivery.id,
@@ -1918,6 +2007,10 @@ export function createNotifyKit<
         const rule = matchFallbackRules(def.fallback, pf.trigger, pf.fromChannel, attempted);
         if (!rule) continue;
         attempted.add(rule.then.type);
+        recordTimeline(deliverTlCtx, "fallback.triggered", `Fallback to "${rule.then.type}" triggered by "${pf.trigger}" on "${pf.fromChannel}"`, {
+          channel: rule.then.type,
+          metadata: { trigger: pf.trigger, fromChannel: pf.fromChannel },
+        });
         try {
           const result = await executeFallbackChannel(rule.then, fallbackCtx);
           if (result.inboxItem) inboxItems.push(result.inboxItem);
@@ -1942,10 +2035,23 @@ export function createNotifyKit<
   }
 
   async function processDeliveryJob(job: DeliveryJob): Promise<void> {
+    const jobTlCtx = {
+      notificationRecordId: job.notificationRecordId,
+      recipientId: job.recipientId,
+      tenantId: job.tenantId,
+      workspaceId: job.workspaceId,
+      notificationId: job.notificationId,
+    };
     let lastError: Error | null = null;
     for (let attempt = 1; attempt <= retry.maxAttempts; attempt++) {
       if (attempt > 1) {
         const wait = retry.delayMs(attempt);
+        recordTimeline(jobTlCtx, "delivery.attempt", `Retry attempt ${attempt}/${retry.maxAttempts} (delay: ${wait}ms)`, {
+          deliveryId: job.deliveryId,
+          channel: job.channel,
+          provider: job.provider,
+          metadata: { attempt, maxAttempts: retry.maxAttempts, delayMs: wait },
+        });
         if (wait > 0) {
           await new Promise<void>((r) => setTimeout(r, wait));
         }
@@ -1988,6 +2094,19 @@ export function createNotifyKit<
           sentAt: new Date(),
           error: undefined,
         });
+        recordTimeline(jobTlCtx, "delivery.sent", `Delivery sent on attempt ${attempt}`, {
+          deliveryId: job.deliveryId,
+          channel: job.channel,
+          provider: job.provider,
+        });
+        if (result.providerMessageId) {
+          recordTimeline(jobTlCtx, "provider.message_id_stored", `Provider message ID: ${result.providerMessageId}`, {
+            deliveryId: job.deliveryId,
+            channel: job.channel,
+            provider: job.provider,
+            metadata: { providerMessageId: result.providerMessageId },
+          });
+        }
         try {
           if (updated) {
             const jobDef = byId.get(job.notificationId);
@@ -2004,6 +2123,12 @@ export function createNotifyKit<
         return;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
+        recordTimeline(jobTlCtx, "provider.error", `Provider error on attempt ${attempt}: ${lastError.message}`, {
+          deliveryId: job.deliveryId,
+          channel: job.channel,
+          provider: job.provider,
+          metadata: { attempt, error: lastError.message, permanent: !!(lastError as any).permanent },
+        });
         try {
           await database.deliveries.update(job.deliveryId, {
             attempts: attempt,
@@ -2018,6 +2143,12 @@ export function createNotifyKit<
     const failed = await database.deliveries.update(job.deliveryId, {
       status: "failed",
       failedAt: new Date(),
+    });
+    recordTimeline(jobTlCtx, "delivery.failed", `Delivery failed after ${retry.maxAttempts} attempt(s): ${lastError?.message ?? "unknown error"}`, {
+      deliveryId: job.deliveryId,
+      channel: job.channel,
+      provider: job.provider,
+      metadata: { attempts: retry.maxAttempts, error: lastError?.message },
     });
     const isFallbackDelivery = fallbackDeliveryIds.has(job.deliveryId);
     fallbackDeliveryIds.delete(job.deliveryId);
@@ -2038,6 +2169,12 @@ export function createNotifyKit<
 
     const def = byId.get(job.notificationId);
     if (def?.fallback) {
+      recordTimeline(jobTlCtx, "fallback.triggered", `Fallback triggered after "${job.channel}" delivery failed`, {
+        deliveryId: job.deliveryId,
+        channel: job.channel,
+        provider: job.provider,
+        metadata: { trigger: "channel.failed" },
+      });
       try {
         if (isLegacyFallback(def.fallback)) {
           const fallbackScope: SecurityScope = {
@@ -2500,6 +2637,12 @@ export function createNotifyKit<
       }
       if (!def.redact || def.redact.length === 0) return payload;
       return redactPayload(payload, def.redact);
+    },
+    async timeline(notificationRecordId, options) {
+      if (options?.deliveryId) {
+        return database.timeline.listByDeliveryId(options.deliveryId);
+      }
+      return database.timeline.listByNotificationRecordId(notificationRecordId);
     },
   };
 }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -124,6 +124,11 @@ export type CreateNotifyKitInput<
    * Use this to route persistent timeline failures to your monitoring system.
    */
   onTimelineError?: (error: unknown) => void;
+  /**
+   * How long to retain timeline events. Events older than this are pruned
+   * opportunistically during flush. Default: 7 days. Set to `0` to disable.
+   */
+  timelineRetentionMs?: number;
 };
 
 export type SendResult = {
@@ -358,6 +363,7 @@ export function createNotifyKit<
 >(config: CreateNotifyKitInput<T>): NotifyKit<T> {
   const { notifications, database, providers, on } = config;
   const onTimelineError = config.onTimelineError ?? ((err: unknown) => console.error("[notifykit] timeline append error:", err));
+  const timelineRetentionMs = config.timelineRetentionMs ?? 7 * 24 * 60 * 60 * 1000;
   const timelineAdapter = database.timeline ?? {
     async append() { return []; },
     async listByNotificationRecordId() { return []; },
@@ -481,6 +487,9 @@ export function createNotifyKit<
     const p = timelineAdapter.append(batch).then(() => {}).catch(onTimelineError);
     pendingTimelineWrites.add(p);
     try { await p; } finally { pendingTimelineWrites.delete(p); }
+    if (timelineRetentionMs > 0 && Math.random() < 0.01) {
+      timelineAdapter.prune(new Date(Date.now() - timelineRetentionMs)).catch(onTimelineError);
+    }
   }
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -437,6 +437,8 @@ export function createNotifyKit<
     }
   }
 
+  const pendingTimelineWrites: Promise<unknown>[] = [];
+
   function recordTimeline(
     ctx: {
       notificationRecordId: string;
@@ -449,7 +451,7 @@ export function createNotifyKit<
     message: string,
     opts?: { deliveryId?: string; channel?: ChannelType; provider?: string; metadata?: Record<string, unknown> },
   ): void {
-    database.timeline.append([{
+    const p = database.timeline.append([{
       notificationRecordId: ctx.notificationRecordId,
       deliveryId: opts?.deliveryId,
       recipientId: ctx.recipientId,
@@ -462,6 +464,12 @@ export function createNotifyKit<
       message,
       metadata: opts?.metadata,
     }]).catch(onTimelineError);
+    pendingTimelineWrites.push(p);
+  }
+
+  async function flushTimeline(): Promise<void> {
+    const pending = pendingTimelineWrites.splice(0);
+    if (pending.length > 0) await Promise.all(pending);
   }
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends
@@ -768,6 +776,7 @@ export function createNotifyKit<
 
   async function send(rawInput: SendInput<T>): Promise<SendResult> {
     const input = rawInput as { notificationId: string; recipientId: string; idempotencyKey?: string };
+    let result: SendResult;
     if (input.idempotencyKey) {
       if (input.idempotencyKey.length > 256) {
         throw new NotifyKitError(
@@ -782,7 +791,7 @@ export function createNotifyKit<
       const lockKey = `${input.notificationId}:${input.recipientId}:${input.idempotencyKey}`;
       const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
       try {
-        return await withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
+        result = await withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
       } catch (err) {
         if (isIdempotencyKeyConstraintError(err) || isUniqueConstraintError(err)) {
           const existing = await database.notifications.findByIdempotencyKey(compositeKey);
@@ -791,16 +800,25 @@ export function createNotifyKit<
             const age = Date.now() - existing.createdAt.getTime();
             if (age < ttl) {
               const replay = await buildIdempotentReplay(existing);
-              if (replay) return replay;
+              if (replay) {
+                await flushTimeline();
+                return replay;
+              }
             }
             await database.notifications.clearIdempotencyKey(existing.id);
-            return withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
+            result = await withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
+          } else {
+            throw err;
           }
+        } else {
+          throw err;
         }
-        throw err;
       }
+    } else {
+      result = await sendInner(rawInput);
     }
-    return sendInner(rawInput);
+    await flushTimeline();
+    return result;
   }
 
   async function sendInner(rawInput: SendInput<T>, preComputedCompositeKey?: string): Promise<SendResult> {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -348,7 +348,7 @@ export type NotifyKit<
    */
   timeline(
     notificationRecordId: string,
-    options?: { deliveryId?: string },
+    options?: { deliveryId?: string; limit?: number },
   ): Promise<TimelineEvent[]>;
   /**
    * The realtime adapter passed to `createNotifyKit`, or `undefined` if none
@@ -2694,10 +2694,16 @@ export function createNotifyKit<
       return redactPayload(payload, def.redact);
     },
     async timeline(notificationRecordId, options) {
+      let events: TimelineEvent[];
       if (options?.deliveryId) {
-        return timelineAdapter.listByDeliveryId(options.deliveryId, notificationRecordId);
+        events = await timelineAdapter.listByDeliveryId(options.deliveryId, notificationRecordId);
+      } else {
+        events = await timelineAdapter.listByNotificationRecordId(notificationRecordId);
       }
-      return timelineAdapter.listByNotificationRecordId(notificationRecordId);
+      if (options?.limit != null && options.limit < events.length) {
+        return events.slice(0, options.limit);
+      }
+      return events;
     },
   };
 }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -783,49 +783,49 @@ export function createNotifyKit<
   async function send(rawInput: SendInput<T>): Promise<SendResult> {
     const input = rawInput as { notificationId: string; recipientId: string; idempotencyKey?: string };
     const pending: TimelineBuffer = [];
-    let result: SendResult;
-    if (input.idempotencyKey) {
-      if (input.idempotencyKey.length > 256) {
-        throw new NotifyKitError(
-          "idempotencyKey must be 256 characters or fewer.",
-          {
-            code: "INVALID_INPUT",
-            field: "idempotencyKey",
-            fix: "Shorten the idempotencyKey to 256 characters or fewer.",
-          },
-        );
-      }
-      const lockKey = `${input.notificationId}:${input.recipientId}:${input.idempotencyKey}`;
-      const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
-      try {
-        result = await withIdempotencyLock(lockKey, () => sendInner(pending, rawInput, compositeKey));
-      } catch (err) {
-        if (isIdempotencyKeyConstraintError(err) || isUniqueConstraintError(err)) {
-          const existing = await database.notifications.findByIdempotencyKey(compositeKey);
-          if (existing) {
-            const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
-            const age = Date.now() - existing.createdAt.getTime();
-            if (age < ttl) {
-              const replay = await buildIdempotentReplay(existing);
-              if (replay) {
-                await flushTimeline(pending);
-                return replay;
+    try {
+      let result: SendResult;
+      if (input.idempotencyKey) {
+        if (input.idempotencyKey.length > 256) {
+          throw new NotifyKitError(
+            "idempotencyKey must be 256 characters or fewer.",
+            {
+              code: "INVALID_INPUT",
+              field: "idempotencyKey",
+              fix: "Shorten the idempotencyKey to 256 characters or fewer.",
+            },
+          );
+        }
+        const lockKey = `${input.notificationId}:${input.recipientId}:${input.idempotencyKey}`;
+        const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
+        try {
+          result = await withIdempotencyLock(lockKey, () => sendInner(pending, rawInput, compositeKey));
+        } catch (err) {
+          if (isIdempotencyKeyConstraintError(err) || isUniqueConstraintError(err)) {
+            const existing = await database.notifications.findByIdempotencyKey(compositeKey);
+            if (existing) {
+              const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
+              const age = Date.now() - existing.createdAt.getTime();
+              if (age < ttl) {
+                const replay = await buildIdempotentReplay(existing);
+                if (replay) return replay;
               }
+              await database.notifications.clearIdempotencyKey(existing.id);
+              result = await withIdempotencyLock(lockKey, () => sendInner(pending, rawInput, compositeKey));
+            } else {
+              throw err;
             }
-            await database.notifications.clearIdempotencyKey(existing.id);
-            result = await withIdempotencyLock(lockKey, () => sendInner(pending, rawInput, compositeKey));
           } else {
             throw err;
           }
-        } else {
-          throw err;
         }
+      } else {
+        result = await sendInner(pending, rawInput);
       }
-    } else {
-      result = await sendInner(pending, rawInput);
+      return result;
+    } finally {
+      await flushTimeline(pending);
     }
-    await flushTimeline(pending);
-    return result;
   }
 
   async function sendInner(pending: TimelineBuffer, rawInput: SendInput<T>, preComputedCompositeKey?: string): Promise<SendResult> {
@@ -1334,56 +1334,46 @@ export function createNotifyKit<
     // around until we confirm delivery succeeded.
     const record = await database.scheduledSends.claim(id);
     if (!record) return;
+    const def = byId.get(record.notificationId);
+    if (!def) {
+      await database.scheduledSends.complete(id);
+      return;
+    }
+    const recipient = await database.recipients.findById(record.recipientId);
+    if (!recipient) {
+      await database.scheduledSends.complete(id);
+      return;
+    }
+    const scope = resolveScope(record, recipient);
+    const payload = def.validate
+      ? record.payload
+      : validatePayload(def.payload, record.payload, def.id);
+    const existingNotification = record.notificationRecordId
+      ? {
+          id: record.notificationRecordId,
+          recipientId: record.recipientId,
+          tenantId: record.tenantId,
+          workspaceId: record.workspaceId,
+          notificationId: record.notificationId,
+          payload,
+          createdAt: record.createdAt,
+        }
+      : undefined;
+    const scheduledPending: TimelineBuffer = [];
     try {
-      const def = byId.get(record.notificationId);
-      if (!def) {
-        // Definition was removed since the row was created. There's nothing
-        // we can deliver, so complete the row to stop it from blocking
-        // future sweeps.
-        await database.scheduledSends.complete(id);
-        return;
-      }
-      const recipient = await database.recipients.findById(record.recipientId);
-      if (!recipient) {
-        // Recipient no longer exists. Same reasoning — complete to drop.
-        await database.scheduledSends.complete(id);
-        return;
-      }
-      const scope = resolveScope(record, recipient);
-      // The payload was already validated (and potentially transformed) by
-      // send() before being stored. Re-running a custom validator could apply
-      // a non-idempotent transform a second time, and custom validators may
-      // deliberately accept a different input shape than the primitive schema.
-      const payload = def.validate
-        ? record.payload
-        : validatePayload(def.payload, record.payload, def.id);
-      const existingNotification = record.notificationRecordId
-        ? {
-            id: record.notificationRecordId,
-            recipientId: record.recipientId,
-            tenantId: record.tenantId,
-            workspaceId: record.workspaceId,
-            notificationId: record.notificationId,
-            payload,
-            createdAt: record.createdAt,
-          }
-        : undefined;
-      const scheduledPending: TimelineBuffer = [];
       await deliver(scheduledPending, recipient, def, payload, {
         onlyChannels: ["email", "webhook", "sms"],
         scope,
         existingNotification,
       });
-      await flushTimeline(scheduledPending);
-      // Only delete after delivery has been enqueued/completed successfully.
       await database.scheduledSends.complete(id);
     } catch (err) {
-      // Something blew up after the claim. Release so a retry sweep can pick
-      // the row up again — we do NOT want silent data loss.
       await database.scheduledSends.release(id).catch((releaseErr) => {
         console.error("[notifykit] scheduled send release failed:", releaseErr);
       });
       throw err;
+    } finally {
+      await flushTimeline(scheduledPending);
     }
   }
 
@@ -1454,26 +1444,28 @@ export function createNotifyKit<
       }
 
       const digestPending: TimelineBuffer = [];
-      if (deferChannels.length > 0) {
-        const result = await deliver(digestPending, recipient, def, validated, { deferChannels, scope, prefResult });
-        await flushTimeline(digestPending);
-        const scheduledFor = nextQuietHoursEnd(recipient.quietHours!);
-        const record = await database.scheduledSends.create({
-          recipientId: recipient.id,
-          tenantId: scope.tenantId,
-          workspaceId: scope.workspaceId,
-          notificationId: def.id,
-          notificationRecordId: result.notification?.id,
-          payload: validated,
-          scheduledFor,
-          reason: "quiet_hours",
-        });
-        scheduleDeferredFlush(record.id, scheduledFor);
-        return;
-      }
+      try {
+        if (deferChannels.length > 0) {
+          const result = await deliver(digestPending, recipient, def, validated, { deferChannels, scope, prefResult });
+          const scheduledFor = nextQuietHoursEnd(recipient.quietHours!);
+          const record = await database.scheduledSends.create({
+            recipientId: recipient.id,
+            tenantId: scope.tenantId,
+            workspaceId: scope.workspaceId,
+            notificationId: def.id,
+            notificationRecordId: result.notification?.id,
+            payload: validated,
+            scheduledFor,
+            reason: "quiet_hours",
+          });
+          scheduleDeferredFlush(record.id, scheduledFor);
+          return;
+        }
 
-      await deliver(digestPending, recipient, def, validated, { scope, prefResult });
-      await flushTimeline(digestPending);
+        await deliver(digestPending, recipient, def, validated, { scope, prefResult });
+      } finally {
+        await flushTimeline(digestPending);
+      }
     } catch (err) {
       const permanent =
         err instanceof NotifyKitError &&
@@ -2078,201 +2070,200 @@ export function createNotifyKit<
       workspaceId: job.workspaceId,
       notificationId: job.notificationId,
     };
-    let lastError: Error | null = null;
-    for (let attempt = 1; attempt <= retry.maxAttempts; attempt++) {
-      if (attempt > 1) {
-        const wait = retry.delayMs(attempt);
-        recordTimeline(jobPending, jobTlCtx, "delivery.attempt", `Retry attempt ${attempt}/${retry.maxAttempts} (delay: ${wait}ms)`, {
-          deliveryId: job.deliveryId,
-          channel: job.channel,
-          provider: job.provider,
-          metadata: { attempt, maxAttempts: retry.maxAttempts, delayMs: wait },
-        });
-        if (wait > 0) {
-          await new Promise<void>((r) => setTimeout(r, wait));
-        }
-      }
-      try {
-        let result: { providerMessageId?: string };
-        if (job.channel === "email") {
-          const provider = providers!.email!;
-          result = await provider.send({
-            to: job.to,
-            subject: job.subject,
-            body: job.body,
-          });
-        } else if (job.channel === "webhook") {
-          const provider = providers!.webhook!;
-          result = await provider.send({
-            url: job.url,
-            headers: job.headers,
-            payload: {
-              notificationId: job.notificationId,
-              recipientId: job.recipientId,
-              tenantId: job.tenantId,
-              workspaceId: job.workspaceId,
-              payload: job.payload,
-              sentAt: new Date().toISOString(),
-            },
-          });
-        } else {
-          const provider = providers!.sms!;
-          result = await provider.send({
-            to: job.to,
-            body: job.body,
-          });
-        }
-
-        const updated = await database.deliveries.update(job.deliveryId, {
-          status: "sent",
-          providerMessageId: result.providerMessageId,
-          attempts: attempt,
-          sentAt: new Date(),
-          error: undefined,
-        });
-        recordTimeline(jobPending, jobTlCtx, "delivery.sent", `Delivery sent on attempt ${attempt}`, {
-          deliveryId: job.deliveryId,
-          channel: job.channel,
-          provider: job.provider,
-        });
-        if (result.providerMessageId) {
-          recordTimeline(jobPending, jobTlCtx, "provider.message_id_stored", `Provider message ID: ${result.providerMessageId}`, {
+    try {
+      let lastError: Error | null = null;
+      for (let attempt = 1; attempt <= retry.maxAttempts; attempt++) {
+        if (attempt > 1) {
+          const wait = retry.delayMs(attempt);
+          recordTimeline(jobPending, jobTlCtx, "delivery.attempt", `Retry attempt ${attempt}/${retry.maxAttempts} (delay: ${wait}ms)`, {
             deliveryId: job.deliveryId,
             channel: job.channel,
             provider: job.provider,
-            metadata: { providerMessageId: result.providerMessageId },
+            metadata: { attempt, maxAttempts: retry.maxAttempts, delayMs: wait },
           });
+          if (wait > 0) {
+            await new Promise<void>((r) => setTimeout(r, wait));
+          }
         }
         try {
-          if (updated) {
-            const jobDef = byId.get(job.notificationId);
-            await runHook("delivery.sent", {
-              delivery: updated,
-              redactedPayload: jobDef
-                ? redactForDef(jobDef, job.payload)
-                : job.payload,
+          let result: { providerMessageId?: string };
+          if (job.channel === "email") {
+            const provider = providers!.email!;
+            result = await provider.send({
+              to: job.to,
+              subject: job.subject,
+              body: job.body,
+            });
+          } else if (job.channel === "webhook") {
+            const provider = providers!.webhook!;
+            result = await provider.send({
+              url: job.url,
+              headers: job.headers,
+              payload: {
+                notificationId: job.notificationId,
+                recipientId: job.recipientId,
+                tenantId: job.tenantId,
+                workspaceId: job.workspaceId,
+                payload: job.payload,
+                sentAt: new Date().toISOString(),
+              },
+            });
+          } else {
+            const provider = providers!.sms!;
+            result = await provider.send({
+              to: job.to,
+              body: job.body,
             });
           }
-        } finally {
-          fallbackDeliveryIds.delete(job.deliveryId);
-        }
-        await flushTimeline(jobPending);
-        return;
-      } catch (err) {
-        lastError = err instanceof Error ? err : new Error(String(err));
-        recordTimeline(jobPending, jobTlCtx, "provider.error", `Provider error on attempt ${attempt}: ${lastError.message}`, {
-          deliveryId: job.deliveryId,
-          channel: job.channel,
-          provider: job.provider,
-          metadata: { attempt, error: lastError.message, permanent: !!(lastError as any).permanent },
-        });
-        try {
-          await database.deliveries.update(job.deliveryId, {
+
+          const updated = await database.deliveries.update(job.deliveryId, {
+            status: "sent",
+            providerMessageId: result.providerMessageId,
             attempts: attempt,
-            error: lastError.message,
+            sentAt: new Date(),
+            error: undefined,
           });
-        } catch (updateErr) {
-          console.error("[notifykit] delivery attempt update error:", updateErr);
+          recordTimeline(jobPending, jobTlCtx, "delivery.sent", `Delivery sent on attempt ${attempt}`, {
+            deliveryId: job.deliveryId,
+            channel: job.channel,
+            provider: job.provider,
+          });
+          if (result.providerMessageId) {
+            recordTimeline(jobPending, jobTlCtx, "provider.message_id_stored", `Provider message ID: ${result.providerMessageId}`, {
+              deliveryId: job.deliveryId,
+              channel: job.channel,
+              provider: job.provider,
+              metadata: { providerMessageId: result.providerMessageId },
+            });
+          }
+          try {
+            if (updated) {
+              const jobDef = byId.get(job.notificationId);
+              await runHook("delivery.sent", {
+                delivery: updated,
+                redactedPayload: jobDef
+                  ? redactForDef(jobDef, job.payload)
+                  : job.payload,
+              });
+            }
+          } finally {
+            fallbackDeliveryIds.delete(job.deliveryId);
+          }
+          return;
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+          recordTimeline(jobPending, jobTlCtx, "provider.error", `Provider error on attempt ${attempt}: ${lastError.message}`, {
+            deliveryId: job.deliveryId,
+            channel: job.channel,
+            provider: job.provider,
+            metadata: { attempt, error: lastError.message, permanent: !!(lastError as any).permanent },
+          });
+          try {
+            await database.deliveries.update(job.deliveryId, {
+              attempts: attempt,
+              error: lastError.message,
+            });
+          } catch (updateErr) {
+            console.error("[notifykit] delivery attempt update error:", updateErr);
+          }
+          if ((lastError as any).permanent) break;
         }
-        if ((lastError as any).permanent) break;
       }
-    }
-    const failed = await database.deliveries.update(job.deliveryId, {
-      status: "failed",
-      failedAt: new Date(),
-    });
-    recordTimeline(jobPending, jobTlCtx, "delivery.failed", `Delivery failed after ${retry.maxAttempts} attempt(s): ${lastError?.message ?? "unknown error"}`, {
-      deliveryId: job.deliveryId,
-      channel: job.channel,
-      provider: job.provider,
-      metadata: { attempts: retry.maxAttempts, error: lastError?.message },
-    });
-    const isFallbackDelivery = fallbackDeliveryIds.has(job.deliveryId);
-    fallbackDeliveryIds.delete(job.deliveryId);
-    if (failed) {
-      const failedDef = byId.get(job.notificationId);
-      await runHook("delivery.failed", {
-        delivery: failed,
-        error: lastError ?? new Error("Delivery failed"),
-        redactedPayload: failedDef
-          ? redactForDef(failedDef, job.payload)
-          : job.payload,
+      const failed = await database.deliveries.update(job.deliveryId, {
+        status: "failed",
+        failedAt: new Date(),
       });
-    }
-
-    if (isFallbackDelivery) {
-      await flushTimeline(jobPending);
-      return;
-    }
-
-    const def = byId.get(job.notificationId);
-    if (def?.fallback) {
-      recordTimeline(jobPending, jobTlCtx, "fallback.triggered", `Fallback triggered after "${job.channel}" delivery failed`, {
+      recordTimeline(jobPending, jobTlCtx, "delivery.failed", `Delivery failed after ${retry.maxAttempts} attempt(s): ${lastError?.message ?? "unknown error"}`, {
         deliveryId: job.deliveryId,
         channel: job.channel,
         provider: job.provider,
-        metadata: { trigger: "channel.failed" },
+        metadata: { attempts: retry.maxAttempts, error: lastError?.message },
       });
-      try {
-        if (isLegacyFallback(def.fallback)) {
-          const fallbackScope: SecurityScope = {
-            tenantId: job.tenantId,
-            workspaceId: job.workspaceId,
-          };
-          const fallbackRecipient = await database.recipients.findById(job.recipientId);
-          const resCtx = await buildResolutionCtx(
-            fallbackRecipient ?? { id: job.recipientId, createdAt: new Date(), updatedAt: new Date() },
-            def,
-            fallbackScope,
-          );
-          const inboxResolution = resolveChannel("inbox", resCtx);
-          if (inboxResolution.allowed) {
-            const fallback = def.fallback;
-            const item = await database.inbox.create({
-              notificationRecordId: job.notificationRecordId,
-              recipientId: job.recipientId,
-              tenantId: job.tenantId,
-              workspaceId: job.workspaceId,
-              notificationId: job.notificationId,
-              title: renderTemplate(fallback.title, job.payload, { escapeHtml: true }),
-              body:
-                fallback.body !== undefined
-                  ? renderTemplate(fallback.body, job.payload, { escapeHtml: true })
-                  : undefined,
-              actionUrl: fallback.actionUrl !== undefined
-                ? sanitizeActionUrl(renderTemplate(fallback.actionUrl, job.payload, { escapeHtml: false }))
-                : undefined,
-            });
-            await runHook("inbox.created", { inboxItem: item });
-            await publishRealtime(job.recipientId, fallbackScope, {
-              type: "inbox.created",
-              item,
-            });
-          }
-        } else {
-          const attempted = new Set<ChannelType>(
-            def.channels.map((c) => c.type),
-          );
-          attempted.add(job.channel);
-          const rule = matchFallbackRules(def.fallback, "channel.failed", job.channel, attempted);
-          if (rule) {
-            attempted.add(rule.then.type);
-            await executeFallbackChannel(rule.then, {
-              notificationRecordId: job.notificationRecordId,
-              recipientId: job.recipientId,
-              tenantId: job.tenantId,
-              workspaceId: job.workspaceId,
-              notificationId: job.notificationId,
-              payload: job.payload,
-              insideQueue: true,
-            });
-          }
-        }
-      } catch (fallbackErr) {
-        console.error("[notifykit] fallback after channel.failed error:", fallbackErr);
+      const isFallbackDelivery = fallbackDeliveryIds.has(job.deliveryId);
+      fallbackDeliveryIds.delete(job.deliveryId);
+      if (failed) {
+        const failedDef = byId.get(job.notificationId);
+        await runHook("delivery.failed", {
+          delivery: failed,
+          error: lastError ?? new Error("Delivery failed"),
+          redactedPayload: failedDef
+            ? redactForDef(failedDef, job.payload)
+            : job.payload,
+        });
       }
+
+      if (isFallbackDelivery) return;
+
+      const def = byId.get(job.notificationId);
+      if (def?.fallback) {
+        recordTimeline(jobPending, jobTlCtx, "fallback.triggered", `Fallback triggered after "${job.channel}" delivery failed`, {
+          deliveryId: job.deliveryId,
+          channel: job.channel,
+          provider: job.provider,
+          metadata: { trigger: "channel.failed" },
+        });
+        try {
+          if (isLegacyFallback(def.fallback)) {
+            const fallbackScope: SecurityScope = {
+              tenantId: job.tenantId,
+              workspaceId: job.workspaceId,
+            };
+            const fallbackRecipient = await database.recipients.findById(job.recipientId);
+            const resCtx = await buildResolutionCtx(
+              fallbackRecipient ?? { id: job.recipientId, createdAt: new Date(), updatedAt: new Date() },
+              def,
+              fallbackScope,
+            );
+            const inboxResolution = resolveChannel("inbox", resCtx);
+            if (inboxResolution.allowed) {
+              const fallback = def.fallback;
+              const item = await database.inbox.create({
+                notificationRecordId: job.notificationRecordId,
+                recipientId: job.recipientId,
+                tenantId: job.tenantId,
+                workspaceId: job.workspaceId,
+                notificationId: job.notificationId,
+                title: renderTemplate(fallback.title, job.payload, { escapeHtml: true }),
+                body:
+                  fallback.body !== undefined
+                    ? renderTemplate(fallback.body, job.payload, { escapeHtml: true })
+                    : undefined,
+                actionUrl: fallback.actionUrl !== undefined
+                  ? sanitizeActionUrl(renderTemplate(fallback.actionUrl, job.payload, { escapeHtml: false }))
+                  : undefined,
+              });
+              await runHook("inbox.created", { inboxItem: item });
+              await publishRealtime(job.recipientId, fallbackScope, {
+                type: "inbox.created",
+                item,
+              });
+            }
+          } else {
+            const attempted = new Set<ChannelType>(
+              def.channels.map((c) => c.type),
+            );
+            attempted.add(job.channel);
+            const rule = matchFallbackRules(def.fallback, "channel.failed", job.channel, attempted);
+            if (rule) {
+              attempted.add(rule.then.type);
+              await executeFallbackChannel(rule.then, {
+                notificationRecordId: job.notificationRecordId,
+                recipientId: job.recipientId,
+                tenantId: job.tenantId,
+                workspaceId: job.workspaceId,
+                notificationId: job.notificationId,
+                payload: job.payload,
+                insideQueue: true,
+              });
+            }
+          }
+        } catch (fallbackErr) {
+          console.error("[notifykit] fallback after channel.failed error:", fallbackErr);
+        }
+      }
+    } finally {
+      await flushTimeline(jobPending);
     }
-    await flushTimeline(jobPending);
   }
 
   async function updatePreference(

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2636,6 +2636,9 @@ export function createNotifyKit<
         await Promise.all(Array.from(pendingFlushes));
       }
       await queue.drain();
+      for (let i = 0; i < 10 && pendingTimelineWrites.size > 0; i++) {
+        await Promise.all(Array.from(pendingTimelineWrites));
+      }
     },
     async flushDigests() {
       const errors: unknown[] = [];

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -519,6 +519,12 @@ export function createNotifyKit<
     }
   }
 
+  async function drainPendingTimelineWrites(): Promise<void> {
+    for (let i = 0; i < 10 && pendingTimelineWrites.size > 0; i++) {
+      await Promise.all(Array.from(pendingTimelineWrites));
+    }
+  }
+
   // Per-key serialization for idempotency checks. Prevents concurrent sends
   // with the same key from racing past the findByIdempotencyKey check.
   const idempotencyLocks = new Map<string, { chain: Promise<unknown>; pending: number }>();
@@ -2663,12 +2669,7 @@ export function createNotifyKit<
         await Promise.all(Array.from(pendingFlushes));
       }
       await queue.drain();
-      // Bounded: a flush can spawn a pruneP (1 extra promise at most), so 10
-      // iterations is more than sufficient. Unbounded would risk infinite loops
-      // if a buggy adapter continuously adds promises.
-      for (let i = 0; i < 10 && pendingTimelineWrites.size > 0; i++) {
-        await Promise.all(Array.from(pendingTimelineWrites));
-      }
+      await drainPendingTimelineWrites();
     },
     async flushDigests() {
       const errors: unknown[] = [];
@@ -2702,12 +2703,7 @@ export function createNotifyKit<
         await Promise.all(Array.from(pendingFlushes));
       }
       await queue.drain();
-      // Bounded: a flush can spawn a pruneP (1 extra promise at most), so 10
-      // iterations is more than sufficient. Unbounded would risk infinite loops
-      // if a buggy adapter continuously adds promises.
-      for (let i = 0; i < 10 && pendingTimelineWrites.size > 0; i++) {
-        await Promise.all(Array.from(pendingTimelineWrites));
-      }
+      await drainPendingTimelineWrites();
       if (errors.length > 0) {
         throw errors[0];
       }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -443,7 +443,7 @@ export function createNotifyKit<
     }
   }
 
-  type TimelineBuffer = Omit<TimelineEvent, "id" | "timestamp">[];
+  type TimelineBuffer = Omit<TimelineEvent, "id" | "seq" | "timestamp">[];
 
   function recordTimeline(
     buffer: TimelineBuffer,

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -351,6 +351,12 @@ export type NotifyKit<
     options?: { deliveryId?: string; limit?: number },
   ): Promise<TimelineEvent[]>;
   /**
+   * Manually prune timeline events older than the configured retention period
+   * (or a custom cutoff). Returns the number of deleted events. Useful when
+   * `timelineRetentionMs` is set to `0` (automatic pruning disabled).
+   */
+  pruneTimeline(olderThan?: Date): Promise<number>;
+  /**
    * The realtime adapter passed to `createNotifyKit`, or `undefined` if none
    * was provided. Exposed so handlers and transports can subscribe clients;
    * core inbox mutations publish their own realtime events.
@@ -2711,6 +2717,10 @@ export function createNotifyKit<
         return events.slice(0, options.limit);
       }
       return events;
+    },
+    async pruneTimeline(olderThan) {
+      const cutoff = olderThan ?? new Date(Date.now() - timelineRetentionMs);
+      return timelineAdapter.prune(cutoff);
     },
   };
 }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -526,6 +526,9 @@ export function createNotifyKit<
   }
 
   async function drainPendingTimelineWrites(): Promise<void> {
+    // Cap iterations: a completing write can spawn a prune, which may itself
+    // resolve and remove itself, so we re-check. 10 rounds is generous; if
+    // writes still remain, they are in-flight prunes we can safely orphan.
     for (let i = 0; i < 10 && pendingTimelineWrites.size > 0; i++) {
       await Promise.all(Array.from(pendingTimelineWrites));
     }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1544,11 +1544,11 @@ export function createNotifyKit<
     return null;
   }
 
-  async function enqueueOrRun(job: DeliveryJob, insideQueue: boolean): Promise<void> {
+  async function enqueueOrRun(job: DeliveryJob, insideQueue: boolean, parentBuffer?: TimelineBuffer): Promise<void> {
     if (insideQueue) {
-      await processDeliveryJob(job);
+      await processDeliveryJob(job, parentBuffer);
     } else {
-      await queue.enqueue(job, (j) => processDeliveryJob(j));
+      await queue.enqueue(job, (j) => processDeliveryJob(j, parentBuffer));
     }
   }
 
@@ -1562,6 +1562,7 @@ export function createNotifyKit<
       notificationId: string;
       payload: Record<string, unknown>;
       insideQueue?: boolean;
+      timelineBuffer?: TimelineBuffer;
     },
   ): Promise<{ inboxItem?: InboxItem; delivery?: DeliveryRecord }> {
     const scope: SecurityScope = { tenantId: ctx.tenantId, workspaceId: ctx.workspaceId };
@@ -1642,7 +1643,7 @@ export function createNotifyKit<
         body,
         payload: ctx.payload,
       };
-      await enqueueOrRun(job, !!ctx.insideQueue);
+      await enqueueOrRun(job, !!ctx.insideQueue, ctx.timelineBuffer);
       const latest = await database.deliveries.findById(delivery.id);
       return { delivery: latest ?? delivery };
     }
@@ -1685,7 +1686,7 @@ export function createNotifyKit<
         headers,
         payload: ctx.payload,
       };
-      await enqueueOrRun(job, !!ctx.insideQueue);
+      await enqueueOrRun(job, !!ctx.insideQueue, ctx.timelineBuffer);
       const latest = await database.deliveries.findById(delivery.id);
       return { delivery: latest ?? delivery };
     }
@@ -1721,7 +1722,7 @@ export function createNotifyKit<
         body,
         payload: ctx.payload,
       };
-      await enqueueOrRun(job, !!ctx.insideQueue);
+      await enqueueOrRun(job, !!ctx.insideQueue, ctx.timelineBuffer);
       const latest = await database.deliveries.findById(delivery.id);
       return { delivery: latest ?? delivery };
     }
@@ -1923,7 +1924,7 @@ export function createNotifyKit<
           payload,
         };
 
-        await queue.enqueue(job, (j) => processDeliveryJob(j));
+        await queue.enqueue(job, (j) => processDeliveryJob(j, pending));
 
         // Re-read after enqueue so inline queues return final state; async
         // queues return "pending" here (callers use drain() + deliveries.list).
@@ -1972,7 +1973,7 @@ export function createNotifyKit<
           payload,
         };
 
-        await queue.enqueue(job, (j) => processDeliveryJob(j));
+        await queue.enqueue(job, (j) => processDeliveryJob(j, pending));
 
         const latest = await database.deliveries.findById(delivery.id);
         deliveries.push(latest ?? delivery);
@@ -2019,7 +2020,7 @@ export function createNotifyKit<
           payload,
         };
 
-        await queue.enqueue(job, (j) => processDeliveryJob(j));
+        await queue.enqueue(job, (j) => processDeliveryJob(j, pending));
 
         const latest = await database.deliveries.findById(delivery.id);
         deliveries.push(latest ?? delivery);
@@ -2051,6 +2052,7 @@ export function createNotifyKit<
         workspaceId: scope.workspaceId,
         notificationId: def.id,
         payload,
+        timelineBuffer: pending,
       };
       for (const pf of pendingFallbacks) {
         const rule = matchFallbackRules(def.fallback, pf.trigger, pf.fromChannel, attempted);
@@ -2083,8 +2085,9 @@ export function createNotifyKit<
     };
   }
 
-  async function processDeliveryJob(job: DeliveryJob): Promise<void> {
-    const jobPending: TimelineBuffer = [];
+  async function processDeliveryJob(job: DeliveryJob, parentBuffer?: TimelineBuffer): Promise<void> {
+    const ownsBuffer = !parentBuffer;
+    const jobPending: TimelineBuffer = parentBuffer ?? [];
     const jobTlCtx = {
       notificationRecordId: job.notificationRecordId,
       recipientId: job.recipientId,
@@ -2276,6 +2279,7 @@ export function createNotifyKit<
                 notificationId: job.notificationId,
                 payload: job.payload,
                 insideQueue: true,
+                timelineBuffer: jobPending,
               });
             }
           }
@@ -2284,7 +2288,7 @@ export function createNotifyKit<
         }
       }
     } finally {
-      await flushTimeline(jobPending);
+      if (ownsBuffer) await flushTimeline(jobPending);
     }
   }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -488,6 +488,7 @@ export function createNotifyKit<
   }
 
   const pendingTimelineWrites = new Set<Promise<void>>();
+  let pruneFailures = 0;
 
   async function reportTimelineError(error: unknown): Promise<void> {
     try {
@@ -503,10 +504,18 @@ export function createNotifyKit<
     const p = timelineAdapter.append(batch).then(() => {}).catch(reportTimelineError);
     pendingTimelineWrites.add(p);
     try { await p; } finally { pendingTimelineWrites.delete(p); }
-    if (timelineRetentionMs > 0 && Math.random() < 0.01) {
-      const pruneP = timelineAdapter.prune(new Date(Date.now() - timelineRetentionMs)).then(() => {}).catch(reportTimelineError);
-      pendingTimelineWrites.add(pruneP);
-      pruneP.finally(() => pendingTimelineWrites.delete(pruneP));
+    if (timelineRetentionMs > 0) {
+      const pruneProbability = pruneFailures >= 10 ? 1 : 0.01;
+      if (Math.random() < pruneProbability) {
+        const pruneP = timelineAdapter.prune(new Date(Date.now() - timelineRetentionMs))
+          .then(() => { pruneFailures = 0; })
+          .catch((err: unknown) => {
+            pruneFailures++;
+            return reportTimelineError(err);
+          });
+        pendingTimelineWrites.add(pruneP);
+        pruneP.finally(() => pendingTimelineWrites.delete(pruneP));
+      }
     }
   }
 
@@ -2654,6 +2663,9 @@ export function createNotifyKit<
         await Promise.all(Array.from(pendingFlushes));
       }
       await queue.drain();
+      // Bounded: a flush can spawn a pruneP (1 extra promise at most), so 10
+      // iterations is more than sufficient. Unbounded would risk infinite loops
+      // if a buggy adapter continuously adds promises.
       for (let i = 0; i < 10 && pendingTimelineWrites.size > 0; i++) {
         await Promise.all(Array.from(pendingTimelineWrites));
       }
@@ -2690,6 +2702,9 @@ export function createNotifyKit<
         await Promise.all(Array.from(pendingFlushes));
       }
       await queue.drain();
+      // Bounded: a flush can spawn a pruneP (1 extra promise at most), so 10
+      // iterations is more than sufficient. Unbounded would risk infinite loops
+      // if a buggy adapter continuously adds promises.
       for (let i = 0; i < 10 && pendingTimelineWrites.size > 0; i++) {
         await Promise.all(Array.from(pendingTimelineWrites));
       }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -824,7 +824,14 @@ export function createNotifyKit<
               const age = Date.now() - existing.createdAt.getTime();
               if (age < ttl) {
                 const replay = await buildIdempotentReplay(existing);
-                if (replay) return replay;
+                if (replay) {
+                  recordTimeline(pending, {
+                    notificationRecordId: existing.id,
+                    recipientId: input.recipientId,
+                    notificationId: input.notificationId,
+                  }, "idempotent.replay", `Idempotent replay of notification ${existing.id}`);
+                  return replay;
+                }
               }
               await database.notifications.clearIdempotencyKey(existing.id);
               result = await withIdempotencyLock(lockKey, () => sendInner(pending, rawInput, compositeKey));

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2723,6 +2723,7 @@ export function createNotifyKit<
       return events;
     },
     async pruneTimeline(olderThan) {
+      if (!olderThan && timelineRetentionMs === 0) return 0;
       const cutoff = olderThan ?? new Date(Date.now() - timelineRetentionMs);
       return timelineAdapter.prune(cutoff);
     },

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -489,14 +489,22 @@ export function createNotifyKit<
 
   const pendingTimelineWrites = new Set<Promise<void>>();
 
+  async function reportTimelineError(error: unknown): Promise<void> {
+    try {
+      await onTimelineError(error);
+    } catch (handlerError) {
+      console.error("[notifykit] onTimelineError handler error:", handlerError);
+    }
+  }
+
   async function flushTimeline(buffer: TimelineBuffer): Promise<void> {
     const batch = buffer.splice(0);
     if (batch.length === 0) return;
-    const p = timelineAdapter.append(batch).then(() => {}).catch(onTimelineError);
+    const p = timelineAdapter.append(batch).then(() => {}).catch(reportTimelineError);
     pendingTimelineWrites.add(p);
     try { await p; } finally { pendingTimelineWrites.delete(p); }
     if (timelineRetentionMs > 0 && Math.random() < 0.01) {
-      const pruneP = timelineAdapter.prune(new Date(Date.now() - timelineRetentionMs)).then(() => {}).catch(onTimelineError);
+      const pruneP = timelineAdapter.prune(new Date(Date.now() - timelineRetentionMs)).then(() => {}).catch(reportTimelineError);
       pendingTimelineWrites.add(pruneP);
       pruneP.finally(() => pendingTimelineWrites.delete(pruneP));
     }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -441,20 +441,20 @@ export function createNotifyKit<
     },
     event: TimelineEventType,
     message: string,
-    extra?: { deliveryId?: string; channel?: ChannelType; provider?: string; metadata?: Record<string, unknown> },
+    opts?: { deliveryId?: string; channel?: ChannelType; provider?: string; metadata?: Record<string, unknown> },
   ): void {
     database.timeline.append([{
       notificationRecordId: ctx.notificationRecordId,
-      deliveryId: extra?.deliveryId,
+      deliveryId: opts?.deliveryId,
       recipientId: ctx.recipientId,
       tenantId: ctx.tenantId,
       workspaceId: ctx.workspaceId,
       notificationId: ctx.notificationId,
-      channel: extra?.channel,
-      provider: extra?.provider,
+      channel: opts?.channel,
+      provider: opts?.provider,
       event,
       message,
-      metadata: extra?.metadata,
+      metadata: opts?.metadata,
     }]).catch((err) => {
       console.error("[notifykit] timeline append error:", err);
     });

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -344,7 +344,7 @@ export type NotifyKit<
   /**
    * Retrieve the debug timeline for a notification. Returns lifecycle events
    * in chronological order showing every decision, side effect, and provider
-   * interaction. Optionally filter to a specific delivery.
+   * interaction. Optionally filter to a specific delivery. Default limit: 1000.
    */
   timeline(
     notificationRecordId: string,
@@ -2730,10 +2730,11 @@ export function createNotifyKit<
       return redactPayload(payload, def.redact);
     },
     async timeline(notificationRecordId, options) {
+      const cap = options?.limit ?? 1000;
       if (options?.deliveryId) {
-        return timelineAdapter.listByDeliveryId(options.deliveryId, notificationRecordId, options?.limit);
+        return timelineAdapter.listByDeliveryId(options.deliveryId, notificationRecordId, cap);
       }
-      return timelineAdapter.listByNotificationRecordId(notificationRecordId, options?.limit);
+      return timelineAdapter.listByNotificationRecordId(notificationRecordId, cap);
     },
     async pruneTimeline(olderThan) {
       if (!olderThan && timelineRetentionMs === 0) return 0;

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -473,9 +473,14 @@ export function createNotifyKit<
     });
   }
 
+  const pendingTimelineWrites = new Set<Promise<void>>();
+
   async function flushTimeline(buffer: TimelineBuffer): Promise<void> {
     const batch = buffer.splice(0);
-    if (batch.length > 0) await timelineAdapter.append(batch).catch(onTimelineError);
+    if (batch.length === 0) return;
+    const p = timelineAdapter.append(batch).then(() => {}).catch(onTimelineError);
+    pendingTimelineWrites.add(p);
+    try { await p; } finally { pendingTimelineWrites.delete(p); }
   }
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends
@@ -2643,6 +2648,9 @@ export function createNotifyKit<
         await Promise.all(Array.from(pendingFlushes));
       }
       await queue.drain();
+      while (pendingTimelineWrites.size > 0) {
+        await Promise.all(Array.from(pendingTimelineWrites));
+      }
       if (errors.length > 0) {
         throw errors[0];
       }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -362,7 +362,9 @@ export function createNotifyKit<
   const T extends readonly NotificationDefinition<string, PayloadSchema>[],
 >(config: CreateNotifyKitInput<T>): NotifyKit<T> {
   const { notifications, database, providers, on } = config;
-  const onTimelineError = config.onTimelineError ?? ((err: unknown) => console.error("[notifykit] timeline append error:", err));
+  const onTimelineError = config.onTimelineError ?? ((err: unknown) => {
+    console.error("[notifykit] timeline append error:", err);
+  });
   const timelineRetentionMs = config.timelineRetentionMs ?? 7 * 24 * 60 * 60 * 1000;
   const timelineAdapter = database.timeline ?? {
     async append() { return []; },

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -913,10 +913,7 @@ export function createNotifyKit<
     }
     const scope = resolveScope(input, recipient);
 
-    // Timeline context used for early events (before notificationRecord exists).
-    // The real notificationRecordId is patched in once the record is created.
     const tlCtx = {
-      notificationRecordId: "",
       recipientId: recipient.id,
       tenantId: scope.tenantId,
       workspaceId: scope.workspaceId,

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2678,8 +2678,7 @@ export function createNotifyKit<
     },
     async timeline(notificationRecordId, options) {
       if (options?.deliveryId) {
-        const events = await timelineAdapter.listByDeliveryId(options.deliveryId);
-        return events.filter((e) => e.notificationRecordId === notificationRecordId);
+        return timelineAdapter.listByDeliveryId(options.deliveryId, notificationRecordId);
       }
       return timelineAdapter.listByNotificationRecordId(notificationRecordId);
     },

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -489,6 +489,7 @@ export function createNotifyKit<
 
   const pendingTimelineWrites = new Set<Promise<void>>();
   let pruneFailures = 0;
+  let lastPruneAttemptMs = 0;
 
   async function reportTimelineError(error: unknown): Promise<void> {
     try {
@@ -505,16 +506,21 @@ export function createNotifyKit<
     pendingTimelineWrites.add(p);
     try { await p; } finally { pendingTimelineWrites.delete(p); }
     if (timelineRetentionMs > 0) {
-      const pruneProbability = pruneFailures >= 10 ? 1 : 0.01;
-      if (Math.random() < pruneProbability) {
-        const pruneP = timelineAdapter.prune(new Date(Date.now() - timelineRetentionMs))
-          .then(() => { pruneFailures = 0; })
-          .catch((err: unknown) => {
-            pruneFailures++;
-            return reportTimelineError(err);
-          });
-        pendingTimelineWrites.add(pruneP);
-        pruneP.finally(() => pendingTimelineWrites.delete(pruneP));
+      const now = Date.now();
+      const backoffMs = pruneFailures >= 10 ? 60_000 : 0;
+      if (now - lastPruneAttemptMs >= backoffMs) {
+        const pruneProbability = pruneFailures >= 10 ? 1 : 0.01;
+        if (Math.random() < pruneProbability) {
+          lastPruneAttemptMs = now;
+          const pruneP = timelineAdapter.prune(new Date(now - timelineRetentionMs))
+            .then(() => { pruneFailures = 0; })
+            .catch((err: unknown) => {
+              pruneFailures++;
+              return reportTimelineError(err);
+            });
+          pendingTimelineWrites.add(pruneP);
+          pruneP.finally(() => pendingTimelineWrites.delete(pruneP));
+        }
       }
     }
   }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -437,8 +437,10 @@ export function createNotifyKit<
     }
   }
 
+  type TimelineBuffer = Omit<TimelineEvent, "id" | "timestamp">[];
+
   function recordTimeline(
-    pending: Promise<unknown>[],
+    buffer: TimelineBuffer,
     ctx: {
       notificationRecordId: string;
       recipientId: string;
@@ -450,7 +452,7 @@ export function createNotifyKit<
     message: string,
     opts?: { deliveryId?: string; channel?: ChannelType; provider?: string; metadata?: Record<string, unknown> },
   ): void {
-    const p = database.timeline.append([{
+    buffer.push({
       notificationRecordId: ctx.notificationRecordId,
       deliveryId: opts?.deliveryId,
       recipientId: ctx.recipientId,
@@ -462,13 +464,12 @@ export function createNotifyKit<
       event,
       message,
       metadata: opts?.metadata,
-    }]).catch(onTimelineError);
-    pending.push(p);
+    });
   }
 
-  async function flushTimeline(pending: Promise<unknown>[]): Promise<void> {
-    const batch = pending.splice(0);
-    if (batch.length > 0) await Promise.all(batch);
+  async function flushTimeline(buffer: TimelineBuffer): Promise<void> {
+    const batch = buffer.splice(0);
+    if (batch.length > 0) await database.timeline.append(batch).catch(onTimelineError);
   }
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends
@@ -775,7 +776,7 @@ export function createNotifyKit<
 
   async function send(rawInput: SendInput<T>): Promise<SendResult> {
     const input = rawInput as { notificationId: string; recipientId: string; idempotencyKey?: string };
-    const pending: Promise<unknown>[] = [];
+    const pending: TimelineBuffer = [];
     let result: SendResult;
     if (input.idempotencyKey) {
       if (input.idempotencyKey.length > 256) {
@@ -821,7 +822,7 @@ export function createNotifyKit<
     return result;
   }
 
-  async function sendInner(pending: Promise<unknown>[], rawInput: SendInput<T>, preComputedCompositeKey?: string): Promise<SendResult> {
+  async function sendInner(pending: TimelineBuffer, rawInput: SendInput<T>, preComputedCompositeKey?: string): Promise<SendResult> {
     const input = rawInput as {
       recipientId: string;
       tenantId?: string;
@@ -1361,7 +1362,7 @@ export function createNotifyKit<
             createdAt: record.createdAt,
           }
         : undefined;
-      const scheduledPending: Promise<unknown>[] = [];
+      const scheduledPending: TimelineBuffer = [];
       await deliver(scheduledPending, recipient, def, payload, {
         onlyChannels: ["email", "webhook", "sms"],
         scope,
@@ -1446,7 +1447,7 @@ export function createNotifyKit<
         }
       }
 
-      const digestPending: Promise<unknown>[] = [];
+      const digestPending: TimelineBuffer = [];
       if (deferChannels.length > 0) {
         const result = await deliver(digestPending, recipient, def, validated, { deferChannels, scope, prefResult });
         await flushTimeline(digestPending);
@@ -1731,7 +1732,7 @@ export function createNotifyKit<
   };
 
   async function deliver(
-    pending: Promise<unknown>[],
+    pending: TimelineBuffer,
     recipient: Recipient,
     def: NotificationDefinition<string, PayloadSchema>,
     payload: Record<string, unknown>,
@@ -2063,7 +2064,7 @@ export function createNotifyKit<
   }
 
   async function processDeliveryJob(job: DeliveryJob): Promise<void> {
-    const jobPending: Promise<unknown>[] = [];
+    const jobPending: TimelineBuffer = [];
     const jobTlCtx = {
       notificationRecordId: job.notificationRecordId,
       recipientId: job.recipientId,

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2648,7 +2648,7 @@ export function createNotifyKit<
         await Promise.all(Array.from(pendingFlushes));
       }
       await queue.drain();
-      while (pendingTimelineWrites.size > 0) {
+      for (let i = 0; i < 10 && pendingTimelineWrites.size > 0; i++) {
         await Promise.all(Array.from(pendingTimelineWrites));
       }
       if (errors.length > 0) {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -437,9 +437,8 @@ export function createNotifyKit<
     }
   }
 
-  const pendingTimelineWrites: Promise<unknown>[] = [];
-
   function recordTimeline(
+    pending: Promise<unknown>[],
     ctx: {
       notificationRecordId: string;
       recipientId: string;
@@ -464,12 +463,12 @@ export function createNotifyKit<
       message,
       metadata: opts?.metadata,
     }]).catch(onTimelineError);
-    pendingTimelineWrites.push(p);
+    pending.push(p);
   }
 
-  async function flushTimeline(): Promise<void> {
-    const pending = pendingTimelineWrites.splice(0);
-    if (pending.length > 0) await Promise.all(pending);
+  async function flushTimeline(pending: Promise<unknown>[]): Promise<void> {
+    const batch = pending.splice(0);
+    if (batch.length > 0) await Promise.all(batch);
   }
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends
@@ -776,6 +775,7 @@ export function createNotifyKit<
 
   async function send(rawInput: SendInput<T>): Promise<SendResult> {
     const input = rawInput as { notificationId: string; recipientId: string; idempotencyKey?: string };
+    const pending: Promise<unknown>[] = [];
     let result: SendResult;
     if (input.idempotencyKey) {
       if (input.idempotencyKey.length > 256) {
@@ -791,7 +791,7 @@ export function createNotifyKit<
       const lockKey = `${input.notificationId}:${input.recipientId}:${input.idempotencyKey}`;
       const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
       try {
-        result = await withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
+        result = await withIdempotencyLock(lockKey, () => sendInner(pending, rawInput, compositeKey));
       } catch (err) {
         if (isIdempotencyKeyConstraintError(err) || isUniqueConstraintError(err)) {
           const existing = await database.notifications.findByIdempotencyKey(compositeKey);
@@ -801,12 +801,12 @@ export function createNotifyKit<
             if (age < ttl) {
               const replay = await buildIdempotentReplay(existing);
               if (replay) {
-                await flushTimeline();
+                await flushTimeline(pending);
                 return replay;
               }
             }
             await database.notifications.clearIdempotencyKey(existing.id);
-            result = await withIdempotencyLock(lockKey, () => sendInner(rawInput, compositeKey));
+            result = await withIdempotencyLock(lockKey, () => sendInner(pending, rawInput, compositeKey));
           } else {
             throw err;
           }
@@ -815,13 +815,13 @@ export function createNotifyKit<
         }
       }
     } else {
-      result = await sendInner(rawInput);
+      result = await sendInner(pending, rawInput);
     }
-    await flushTimeline();
+    await flushTimeline(pending);
     return result;
   }
 
-  async function sendInner(rawInput: SendInput<T>, preComputedCompositeKey?: string): Promise<SendResult> {
+  async function sendInner(pending: Promise<unknown>[], rawInput: SendInput<T>, preComputedCompositeKey?: string): Promise<SendResult> {
     const input = rawInput as {
       recipientId: string;
       tenantId?: string;
@@ -904,7 +904,7 @@ export function createNotifyKit<
         if (age < ttl) {
           const replay = await buildIdempotentReplay(existing);
           if (replay) {
-            recordTimeline({ ...tlCtx, notificationRecordId: existing.id }, "idempotent.replay", `Idempotent replay of notification ${existing.id}`);
+            recordTimeline(pending, { ...tlCtx, notificationRecordId: existing.id }, "idempotent.replay", `Idempotent replay of notification ${existing.id}`);
             return replay;
           }
         }
@@ -967,7 +967,7 @@ export function createNotifyKit<
         const { notificationRecord, skippedRecords } = await createSkippedNotification({
           recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
         });
-        recordTimeline({ ...tlCtx, notificationRecordId: notificationRecord.id }, "deduplicated", `Duplicate send blocked: key "${input.dedupeKey}" within ${input.dedupeWindowMs}ms window`, {
+        recordTimeline(pending, { ...tlCtx, notificationRecordId: notificationRecord.id }, "deduplicated", `Duplicate send blocked: key "${input.dedupeKey}" within ${input.dedupeWindowMs}ms window`, {
           metadata: { dedupeKey: input.dedupeKey, windowMs: input.dedupeWindowMs },
         });
         await runHook("notification.deduplicated", {
@@ -1018,8 +1018,8 @@ export function createNotifyKit<
         recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
       });
       const suppressCtx = { ...tlCtx, notificationRecordId: notificationRecord.id };
-      recordTimeline(suppressCtx, "preferences.resolved", `All channels disabled by preferences`);
-      recordTimeline(suppressCtx, "notification.suppressed", `Notification suppressed: no deliverable channels`, {
+      recordTimeline(pending, suppressCtx, "preferences.resolved", `All channels disabled by preferences`);
+      recordTimeline(pending, suppressCtx, "notification.suppressed", `Notification suppressed: no deliverable channels`, {
         metadata: { skippedChannels },
       });
       await runHook("notification.suppressed", {
@@ -1067,7 +1067,7 @@ export function createNotifyKit<
         const { notificationRecord, skippedRecords } = await createSkippedNotification({
           recipient, scope, def, payload, skipped, idempotencyKey: compositeIdempotencyKey,
         });
-        recordTimeline({ ...tlCtx, notificationRecordId: notificationRecord.id }, "rate_limited", `Rate limit exceeded: ${limit.max} per ${limit.windowMs}ms`, {
+        recordTimeline(pending, { ...tlCtx, notificationRecordId: notificationRecord.id }, "rate_limited", `Rate limit exceeded: ${limit.max} per ${limit.windowMs}ms`, {
           metadata: { max: limit.max, windowMs: limit.windowMs, scope: rateLimitScope },
         });
         await runHook("notification.rate_limited", {
@@ -1161,7 +1161,7 @@ export function createNotifyKit<
     }
 
     if (deferChannels.length > 0) {
-      const result = await deliver(recipient, def, payload, { deferChannels, scope, prefResult, idempotencyKey: compositeIdempotencyKey });
+      const result = await deliver(pending, recipient, def, payload, { deferChannels, scope, prefResult, idempotencyKey: compositeIdempotencyKey });
       const scheduledFor = nextQuietHoursEnd(recipient.quietHours!);
       const record = await database.scheduledSends.create({
         recipientId: recipient.id,
@@ -1177,7 +1177,7 @@ export function createNotifyKit<
       return result;
     }
 
-    return deliver(recipient, def, payload, { scope, prefResult, idempotencyKey: compositeIdempotencyKey });
+    return deliver(pending, recipient, def, payload, { scope, prefResult, idempotencyKey: compositeIdempotencyKey });
   }
 
   async function explain(rawInput: SendInput<T>): Promise<DeliveryExplanation> {
@@ -1361,11 +1361,13 @@ export function createNotifyKit<
             createdAt: record.createdAt,
           }
         : undefined;
-      await deliver(recipient, def, payload, {
+      const scheduledPending: Promise<unknown>[] = [];
+      await deliver(scheduledPending, recipient, def, payload, {
         onlyChannels: ["email", "webhook", "sms"],
         scope,
         existingNotification,
       });
+      await flushTimeline(scheduledPending);
       // Only delete after delivery has been enqueued/completed successfully.
       await database.scheduledSends.complete(id);
     } catch (err) {
@@ -1444,8 +1446,10 @@ export function createNotifyKit<
         }
       }
 
+      const digestPending: Promise<unknown>[] = [];
       if (deferChannels.length > 0) {
-        const result = await deliver(recipient, def, validated, { deferChannels, scope, prefResult });
+        const result = await deliver(digestPending, recipient, def, validated, { deferChannels, scope, prefResult });
+        await flushTimeline(digestPending);
         const scheduledFor = nextQuietHoursEnd(recipient.quietHours!);
         const record = await database.scheduledSends.create({
           recipientId: recipient.id,
@@ -1461,7 +1465,8 @@ export function createNotifyKit<
         return;
       }
 
-      await deliver(recipient, def, validated, { scope, prefResult });
+      await deliver(digestPending, recipient, def, validated, { scope, prefResult });
+      await flushTimeline(digestPending);
     } catch (err) {
       const permanent =
         err instanceof NotifyKitError &&
@@ -1726,6 +1731,7 @@ export function createNotifyKit<
   };
 
   async function deliver(
+    pending: Promise<unknown>[],
     recipient: Recipient,
     def: NotificationDefinition<string, PayloadSchema>,
     payload: Record<string, unknown>,
@@ -1772,11 +1778,11 @@ export function createNotifyKit<
       notificationId: def.id,
     };
     if (!options.existingNotification) {
-      recordTimeline(deliverTlCtx, "payload.validated", "Payload validated successfully");
-      recordTimeline(deliverTlCtx, "recipient.resolved", `Recipient "${recipient.id}" resolved`, {
+      recordTimeline(pending, deliverTlCtx, "payload.validated", "Payload validated successfully");
+      recordTimeline(pending, deliverTlCtx, "recipient.resolved", `Recipient "${recipient.id}" resolved`, {
         metadata: { email: recipient.email ? "present" : "absent", phone: recipient.phone ? "present" : "absent" },
       });
-      recordTimeline(deliverTlCtx, "preferences.resolved", `Preference resolution complete: ${explanation.channels.filter((c) => c.allowed).map((c) => c.channel).join(", ") || "none"} enabled`);
+      recordTimeline(pending, deliverTlCtx, "preferences.resolved", `Preference resolution complete: ${explanation.channels.filter((c) => c.allowed).map((c) => c.channel).join(", ") || "none"} enabled`);
     }
 
     const inboxItems: InboxItem[] = [];
@@ -1797,7 +1803,7 @@ export function createNotifyKit<
       if (deferSet.has(ch.type)) {
         deferredChannels.push(ch.type);
         pendingSkips.push({ channel: ch.type, reason: "quiet_hours_deferred", details: "Deferred until quiet hours end" });
-        recordTimeline(deliverTlCtx, "quiet_hours.deferred", `Channel "${ch.type}" deferred until quiet hours end`, { channel: ch.type });
+        recordTimeline(pending, deliverTlCtx, "quiet_hours.deferred", `Channel "${ch.type}" deferred until quiet hours end`, { channel: ch.type });
         continue;
       }
       if (!isChannelAllowed(ch.type)) {
@@ -1806,7 +1812,7 @@ export function createNotifyKit<
         const skipReason = resolvedByToSkipReason(entry?.resolvedBy);
         const skipDetails = entry?.reason;
         queueSkip(ch.type, skipReason, skipDetails);
-        recordTimeline(deliverTlCtx, "channel.skipped", `Channel "${ch.type}" skipped: ${skipDetails ?? skipReason}`, {
+        recordTimeline(pending, deliverTlCtx, "channel.skipped", `Channel "${ch.type}" skipped: ${skipDetails ?? skipReason}`, {
           channel: ch.type,
           metadata: { reason: skipReason, details: skipDetails },
         });
@@ -1833,7 +1839,7 @@ export function createNotifyKit<
             : undefined,
         });
         inboxItems.push(item);
-        recordTimeline(deliverTlCtx, "inbox.created", `Inbox item created: "${item.title}"`, { channel: "inbox" });
+        recordTimeline(pending, deliverTlCtx, "inbox.created", `Inbox item created: "${item.title}"`, { channel: "inbox" });
         await runHook("inbox.created", { inboxItem: item });
         await publishRealtime(recipient.id, scope, {
           type: "inbox.created",
@@ -1846,7 +1852,7 @@ export function createNotifyKit<
         if (!recipient.email) {
           skippedChannels.push("email");
           queueSkip("email", "missing_address", "Recipient has no email address");
-          recordTimeline(deliverTlCtx, "channel.skipped", `Channel "email" skipped: recipient has no email address`, { channel: "email", metadata: { reason: "missing_address" } });
+          recordTimeline(pending, deliverTlCtx, "channel.skipped", `Channel "email" skipped: recipient has no email address`, { channel: "email", metadata: { reason: "missing_address" } });
           if (def.fallback && !isLegacyFallback(def.fallback)) {
             pendingFallbacks.push({ trigger: "missing_address", fromChannel: "email" });
           }
@@ -1879,7 +1885,7 @@ export function createNotifyKit<
           body,
           attempts: 0,
         });
-        recordTimeline(deliverTlCtx, "delivery.created", `Email delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "email", provider: provider.id });
+        recordTimeline(pending, deliverTlCtx, "delivery.created", `Email delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "email", provider: provider.id });
 
         const job: DeliveryJob = {
           deliveryId: delivery.id,
@@ -1929,7 +1935,7 @@ export function createNotifyKit<
           body: JSON.stringify(payload),
           attempts: 0,
         });
-        recordTimeline(deliverTlCtx, "delivery.created", `Webhook delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "webhook", provider: provider.id });
+        recordTimeline(pending, deliverTlCtx, "delivery.created", `Webhook delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "webhook", provider: provider.id });
 
         const job: DeliveryJob = {
           deliveryId: delivery.id,
@@ -1954,7 +1960,7 @@ export function createNotifyKit<
         if (!recipient.phone) {
           skippedChannels.push("sms");
           queueSkip("sms", "missing_address", "Recipient has no phone number");
-          recordTimeline(deliverTlCtx, "channel.skipped", `Channel "sms" skipped: recipient has no phone number`, { channel: "sms", metadata: { reason: "missing_address" } });
+          recordTimeline(pending, deliverTlCtx, "channel.skipped", `Channel "sms" skipped: recipient has no phone number`, { channel: "sms", metadata: { reason: "missing_address" } });
           if (def.fallback && !isLegacyFallback(def.fallback)) {
             pendingFallbacks.push({ trigger: "missing_address", fromChannel: "sms" });
           }
@@ -1976,7 +1982,7 @@ export function createNotifyKit<
           body,
           attempts: 0,
         });
-        recordTimeline(deliverTlCtx, "delivery.created", `SMS delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "sms", provider: provider.id });
+        recordTimeline(pending, deliverTlCtx, "delivery.created", `SMS delivery created via ${provider.id}`, { deliveryId: delivery.id, channel: "sms", provider: provider.id });
 
         const job: DeliveryJob = {
           deliveryId: delivery.id,
@@ -2029,7 +2035,7 @@ export function createNotifyKit<
         const rule = matchFallbackRules(def.fallback, pf.trigger, pf.fromChannel, attempted);
         if (!rule) continue;
         attempted.add(rule.then.type);
-        recordTimeline(deliverTlCtx, "fallback.triggered", `Fallback to "${rule.then.type}" triggered by "${pf.trigger}" on "${pf.fromChannel}"`, {
+        recordTimeline(pending, deliverTlCtx, "fallback.triggered", `Fallback to "${rule.then.type}" triggered by "${pf.trigger}" on "${pf.fromChannel}"`, {
           channel: rule.then.type,
           metadata: { trigger: pf.trigger, fromChannel: pf.fromChannel },
         });
@@ -2057,6 +2063,7 @@ export function createNotifyKit<
   }
 
   async function processDeliveryJob(job: DeliveryJob): Promise<void> {
+    const jobPending: Promise<unknown>[] = [];
     const jobTlCtx = {
       notificationRecordId: job.notificationRecordId,
       recipientId: job.recipientId,
@@ -2068,7 +2075,7 @@ export function createNotifyKit<
     for (let attempt = 1; attempt <= retry.maxAttempts; attempt++) {
       if (attempt > 1) {
         const wait = retry.delayMs(attempt);
-        recordTimeline(jobTlCtx, "delivery.attempt", `Retry attempt ${attempt}/${retry.maxAttempts} (delay: ${wait}ms)`, {
+        recordTimeline(jobPending, jobTlCtx, "delivery.attempt", `Retry attempt ${attempt}/${retry.maxAttempts} (delay: ${wait}ms)`, {
           deliveryId: job.deliveryId,
           channel: job.channel,
           provider: job.provider,
@@ -2116,13 +2123,13 @@ export function createNotifyKit<
           sentAt: new Date(),
           error: undefined,
         });
-        recordTimeline(jobTlCtx, "delivery.sent", `Delivery sent on attempt ${attempt}`, {
+        recordTimeline(jobPending, jobTlCtx, "delivery.sent", `Delivery sent on attempt ${attempt}`, {
           deliveryId: job.deliveryId,
           channel: job.channel,
           provider: job.provider,
         });
         if (result.providerMessageId) {
-          recordTimeline(jobTlCtx, "provider.message_id_stored", `Provider message ID: ${result.providerMessageId}`, {
+          recordTimeline(jobPending, jobTlCtx, "provider.message_id_stored", `Provider message ID: ${result.providerMessageId}`, {
             deliveryId: job.deliveryId,
             channel: job.channel,
             provider: job.provider,
@@ -2142,10 +2149,11 @@ export function createNotifyKit<
         } finally {
           fallbackDeliveryIds.delete(job.deliveryId);
         }
+        await flushTimeline(jobPending);
         return;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
-        recordTimeline(jobTlCtx, "provider.error", `Provider error on attempt ${attempt}: ${lastError.message}`, {
+        recordTimeline(jobPending, jobTlCtx, "provider.error", `Provider error on attempt ${attempt}: ${lastError.message}`, {
           deliveryId: job.deliveryId,
           channel: job.channel,
           provider: job.provider,
@@ -2166,7 +2174,7 @@ export function createNotifyKit<
       status: "failed",
       failedAt: new Date(),
     });
-    recordTimeline(jobTlCtx, "delivery.failed", `Delivery failed after ${retry.maxAttempts} attempt(s): ${lastError?.message ?? "unknown error"}`, {
+    recordTimeline(jobPending, jobTlCtx, "delivery.failed", `Delivery failed after ${retry.maxAttempts} attempt(s): ${lastError?.message ?? "unknown error"}`, {
       deliveryId: job.deliveryId,
       channel: job.channel,
       provider: job.provider,
@@ -2186,12 +2194,13 @@ export function createNotifyKit<
     }
 
     if (isFallbackDelivery) {
+      await flushTimeline(jobPending);
       return;
     }
 
     const def = byId.get(job.notificationId);
     if (def?.fallback) {
-      recordTimeline(jobTlCtx, "fallback.triggered", `Fallback triggered after "${job.channel}" delivery failed`, {
+      recordTimeline(jobPending, jobTlCtx, "fallback.triggered", `Fallback triggered after "${job.channel}" delivery failed`, {
         deliveryId: job.deliveryId,
         channel: job.channel,
         provider: job.provider,
@@ -2256,6 +2265,7 @@ export function createNotifyKit<
         console.error("[notifykit] fallback after channel.failed error:", fallbackErr);
       }
     }
+    await flushTimeline(jobPending);
   }
 
   async function updatePreference(

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -358,6 +358,12 @@ export function createNotifyKit<
 >(config: CreateNotifyKitInput<T>): NotifyKit<T> {
   const { notifications, database, providers, on } = config;
   const onTimelineError = config.onTimelineError ?? ((err: unknown) => console.error("[notifykit] timeline append error:", err));
+  const timelineAdapter = database.timeline ?? {
+    async append() { return []; },
+    async listByNotificationRecordId() { return []; },
+    async listByDeliveryId() { return []; },
+    async prune() { return 0; },
+  };
   const queue = config.queue ?? inlineQueue();
   const retry: RetryPolicy = {
     maxAttempts: config.retry?.maxAttempts ?? defaultRetryPolicy.maxAttempts,
@@ -469,7 +475,7 @@ export function createNotifyKit<
 
   async function flushTimeline(buffer: TimelineBuffer): Promise<void> {
     const batch = buffer.splice(0);
-    if (batch.length > 0) await database.timeline.append(batch).catch(onTimelineError);
+    if (batch.length > 0) await timelineAdapter.append(batch).catch(onTimelineError);
   }
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends
@@ -2673,10 +2679,10 @@ export function createNotifyKit<
     },
     async timeline(notificationRecordId, options) {
       if (options?.deliveryId) {
-        const events = await database.timeline.listByDeliveryId(options.deliveryId);
+        const events = await timelineAdapter.listByDeliveryId(options.deliveryId);
         return events.filter((e) => e.notificationRecordId === notificationRecordId);
       }
-      return database.timeline.listByNotificationRecordId(notificationRecordId);
+      return timelineAdapter.listByNotificationRecordId(notificationRecordId);
     },
   };
 }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -119,6 +119,11 @@ export type CreateNotifyKitInput<
    * after this window, it is treated as a new send. Default: 24 hours.
    */
   idempotencyKeyTtlMs?: number;
+  /**
+   * Called when a timeline append fails. Defaults to `console.error`.
+   * Use this to route persistent timeline failures to your monitoring system.
+   */
+  onTimelineError?: (error: unknown) => void;
 };
 
 export type SendResult = {
@@ -352,6 +357,7 @@ export function createNotifyKit<
   const T extends readonly NotificationDefinition<string, PayloadSchema>[],
 >(config: CreateNotifyKitInput<T>): NotifyKit<T> {
   const { notifications, database, providers, on } = config;
+  const onTimelineError = config.onTimelineError ?? ((err: unknown) => console.error("[notifykit] timeline append error:", err));
   const queue = config.queue ?? inlineQueue();
   const retry: RetryPolicy = {
     maxAttempts: config.retry?.maxAttempts ?? defaultRetryPolicy.maxAttempts,
@@ -455,9 +461,7 @@ export function createNotifyKit<
       event,
       message,
       metadata: opts?.metadata,
-    }]).catch((err) => {
-      console.error("[notifykit] timeline append error:", err);
-    });
+    }]).catch(onTimelineError);
   }
 
   // Per-key serialization for idempotency checks. Prevents concurrent sends

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2662,7 +2662,8 @@ export function createNotifyKit<
     },
     async timeline(notificationRecordId, options) {
       if (options?.deliveryId) {
-        return database.timeline.listByDeliveryId(options.deliveryId);
+        const events = await database.timeline.listByDeliveryId(options.deliveryId);
+        return events.filter((e) => e.notificationRecordId === notificationRecordId);
       }
       return database.timeline.listByNotificationRecordId(notificationRecordId);
     },

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2734,16 +2734,10 @@ export function createNotifyKit<
       return redactPayload(payload, def.redact);
     },
     async timeline(notificationRecordId, options) {
-      let events: TimelineEvent[];
       if (options?.deliveryId) {
-        events = await timelineAdapter.listByDeliveryId(options.deliveryId, notificationRecordId);
-      } else {
-        events = await timelineAdapter.listByNotificationRecordId(notificationRecordId);
+        return timelineAdapter.listByDeliveryId(options.deliveryId, notificationRecordId, options?.limit);
       }
-      if (options?.limit != null && options.limit < events.length) {
-        return events.slice(0, options.limit);
-      }
-      return events;
+      return timelineAdapter.listByNotificationRecordId(notificationRecordId, options?.limit);
     },
     async pruneTimeline(olderThan) {
       if (!olderThan && timelineRetentionMs === 0) return 0;

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1554,7 +1554,8 @@ export function createNotifyKit<
     if (insideQueue) {
       await processDeliveryJob(job, parentBuffer);
     } else {
-      await queue.enqueue(job, (j) => processDeliveryJob(j, parentBuffer));
+      if (parentBuffer) await flushTimeline(parentBuffer);
+      await queue.enqueue(job, (j) => processDeliveryJob(j));
     }
   }
 
@@ -1930,7 +1931,8 @@ export function createNotifyKit<
           payload,
         };
 
-        await queue.enqueue(job, (j) => processDeliveryJob(j, pending));
+        await flushTimeline(pending);
+        await queue.enqueue(job, (j) => processDeliveryJob(j));
 
         // Re-read after enqueue so inline queues return final state; async
         // queues return "pending" here (callers use drain() + deliveries.list).
@@ -1979,7 +1981,8 @@ export function createNotifyKit<
           payload,
         };
 
-        await queue.enqueue(job, (j) => processDeliveryJob(j, pending));
+        await flushTimeline(pending);
+        await queue.enqueue(job, (j) => processDeliveryJob(j));
 
         const latest = await database.deliveries.findById(delivery.id);
         deliveries.push(latest ?? delivery);
@@ -2026,7 +2029,8 @@ export function createNotifyKit<
           payload,
         };
 
-        await queue.enqueue(job, (j) => processDeliveryJob(j, pending));
+        await flushTimeline(pending);
+        await queue.enqueue(job, (j) => processDeliveryJob(j));
 
         const latest = await database.deliveries.findById(delivery.id);
         deliveries.push(latest ?? delivery);

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2118,6 +2118,10 @@ export function createNotifyKit<
     };
   }
 
+  function isPermanentError(err: Error): boolean {
+    return "permanent" in err && (err as Error & { permanent: unknown }).permanent === true;
+  }
+
   async function processDeliveryJob(job: DeliveryJob, parentBuffer?: TimelineBuffer): Promise<void> {
     const ownsBuffer = !parentBuffer;
     const jobPending: TimelineBuffer = parentBuffer ?? [];
@@ -2214,7 +2218,7 @@ export function createNotifyKit<
             deliveryId: job.deliveryId,
             channel: job.channel,
             provider: job.provider,
-            metadata: { attempt, error: lastError.message, permanent: !!(lastError as any).permanent },
+            metadata: { attempt, error: lastError.message, permanent: isPermanentError(lastError) },
           });
           try {
             await database.deliveries.update(job.deliveryId, {
@@ -2224,7 +2228,7 @@ export function createNotifyKit<
           } catch (updateErr) {
             console.error("[notifykit] delivery attempt update error:", updateErr);
           }
-          if ((lastError as any).permanent) break;
+          if (isPermanentError(lastError)) break;
         }
       }
       const failed = await database.deliveries.update(job.deliveryId, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,7 @@ export {
   validateConfig,
   formatValidationIssues,
 } from "./validate.js";
-export { SKIP_REASONS } from "./types.js";
+export { SKIP_REASONS, TIMELINE_EVENT_TYPES } from "./types.js";
 
 export type {
   Authorize,
@@ -158,6 +158,8 @@ export type {
   SkippedDelivery,
   SmsChannelConfig,
   SmsProvider,
+  TimelineEvent,
+  TimelineEventType,
   UpdatePreferenceInput,
   UpsertRecipientInput,
   WebhookChannelConfig,

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -535,9 +535,9 @@ export function memoryAdapter(): MemoryAdapter {
           .filter((e) => e.notificationRecordId === notificationRecordId)
           .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.seq - b.seq);
       },
-      async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
+      async listByDeliveryId(deliveryId: string, notificationRecordId?: string): Promise<TimelineEvent[]> {
         return state.timelineEvents
-          .filter((e) => e.deliveryId === deliveryId)
+          .filter((e) => e.deliveryId === deliveryId && (!notificationRecordId || e.notificationRecordId === notificationRecordId))
           .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.seq - b.seq);
       },
       async prune(olderThan: Date): Promise<number> {

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -538,6 +538,12 @@ export function memoryAdapter(): MemoryAdapter {
           .filter((e) => e.deliveryId === deliveryId)
           .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
       },
+      async prune(olderThan: Date): Promise<number> {
+        const cutoff = olderThan.getTime();
+        const before = state.timelineEvents.length;
+        state.timelineEvents = state.timelineEvents.filter((e) => e.timestamp.getTime() >= cutoff);
+        return before - state.timelineEvents.length;
+      },
     },
     dedupe: {
       async check(input): Promise<{ duplicate: boolean }> {

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -510,8 +510,10 @@ export function memoryAdapter(): MemoryAdapter {
     timeline: {
       async append(events): Promise<TimelineEvent[]> {
         const now = new Date();
-        const records: TimelineEvent[] = events.map((e) => ({
+        const baseSeq = state.timelineEvents.length;
+        const records: TimelineEvent[] = events.map((e, i) => ({
           id: createId("tl"),
+          seq: baseSeq + i,
           notificationRecordId: e.notificationRecordId,
           deliveryId: e.deliveryId,
           recipientId: e.recipientId,
@@ -531,12 +533,12 @@ export function memoryAdapter(): MemoryAdapter {
       async listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]> {
         return state.timelineEvents
           .filter((e) => e.notificationRecordId === notificationRecordId)
-          .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+          .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.seq - b.seq);
       },
       async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
         return state.timelineEvents
           .filter((e) => e.deliveryId === deliveryId)
-          .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+          .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.seq - b.seq);
       },
       async prune(olderThan: Date): Promise<number> {
         const cutoff = olderThan.getTime();

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -532,15 +532,17 @@ export function memoryAdapter(): MemoryAdapter {
         state.timelineEvents.push(...records);
         return records;
       },
-      async listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]> {
-        return state.timelineEvents
+      async listByNotificationRecordId(notificationRecordId: string, limit?: number): Promise<TimelineEvent[]> {
+        const sorted = state.timelineEvents
           .filter((e) => e.notificationRecordId === notificationRecordId)
           .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.seq - b.seq);
+        return limit != null ? sorted.slice(0, limit) : sorted;
       },
-      async listByDeliveryId(deliveryId: string, notificationRecordId?: string): Promise<TimelineEvent[]> {
-        return state.timelineEvents
+      async listByDeliveryId(deliveryId: string, notificationRecordId?: string, limit?: number): Promise<TimelineEvent[]> {
+        const sorted = state.timelineEvents
           .filter((e) => e.deliveryId === deliveryId && (!notificationRecordId || e.notificationRecordId === notificationRecordId))
           .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.seq - b.seq);
+        return limit != null ? sorted.slice(0, limit) : sorted;
       },
       async prune(olderThan: Date): Promise<number> {
         const cutoff = olderThan.getTime();

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -13,6 +13,7 @@ import type {
   RecipientPreference,
   ScheduledSend,
   SecurityScope,
+  TimelineEvent,
   UpsertRecipientInput,
 } from "./types.js";
 import { createId } from "./utils.js";
@@ -28,6 +29,7 @@ export type MemoryAdapter = DatabaseAdapter & {
     rateLimits: RateLimitEvent[];
     scheduledSends: ScheduledSend[];
     dedupeRecords: DedupeRecord[];
+    timelineEvents: TimelineEvent[];
   };
 };
 
@@ -42,6 +44,7 @@ export function memoryAdapter(): MemoryAdapter {
     rateLimits: [] as RateLimitEvent[],
     scheduledSends: [] as ScheduledSend[],
     dedupeRecords: [] as DedupeRecord[],
+    timelineEvents: [] as TimelineEvent[],
   };
 
   function matchesScope(record: SecurityScope, scope?: SecurityScope): boolean {
@@ -502,6 +505,38 @@ export function memoryAdapter(): MemoryAdapter {
       },
       async list(): Promise<ScheduledSend[]> {
         return state.scheduledSends.map((s) => ({ ...s }));
+      },
+    },
+    timeline: {
+      async append(events): Promise<TimelineEvent[]> {
+        const now = new Date();
+        const records: TimelineEvent[] = events.map((e) => ({
+          id: createId("tl"),
+          notificationRecordId: e.notificationRecordId,
+          deliveryId: e.deliveryId,
+          recipientId: e.recipientId,
+          tenantId: e.tenantId,
+          workspaceId: e.workspaceId,
+          notificationId: e.notificationId,
+          channel: e.channel,
+          provider: e.provider,
+          event: e.event,
+          message: e.message,
+          metadata: e.metadata,
+          timestamp: now,
+        }));
+        state.timelineEvents.push(...records);
+        return records;
+      },
+      async listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]> {
+        return state.timelineEvents
+          .filter((e) => e.notificationRecordId === notificationRecordId)
+          .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+      },
+      async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
+        return state.timelineEvents
+          .filter((e) => e.deliveryId === deliveryId)
+          .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
       },
     },
     dedupe: {

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -46,6 +46,7 @@ export function memoryAdapter(): MemoryAdapter {
     dedupeRecords: [] as DedupeRecord[],
     timelineEvents: [] as TimelineEvent[],
   };
+  let timelineSeqCounter = 0;
 
   function matchesScope(record: SecurityScope, scope?: SecurityScope): boolean {
     if (!scope) return true;
@@ -510,7 +511,8 @@ export function memoryAdapter(): MemoryAdapter {
     timeline: {
       async append(events): Promise<TimelineEvent[]> {
         const now = new Date();
-        const baseSeq = state.timelineEvents.length;
+        const baseSeq = timelineSeqCounter;
+        timelineSeqCounter += events.length;
         const records: TimelineEvent[] = events.map((e, i) => ({
           id: createId("tl"),
           seq: baseSeq + i,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -425,7 +425,6 @@ export const TIMELINE_EVENT_TYPES = [
   "idempotent.replay",
   "deduplicated",
   "rate_limited",
-  "digest.buffered",
   "quiet_hours.deferred",
   "inbox.created",
   "delivery.created",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -795,7 +795,7 @@ export type DatabaseAdapter = {
     prune(): Promise<void>;
   };
   timeline: {
-    /** Append one or more events to the timeline. */
+    /** Append one or more events. All events in a batch share a single timestamp. */
     append(events: Omit<TimelineEvent, "id" | "timestamp">[]): Promise<TimelineEvent[]>;
     /** List events for a notification record, ordered chronologically. */
     listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -418,6 +418,45 @@ export type DigestBufferEntry = {
   updatedAt: Date;
 };
 
+export const TIMELINE_EVENT_TYPES = [
+  "payload.validated",
+  "recipient.resolved",
+  "preferences.resolved",
+  "idempotent.replay",
+  "deduplicated",
+  "rate_limited",
+  "digest.buffered",
+  "quiet_hours.deferred",
+  "inbox.created",
+  "delivery.created",
+  "delivery.attempt",
+  "delivery.sent",
+  "delivery.failed",
+  "provider.message_id_stored",
+  "provider.error",
+  "fallback.triggered",
+  "channel.skipped",
+  "notification.suppressed",
+] as const;
+
+export type TimelineEventType = (typeof TIMELINE_EVENT_TYPES)[number];
+
+export type TimelineEvent = {
+  id: string;
+  notificationRecordId: string;
+  deliveryId?: string;
+  recipientId: string;
+  tenantId?: string;
+  workspaceId?: string;
+  notificationId: string;
+  channel?: ChannelType;
+  provider?: string;
+  event: TimelineEventType;
+  message: string;
+  metadata?: Record<string, unknown>;
+  timestamp: Date;
+};
+
 export const SKIP_REASONS = [
   "preferences_disabled",
   "required_override",
@@ -754,6 +793,14 @@ export type DatabaseAdapter = {
     exists(key: string): Promise<boolean>;
     /** Remove expired entries. Called opportunistically. */
     prune(): Promise<void>;
+  };
+  timeline: {
+    /** Append one or more events to the timeline. */
+    append(events: Omit<TimelineEvent, "id" | "timestamp">[]): Promise<TimelineEvent[]>;
+    /** List events for a notification record, ordered chronologically. */
+    listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]>;
+    /** List events for a specific delivery, ordered chronologically. */
+    listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]>;
   };
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -799,9 +799,9 @@ export type DatabaseAdapter = {
     /** Append one or more events. All events in a batch share a single timestamp. */
     append(events: Omit<TimelineEvent, "id" | "seq" | "timestamp">[]): Promise<TimelineEvent[]>;
     /** List events for a notification record, ordered chronologically. */
-    listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]>;
+    listByNotificationRecordId(notificationRecordId: string, limit?: number): Promise<TimelineEvent[]>;
     /** List events for a specific delivery, ordered chronologically. */
-    listByDeliveryId(deliveryId: string, notificationRecordId?: string): Promise<TimelineEvent[]>;
+    listByDeliveryId(deliveryId: string, notificationRecordId?: string, limit?: number): Promise<TimelineEvent[]>;
     /** Delete events older than the given date. Returns the number of deleted rows. */
     prune(olderThan: Date): Promise<number>;
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -802,7 +802,7 @@ export type DatabaseAdapter = {
     /** List events for a notification record, ordered chronologically. */
     listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]>;
     /** List events for a specific delivery, ordered chronologically. */
-    listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]>;
+    listByDeliveryId(deliveryId: string, notificationRecordId?: string): Promise<TimelineEvent[]>;
     /** Delete events older than the given date. Returns the number of deleted rows. */
     prune(olderThan: Date): Promise<number>;
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -443,6 +443,8 @@ export type TimelineEventType = (typeof TIMELINE_EVENT_TYPES)[number];
 
 export type TimelineEvent = {
   id: string;
+  /** Monotonic insertion order within a batch. Breaks ties when multiple events share a timestamp. */
+  seq: number;
   notificationRecordId: string;
   deliveryId?: string;
   recipientId: string;
@@ -796,7 +798,7 @@ export type DatabaseAdapter = {
   };
   timeline?: {
     /** Append one or more events. All events in a batch share a single timestamp. */
-    append(events: Omit<TimelineEvent, "id" | "timestamp">[]): Promise<TimelineEvent[]>;
+    append(events: Omit<TimelineEvent, "id" | "seq" | "timestamp">[]): Promise<TimelineEvent[]>;
     /** List events for a notification record, ordered chronologically. */
     listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]>;
     /** List events for a specific delivery, ordered chronologically. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -794,7 +794,7 @@ export type DatabaseAdapter = {
     /** Remove expired entries. Called opportunistically. */
     prune(): Promise<void>;
   };
-  timeline: {
+  timeline?: {
     /** Append one or more events. All events in a batch share a single timestamp. */
     append(events: Omit<TimelineEvent, "id" | "timestamp">[]): Promise<TimelineEvent[]>;
     /** List events for a notification record, ordered chronologically. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -801,6 +801,8 @@ export type DatabaseAdapter = {
     listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]>;
     /** List events for a specific delivery, ordered chronologically. */
     listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]>;
+    /** Delete events older than the given date. Returns the number of deleted rows. */
+    prune(olderThan: Date): Promise<number>;
   };
 };
 

--- a/packages/core/tests/timeline.test.ts
+++ b/packages/core/tests/timeline.test.ts
@@ -471,6 +471,43 @@ describe("timeline", () => {
     expect((errors[0] as Error).message).toBe("DB write failed");
   });
 
+  test("onTimelineError failures do not fail sends", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const originalConsoleError = console.error;
+    console.error = mock(() => {});
+    db.timeline.append = async () => {
+      throw new Error("DB write failed");
+    };
+    const def = notification({
+      id: "test",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+      onTimelineError: () => {
+        throw new Error("monitoring failed");
+      },
+    });
+    try {
+      await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+      const result = await notify.send({
+        recipientId: "u1",
+        notificationId: "test",
+        payload: { msg: "hi" },
+      });
+
+      expect(result.notification).toBeDefined();
+      expect(result.deliveries[0]?.status).toBe("sent");
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
   test("timeline events are still flushed on sendInner error", async () => {
     const db = memoryAdapter();
     const emailProvider = fakeEmailProvider();

--- a/packages/core/tests/timeline.test.ts
+++ b/packages/core/tests/timeline.test.ts
@@ -292,6 +292,77 @@ describe("timeline", () => {
     }
   });
 
+  test("records idempotent replay", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [
+        inbox({ title: "{{msg}}" }),
+        email({ subject: "{{msg}}", body: "{{msg}}" }),
+      ],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const first = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "idem-1",
+    });
+
+    const second = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "idem-1",
+    });
+
+    expect(second.idempotent).toBe(true);
+    const timeline = await notify.timeline(first.notification!.id);
+    const replayEvent = timeline.find((e) => e.event === "idempotent.replay");
+    expect(replayEvent).toBeDefined();
+  });
+
+  test("records fallback triggered after primary delivery failure", async () => {
+    const db = memoryAdapter();
+    const failingProvider = {
+      id: "failing-email",
+      async send() {
+        throw new Error("send failed");
+      },
+    };
+    const def = notification({
+      id: "password_reset",
+      payload: { link: "string" },
+      channels: [email({ subject: "Reset", body: "{{link}}" })],
+      fallback: inbox({ title: "Fallback: {{link}}" }),
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: failingProvider },
+      retry: { maxAttempts: 1, delayMs: () => 0 },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "password_reset",
+      payload: { link: "/reset/abc" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const fallbackEvent = timeline.find((e) => e.event === "fallback.triggered");
+    expect(fallbackEvent).toBeDefined();
+  });
+
   test("records quiet hours deferral", async () => {
     const db = memoryAdapter();
     const emailProvider = fakeEmailProvider();

--- a/packages/core/tests/timeline.test.ts
+++ b/packages/core/tests/timeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, mock } from "bun:test";
 import {
   channel,
   createNotifyKit,
@@ -402,5 +402,102 @@ describe("timeline", () => {
     const deferEvent = timeline.find((e) => e.event === "quiet_hours.deferred");
     expect(deferEvent).toBeDefined();
     expect(deferEvent!.channel).toBe("email");
+  });
+
+  test("prune removes events older than cutoff", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "test",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "test",
+      payload: { msg: "hi" },
+    });
+
+    const before = await notify.timeline(result.notification!.id);
+    expect(before.length).toBeGreaterThan(0);
+
+    const futureDate = new Date(Date.now() + 60_000);
+    const pruned = await db.timeline.prune(futureDate);
+    expect(pruned).toBe(before.length);
+
+    const after = await notify.timeline(result.notification!.id);
+    expect(after.length).toBe(0);
+  });
+
+  test("onTimelineError is called when append fails", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const errors: unknown[] = [];
+    const originalAppend = db.timeline.append.bind(db.timeline);
+    let shouldFail = false;
+    db.timeline.append = async (events) => {
+      if (shouldFail) throw new Error("DB write failed");
+      return originalAppend(events);
+    };
+    const def = notification({
+      id: "test",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+      onTimelineError: (err) => errors.push(err),
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    shouldFail = true;
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "test",
+      payload: { msg: "hi" },
+    });
+
+    expect(result.notification).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+    expect((errors[0] as Error).message).toBe("DB write failed");
+  });
+
+  test("timeline events are still flushed on sendInner error", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "test",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+    // Don't upsert recipient — this will cause an error after timeline context is set up
+    try {
+      await notify.send({
+        recipientId: "nonexistent",
+        notificationId: "test",
+        payload: { msg: "hi" },
+      });
+    } catch {
+      // expected
+    }
+
+    // Even though send threw, if any events were buffered they should have been flushed
+    // In this case the error happens before timeline events are recorded (recipient lookup),
+    // so we just verify the flush doesn't cause a secondary crash
+    expect(db._state.timelineEvents.length).toBe(0);
   });
 });

--- a/packages/core/tests/timeline.test.ts
+++ b/packages/core/tests/timeline.test.ts
@@ -525,4 +525,38 @@ describe("timeline", () => {
     expect(prefsIdx).toBeLessThan(deliveryCreatedIdx);
     expect(deliveryCreatedIdx).toBeLessThan(deliverySentIdx);
   });
+
+  test("limit option truncates results", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Alice", body: "Hello" },
+    });
+
+    const all = await notify.timeline(result.notification!.id);
+    expect(all.length).toBeGreaterThan(3);
+
+    const limited = await notify.timeline(result.notification!.id, { limit: 3 });
+    expect(limited.length).toBe(3);
+    expect(limited[0]!.event).toBe(all[0]!.event);
+    expect(limited[2]!.event).toBe(all[2]!.event);
+  });
+
+  test("limit larger than total returns all events", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Alice", body: "Hello" },
+    });
+
+    const all = await notify.timeline(result.notification!.id);
+    const limited = await notify.timeline(result.notification!.id, { limit: 999 });
+    expect(limited.length).toBe(all.length);
+  });
 });

--- a/packages/core/tests/timeline.test.ts
+++ b/packages/core/tests/timeline.test.ts
@@ -500,4 +500,29 @@ describe("timeline", () => {
     // so we just verify the flush doesn't cause a secondary crash
     expect(db._state.timelineEvents.length).toBe(0);
   });
+
+  test("events are in correct chronological order with inline queue", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Alice", body: "Hello" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const events = timeline.map((e) => e.event);
+
+    const payloadIdx = events.indexOf("payload.validated");
+    const recipientIdx = events.indexOf("recipient.resolved");
+    const prefsIdx = events.indexOf("preferences.resolved");
+    const deliveryCreatedIdx = events.indexOf("delivery.created");
+    const deliverySentIdx = events.indexOf("delivery.sent");
+
+    expect(payloadIdx).toBeLessThan(recipientIdx);
+    expect(recipientIdx).toBeLessThan(prefsIdx);
+    expect(prefsIdx).toBeLessThan(deliveryCreatedIdx);
+    expect(deliveryCreatedIdx).toBeLessThan(deliverySentIdx);
+  });
 });

--- a/packages/core/tests/timeline.test.ts
+++ b/packages/core/tests/timeline.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, test } from "bun:test";
+import {
+  channel,
+  createNotifyKit,
+  fakeEmailProvider,
+  fakeSmsProvider,
+  memoryAdapter,
+  notification,
+} from "../src/index.js";
+
+const inbox = channel.inbox();
+const email = channel.email();
+const sms = channel.sms();
+
+function setup() {
+  const db = memoryAdapter();
+  const emailProvider = fakeEmailProvider();
+  const smsProvider = fakeSmsProvider();
+  const def = notification({
+    id: "comment_mentioned",
+    payload: { author: "string", body: "string" },
+    channels: [
+      inbox({ title: "{{author}} mentioned you", body: "{{body}}" }),
+      email({ subject: "{{author}} mentioned you", body: "{{body}}" }),
+    ],
+    redact: ["body"],
+  });
+  const notify = createNotifyKit({
+    notifications: [def] as const,
+    database: db,
+    providers: { email: emailProvider, sms: smsProvider },
+  });
+  return { db, emailProvider, smsProvider, notify };
+}
+
+describe("timeline", () => {
+  test("records lifecycle events for a successful send", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Alice", body: "Hello" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    expect(timeline.length).toBeGreaterThanOrEqual(4);
+
+    const events = timeline.map((e) => e.event);
+    expect(events).toContain("payload.validated");
+    expect(events).toContain("recipient.resolved");
+    expect(events).toContain("preferences.resolved");
+    expect(events).toContain("inbox.created");
+    expect(events).toContain("delivery.created");
+    expect(events).toContain("delivery.sent");
+  });
+
+  test("records provider message ID", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "test",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "test",
+      payload: { msg: "hi" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const msgIdEvent = timeline.find((e) => e.event === "provider.message_id_stored");
+    expect(msgIdEvent).toBeDefined();
+    expect(msgIdEvent!.metadata?.providerMessageId).toBeDefined();
+  });
+
+  test("records deduplication", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Alice", body: "hi" },
+      dedupeKey: "mention-1",
+      dedupeWindowMs: 60_000,
+    });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Alice", body: "hi" },
+      dedupeKey: "mention-1",
+      dedupeWindowMs: 60_000,
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const dedupeEvent = timeline.find((e) => e.event === "deduplicated");
+    expect(dedupeEvent).toBeDefined();
+    expect(dedupeEvent!.metadata?.dedupeKey).toBe("mention-1");
+  });
+
+  test("records rate limiting", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+      rateLimit: { max: 1, windowMs: 60_000 },
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "first" },
+    });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "second" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const rateLimitEvent = timeline.find((e) => e.event === "rate_limited");
+    expect(rateLimitEvent).toBeDefined();
+    expect(rateLimitEvent!.metadata?.max).toBe(1);
+  });
+
+  test("records channel skipped reasons", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [
+        inbox({ title: "{{msg}}" }),
+        email({ subject: "{{msg}}", body: "{{msg}}" }),
+      ],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+    // No email on recipient
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hello" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const skipEvent = timeline.find(
+      (e) => e.event === "channel.skipped" && e.channel === "email",
+    );
+    expect(skipEvent).toBeDefined();
+    expect(skipEvent!.metadata?.reason).toBe("missing_address");
+  });
+
+  test("records retry attempts and provider errors on failure", async () => {
+    const db = memoryAdapter();
+    let callCount = 0;
+    const failingProvider = {
+      id: "failing-email",
+      async send() {
+        callCount++;
+        throw new Error("SMTP timeout");
+      },
+    };
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: failingProvider },
+      retry: { maxAttempts: 3, delayMs: () => 0 },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const providerErrors = timeline.filter((e) => e.event === "provider.error");
+    expect(providerErrors.length).toBe(3);
+    expect(providerErrors[0]!.metadata?.error).toBe("SMTP timeout");
+
+    const retryAttempts = timeline.filter((e) => e.event === "delivery.attempt");
+    expect(retryAttempts.length).toBe(2); // attempts 2 and 3
+
+    const failedEvent = timeline.find((e) => e.event === "delivery.failed");
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent!.metadata?.attempts).toBe(3);
+  });
+
+  test("records suppression when all channels disabled", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "promo",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+    await notify.preferences.update({
+      recipientId: "u1",
+      notificationId: "promo",
+      channels: { email: false },
+    });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "promo",
+      payload: { msg: "sale!" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const suppressEvent = timeline.find((e) => e.event === "notification.suppressed");
+    expect(suppressEvent).toBeDefined();
+  });
+
+  test("filters timeline by deliveryId", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Bob", body: "test" },
+    });
+
+    const emailDelivery = result.deliveries.find((d) => d.channel === "email");
+    expect(emailDelivery).toBeDefined();
+
+    const deliveryTimeline = await notify.timeline(result.notification!.id, {
+      deliveryId: emailDelivery!.id,
+    });
+
+    expect(deliveryTimeline.length).toBeGreaterThan(0);
+    for (const event of deliveryTimeline) {
+      expect(event.deliveryId).toBe(emailDelivery!.id);
+    }
+  });
+
+  test("timeline events have correct metadata fields", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Alice", body: "hello" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    for (const event of timeline) {
+      expect(event.notificationRecordId).toBe(result.notification!.id);
+      expect(event.recipientId).toBe("u1");
+      expect(event.notificationId).toBe("comment_mentioned");
+      expect(event.id).toBeTruthy();
+      expect(event.timestamp).toBeInstanceOf(Date);
+    }
+  });
+
+  test("records quiet hours deferral", async () => {
+    const db = memoryAdapter();
+    const emailProvider = fakeEmailProvider();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [
+        inbox({ title: "{{msg}}" }),
+        email({ subject: "{{msg}}", body: "{{msg}}" }),
+      ],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: emailProvider },
+    });
+
+    const now = new Date();
+    const startHour = now.getHours();
+    const endHour = (startHour + 2) % 24;
+    const start = `${String(startHour).padStart(2, "0")}:00`;
+    const end = `${String(endHour).padStart(2, "0")}:00`;
+
+    await notify.upsertRecipient({
+      id: "u1",
+      email: "u1@test.com",
+      quietHours: { start, end, timezone: "UTC" },
+    });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+    });
+
+    const timeline = await notify.timeline(result.notification!.id);
+    const deferEvent = timeline.find((e) => e.event === "quiet_hours.deferred");
+    expect(deferEvent).toBeDefined();
+    expect(deferEvent!.channel).toBe("email");
+  });
+});

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -149,6 +149,7 @@ export async function createPgTables(
       ON notifykit_dedupe_records (expires_at)`,
     `CREATE TABLE IF NOT EXISTS notifykit_timeline_events (
       id TEXT PRIMARY KEY,
+      seq INTEGER NOT NULL,
       notification_record_id TEXT NOT NULL,
       delivery_id TEXT,
       recipient_id TEXT NOT NULL,
@@ -163,9 +164,9 @@ export async function createPgTables(
       timestamp TIMESTAMPTZ NOT NULL
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_notification_record
-      ON notifykit_timeline_events (notification_record_id, timestamp)`,
+      ON notifykit_timeline_events (notification_record_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
-      ON notifykit_timeline_events (delivery_id, timestamp)`,
+      ON notifykit_timeline_events (delivery_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
       ON notifykit_timeline_events (timestamp)`,
   ];

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -168,6 +168,8 @@ export async function createPgTables(
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
       ON notifykit_timeline_events (delivery_id, timestamp, seq)
       WHERE delivery_id IS NOT NULL`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
+      ON notifykit_timeline_events (timestamp)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -166,6 +166,8 @@ export async function createPgTables(
       ON notifykit_timeline_events (notification_record_id, timestamp)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
       ON notifykit_timeline_events (delivery_id, timestamp)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
+      ON notifykit_timeline_events (timestamp)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -147,6 +147,25 @@ export async function createPgTables(
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_dedupe_expires_at
       ON notifykit_dedupe_records (expires_at)`,
+    `CREATE TABLE IF NOT EXISTS notifykit_timeline_events (
+      id TEXT PRIMARY KEY,
+      notification_record_id TEXT NOT NULL,
+      delivery_id TEXT,
+      recipient_id TEXT NOT NULL,
+      tenant_id TEXT,
+      workspace_id TEXT,
+      notification_id TEXT NOT NULL,
+      channel TEXT,
+      provider TEXT,
+      event TEXT NOT NULL,
+      message TEXT NOT NULL,
+      metadata JSONB,
+      timestamp TIMESTAMPTZ NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_notification_record
+      ON notifykit_timeline_events (notification_record_id, timestamp)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
+      ON notifykit_timeline_events (delivery_id, timestamp)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -166,7 +166,8 @@ export async function createPgTables(
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_notification_record
       ON notifykit_timeline_events (notification_record_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
-      ON notifykit_timeline_events (delivery_id, timestamp, seq)`,
+      ON notifykit_timeline_events (delivery_id, timestamp, seq)
+      WHERE delivery_id IS NOT NULL`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-pg-tables.ts
+++ b/packages/drizzle-adapter/src/create-pg-tables.ts
@@ -167,8 +167,6 @@ export async function createPgTables(
       ON notifykit_timeline_events (notification_record_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
       ON notifykit_timeline_events (delivery_id, timestamp, seq)`,
-    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
-      ON notifykit_timeline_events (timestamp)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -149,6 +149,7 @@ export async function createSqliteTables(
       ON notifykit_dedupe_records (expires_at)`,
     `CREATE TABLE IF NOT EXISTS notifykit_timeline_events (
       id TEXT PRIMARY KEY,
+      seq INTEGER NOT NULL,
       notification_record_id TEXT NOT NULL,
       delivery_id TEXT,
       recipient_id TEXT NOT NULL,
@@ -163,9 +164,9 @@ export async function createSqliteTables(
       timestamp INTEGER NOT NULL
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_notification_record
-      ON notifykit_timeline_events (notification_record_id, timestamp)`,
+      ON notifykit_timeline_events (notification_record_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
-      ON notifykit_timeline_events (delivery_id, timestamp)`,
+      ON notifykit_timeline_events (delivery_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
       ON notifykit_timeline_events (timestamp)`,
   ];

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -167,6 +167,8 @@ export async function createSqliteTables(
       ON notifykit_timeline_events (notification_record_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
       ON notifykit_timeline_events (delivery_id, timestamp, seq)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
+      ON notifykit_timeline_events (timestamp)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -147,6 +147,25 @@ export async function createSqliteTables(
     )`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_dedupe_expires_at
       ON notifykit_dedupe_records (expires_at)`,
+    `CREATE TABLE IF NOT EXISTS notifykit_timeline_events (
+      id TEXT PRIMARY KEY,
+      notification_record_id TEXT NOT NULL,
+      delivery_id TEXT,
+      recipient_id TEXT NOT NULL,
+      tenant_id TEXT,
+      workspace_id TEXT,
+      notification_id TEXT NOT NULL,
+      channel TEXT,
+      provider TEXT,
+      event TEXT NOT NULL,
+      message TEXT NOT NULL,
+      metadata TEXT,
+      timestamp INTEGER NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_notification_record
+      ON notifykit_timeline_events (notification_record_id, timestamp)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
+      ON notifykit_timeline_events (delivery_id, timestamp)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -167,8 +167,6 @@ export async function createSqliteTables(
       ON notifykit_timeline_events (notification_record_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
       ON notifykit_timeline_events (delivery_id, timestamp, seq)`,
-    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
-      ON notifykit_timeline_events (timestamp)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -166,6 +166,8 @@ export async function createSqliteTables(
       ON notifykit_timeline_events (notification_record_id, timestamp)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
       ON notifykit_timeline_events (delivery_id, timestamp)`,
+    `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
+      ON notifykit_timeline_events (timestamp)`,
   ];
 
   for (const stmt of statements) {

--- a/packages/drizzle-adapter/src/create-tables.ts
+++ b/packages/drizzle-adapter/src/create-tables.ts
@@ -166,7 +166,8 @@ export async function createSqliteTables(
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_notification_record
       ON notifykit_timeline_events (notification_record_id, timestamp, seq)`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_delivery
-      ON notifykit_timeline_events (delivery_id, timestamp, seq)`,
+      ON notifykit_timeline_events (delivery_id, timestamp, seq)
+      WHERE delivery_id IS NOT NULL`,
     `CREATE INDEX IF NOT EXISTS idx_notifykit_timeline_timestamp
       ON notifykit_timeline_events (timestamp)`,
   ];

--- a/packages/drizzle-adapter/src/index.ts
+++ b/packages/drizzle-adapter/src/index.ts
@@ -13,6 +13,7 @@ export {
   rateLimitEvents,
   recipients,
   scheduledSends,
+  timelineEvents,
   type NotifyKitSqliteSchema,
 } from "./schema/sqlite.js";
 
@@ -31,5 +32,6 @@ export {
   rateLimitEvents as pgRateLimitEvents,
   recipients as pgRecipients,
   scheduledSends as pgScheduledSends,
+  timelineEvents as pgTimelineEvents,
   type NotifyKitPgSchema,
 } from "./schema/postgres.js";

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -33,6 +33,7 @@ import {
   scheduledSends,
   timelineEvents,
 } from "./schema/postgres.js";
+import { rowToTimelineEvent } from "./timeline-utils.js";
 
 function scopeValue(value: string | undefined): string {
   return value ?? "";
@@ -1091,24 +1092,6 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
   };
 }
 
-function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
-  return {
-    id: row.id,
-    seq: row.seq,
-    notificationRecordId: row.notificationRecordId,
-    deliveryId: row.deliveryId ?? undefined,
-    recipientId: row.recipientId,
-    tenantId: row.tenantId ?? undefined,
-    workspaceId: row.workspaceId ?? undefined,
-    notificationId: row.notificationId,
-    channel: (row.channel ?? undefined) as TimelineEvent["channel"],
-    provider: row.provider ?? undefined,
-    event: row.event as TimelineEvent["event"],
-    message: row.message,
-    metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
-    timestamp: row.timestamp,
-  };
-}
 
 function rowToInboxItem(row: typeof inboxItems.$inferSelect): InboxItem {
   return {

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -14,6 +14,7 @@ import type {
   ScheduledSend,
   SecurityScope,
   SkipReason,
+  TimelineEvent,
   UpsertRecipientInput,
 } from "notifykit";
 import { SKIP_REASONS, createId } from "notifykit";
@@ -30,6 +31,7 @@ import {
   rateLimitEvents,
   recipients,
   scheduledSends,
+  timelineEvents,
 } from "./schema/postgres.js";
 
 function scopeValue(value: string | undefined): string {
@@ -74,6 +76,7 @@ export type DrizzlePostgresAdapter = DatabaseAdapter & {
     rateLimitEvents: typeof rateLimitEvents;
     scheduledSends: typeof scheduledSends;
     dedupeRecords: typeof dedupeRecords;
+    timelineEvents: typeof timelineEvents;
   };
 };
 
@@ -89,6 +92,7 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
       rateLimitEvents,
       scheduledSends,
       dedupeRecords,
+      timelineEvents,
     },
 
     recipients: {
@@ -1005,6 +1009,80 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
         await db.delete(dedupeRecords).where(lt(dedupeRecords.expiresAt, now));
       },
     },
+    timeline: {
+      async append(events): Promise<TimelineEvent[]> {
+        const now = new Date();
+        const records: TimelineEvent[] = events.map((e) => ({
+          id: createId("tl"),
+          notificationRecordId: e.notificationRecordId,
+          deliveryId: e.deliveryId,
+          recipientId: e.recipientId,
+          tenantId: e.tenantId,
+          workspaceId: e.workspaceId,
+          notificationId: e.notificationId,
+          channel: e.channel as TimelineEvent["channel"],
+          provider: e.provider,
+          event: e.event,
+          message: e.message,
+          metadata: e.metadata,
+          timestamp: now,
+        }));
+        if (records.length > 0) {
+          await db.insert(timelineEvents).values(
+            records.map((r) => ({
+              id: r.id,
+              notificationRecordId: r.notificationRecordId,
+              deliveryId: r.deliveryId ?? null,
+              recipientId: r.recipientId,
+              tenantId: r.tenantId ?? null,
+              workspaceId: r.workspaceId ?? null,
+              notificationId: r.notificationId,
+              channel: r.channel ?? null,
+              provider: r.provider ?? null,
+              event: r.event,
+              message: r.message,
+              metadata: r.metadata ?? null,
+              timestamp: r.timestamp,
+            })),
+          );
+        }
+        return records;
+      },
+      async listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]> {
+        const rows = await db
+          .select()
+          .from(timelineEvents)
+          .where(eq(timelineEvents.notificationRecordId, notificationRecordId))
+          .orderBy(asc(timelineEvents.timestamp));
+        return rows.map(rowToTimelineEvent);
+      },
+      async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
+        const rows = await db
+          .select()
+          .from(timelineEvents)
+          .where(eq(timelineEvents.deliveryId, deliveryId))
+          .orderBy(asc(timelineEvents.timestamp));
+        return rows.map(rowToTimelineEvent);
+      },
+    },
+  };
+}
+
+function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
+  return {
+    id: row.id,
+    notificationRecordId: row.notificationRecordId,
+    deliveryId: row.deliveryId ?? undefined,
+    recipientId: row.recipientId,
+    tenantId: row.tenantId ?? undefined,
+    workspaceId: row.workspaceId ?? undefined,
+    notificationId: row.notificationId,
+    channel: (row.channel ?? undefined) as TimelineEvent["channel"],
+    provider: row.provider ?? undefined,
+    event: row.event as TimelineEvent["event"],
+    message: row.message,
+    metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
+    timestamp: row.timestamp,
   };
 }
 

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1065,11 +1065,13 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
         return rows.map(rowToTimelineEvent);
       },
-      async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
+      async listByDeliveryId(deliveryId: string, notificationRecordId?: string): Promise<TimelineEvent[]> {
+        const conditions = [eq(timelineEvents.deliveryId, deliveryId)];
+        if (notificationRecordId) conditions.push(eq(timelineEvents.notificationRecordId, notificationRecordId));
         const rows = await db
           .select()
           .from(timelineEvents)
-          .where(eq(timelineEvents.deliveryId, deliveryId))
+          .where(and(...conditions))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
         return rows.map(rowToTimelineEvent);
       },

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1064,6 +1064,12 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .orderBy(asc(timelineEvents.timestamp));
         return rows.map(rowToTimelineEvent);
       },
+      async prune(olderThan: Date): Promise<number> {
+        const result = await db
+          .delete(timelineEvents)
+          .where(lt(timelineEvents.timestamp, olderThan));
+        return (result as any)?.rowCount ?? 0;
+      },
     },
   };
 }

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -64,6 +64,15 @@ function preferenceScopeConditions(scope?: SecurityScope) {
   ];
 }
 
+function fnv1aHashToInt(str: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
 type PgDb = PgDatabase<PgQueryResultHKT, any, any>;
 
 export type DrizzlePostgresAdapter = DatabaseAdapter & {
@@ -1030,13 +1039,14 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           timestamp: now,
         }));
         if (records.length > 0) {
-          // Lock key derived from fnv1a("notifykit_timeline_seq") to avoid collisions.
-          const TIMELINE_SEQ_LOCK = 3_217_891_453;
+          const nrId = records[0]!.notificationRecordId;
+          const lockKey = fnv1aHashToInt(nrId);
           await db.transaction(async (tx) => {
-            await tx.execute(sql`SELECT pg_advisory_xact_lock(${TIMELINE_SEQ_LOCK})`);
+            await tx.execute(sql`SELECT pg_advisory_xact_lock(${lockKey})`);
             const maxRow = await tx
               .select({ maxSeq: timelineEvents.seq })
               .from(timelineEvents)
+              .where(eq(timelineEvents.notificationRecordId, nrId))
               .orderBy(desc(timelineEvents.seq))
               .limit(1);
             const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1096,11 +1096,14 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
-        const deleted = await db
-          .delete(timelineEvents)
-          .where(lt(timelineEvents.timestamp, olderThan))
-          .returning({ id: timelineEvents.id });
-        return deleted.length;
+        const rows = await db
+          .select({ n: drizzleCount() })
+          .from(timelineEvents)
+          .where(lt(timelineEvents.timestamp, olderThan));
+        const n = rows[0]?.n ?? 0;
+        if (n === 0) return 0;
+        await db.delete(timelineEvents).where(lt(timelineEvents.timestamp, olderThan));
+        return n;
       },
     },
   };

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -64,6 +64,8 @@ function preferenceScopeConditions(scope?: SecurityScope) {
   ];
 }
 
+// 32-bit hash for pg_advisory_xact_lock; collisions serialize unrelated
+// appends but don't affect correctness — acceptable below ~65K concurrent IDs.
 function fnv1aHashToInt(str: string): number {
   let hash = 2166136261;
   for (let i = 0; i < str.length; i++) {

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1074,10 +1074,14 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
-        const result = await db
-          .delete(timelineEvents)
+        const rows = await db
+          .select({ n: drizzleCount() })
+          .from(timelineEvents)
           .where(lt(timelineEvents.timestamp, olderThan));
-        return (result as any)?.rowCount ?? 0;
+        const n = rows[0]?.n ?? 0;
+        if (n === 0) return 0;
+        await db.delete(timelineEvents).where(lt(timelineEvents.timestamp, olderThan));
+        return n;
       },
     },
   };

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1073,22 +1073,26 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
         }
         return records;
       },
-      async listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]> {
-        const rows = await db
+      async listByNotificationRecordId(notificationRecordId: string, limit?: number): Promise<TimelineEvent[]> {
+        let query = db
           .select()
           .from(timelineEvents)
           .where(eq(timelineEvents.notificationRecordId, notificationRecordId))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
+        if (limit != null) query = query.limit(limit) as typeof query;
+        const rows = await query;
         return rows.map(rowToTimelineEvent);
       },
-      async listByDeliveryId(deliveryId: string, notificationRecordId?: string): Promise<TimelineEvent[]> {
+      async listByDeliveryId(deliveryId: string, notificationRecordId?: string, limit?: number): Promise<TimelineEvent[]> {
         const conditions = [eq(timelineEvents.deliveryId, deliveryId)];
         if (notificationRecordId) conditions.push(eq(timelineEvents.notificationRecordId, notificationRecordId));
-        const rows = await db
+        let query = db
           .select()
           .from(timelineEvents)
           .where(and(...conditions))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
+        if (limit != null) query = query.limit(limit) as typeof query;
+        const rows = await query;
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1031,6 +1031,7 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
         }));
         if (records.length > 0) {
           await db.transaction(async (tx) => {
+            await tx.execute(sql`SELECT pg_advisory_xact_lock(4832719)`);
             const maxRow = await tx
               .select({ maxSeq: timelineEvents.seq })
               .from(timelineEvents)
@@ -1079,19 +1080,14 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
-        const rows = await db
-          .select({ n: drizzleCount() })
-          .from(timelineEvents)
-          .where(lt(timelineEvents.timestamp, olderThan));
-        const n = rows[0]?.n ?? 0;
-        if (n === 0) return 0;
-        await db.delete(timelineEvents).where(lt(timelineEvents.timestamp, olderThan));
-        return n;
+        const result: { rowCount?: number } = await db.execute(
+          sql`DELETE FROM notifykit_timeline_events WHERE timestamp < ${olderThan}`,
+        ) as any;
+        return Number(result.rowCount ?? 0);
       },
     },
   };
 }
-
 
 function rowToInboxItem(row: typeof inboxItems.$inferSelect): InboxItem {
   return {

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1082,10 +1082,11 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
-        const result: { rowCount?: number } = await db.execute(
-          sql`DELETE FROM notifykit_timeline_events WHERE timestamp < ${olderThan}`,
-        ) as any;
-        return Number(result.rowCount ?? 0);
+        const deleted = await db
+          .delete(timelineEvents)
+          .where(lt(timelineEvents.timestamp, olderThan))
+          .returning({ id: timelineEvents.id });
+        return deleted.length;
       },
     },
   };

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1029,31 +1029,33 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           timestamp: now,
         }));
         if (records.length > 0) {
-          const maxRow = await db
-            .select({ maxSeq: timelineEvents.seq })
-            .from(timelineEvents)
-            .orderBy(desc(timelineEvents.seq))
-            .limit(1);
-          const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
-          for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
-          await db.insert(timelineEvents).values(
-            records.map((r) => ({
-              id: r.id,
-              seq: r.seq,
-              notificationRecordId: r.notificationRecordId,
-              deliveryId: r.deliveryId ?? null,
-              recipientId: r.recipientId,
-              tenantId: r.tenantId ?? null,
-              workspaceId: r.workspaceId ?? null,
-              notificationId: r.notificationId,
-              channel: r.channel ?? null,
-              provider: r.provider ?? null,
-              event: r.event,
-              message: r.message,
-              metadata: r.metadata ?? null,
-              timestamp: r.timestamp,
-            })),
-          );
+          await db.transaction(async (tx) => {
+            const maxRow = await tx
+              .select({ maxSeq: timelineEvents.seq })
+              .from(timelineEvents)
+              .orderBy(desc(timelineEvents.seq))
+              .limit(1);
+            const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
+            for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
+            await tx.insert(timelineEvents).values(
+              records.map((r) => ({
+                id: r.id,
+                seq: r.seq,
+                notificationRecordId: r.notificationRecordId,
+                deliveryId: r.deliveryId ?? null,
+                recipientId: r.recipientId,
+                tenantId: r.tenantId ?? null,
+                workspaceId: r.workspaceId ?? null,
+                notificationId: r.notificationId,
+                channel: r.channel ?? null,
+                provider: r.provider ?? null,
+                event: r.event,
+                message: r.message,
+                metadata: r.metadata ?? null,
+                timestamp: r.timestamp,
+              })),
+            );
+          });
         }
         return records;
       },

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1012,8 +1012,9 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
     timeline: {
       async append(events): Promise<TimelineEvent[]> {
         const now = new Date();
-        const records: TimelineEvent[] = events.map((e) => ({
+        const records: TimelineEvent[] = events.map((e, i) => ({
           id: createId("tl"),
+          seq: i,
           notificationRecordId: e.notificationRecordId,
           deliveryId: e.deliveryId,
           recipientId: e.recipientId,
@@ -1028,9 +1029,17 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           timestamp: now,
         }));
         if (records.length > 0) {
+          const maxRow = await db
+            .select({ maxSeq: timelineEvents.seq })
+            .from(timelineEvents)
+            .orderBy(desc(timelineEvents.seq))
+            .limit(1);
+          const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
+          for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
           await db.insert(timelineEvents).values(
             records.map((r) => ({
               id: r.id,
+              seq: r.seq,
               notificationRecordId: r.notificationRecordId,
               deliveryId: r.deliveryId ?? null,
               recipientId: r.recipientId,
@@ -1053,7 +1062,7 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .select()
           .from(timelineEvents)
           .where(eq(timelineEvents.notificationRecordId, notificationRecordId))
-          .orderBy(asc(timelineEvents.timestamp));
+          .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
         return rows.map(rowToTimelineEvent);
       },
       async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
@@ -1061,7 +1070,7 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .select()
           .from(timelineEvents)
           .where(eq(timelineEvents.deliveryId, deliveryId))
-          .orderBy(asc(timelineEvents.timestamp));
+          .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
@@ -1077,6 +1086,7 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
 function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
   return {
     id: row.id,
+    seq: row.seq,
     notificationRecordId: row.notificationRecordId,
     deliveryId: row.deliveryId ?? undefined,
     recipientId: row.recipientId,

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -1030,8 +1030,10 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           timestamp: now,
         }));
         if (records.length > 0) {
+          // Lock key derived from fnv1a("notifykit_timeline_seq") to avoid collisions.
+          const TIMELINE_SEQ_LOCK = 3_217_891_453;
           await db.transaction(async (tx) => {
-            await tx.execute(sql`SELECT pg_advisory_xact_lock(4832719)`);
+            await tx.execute(sql`SELECT pg_advisory_xact_lock(${TIMELINE_SEQ_LOCK})`);
             const maxRow = await tx
               .select({ maxSeq: timelineEvents.seq })
               .from(timelineEvents)

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -17,7 +17,7 @@ import type {
   TimelineEvent,
   UpsertRecipientInput,
 } from "notifykit";
-import { SKIP_REASONS, createId } from "notifykit";
+import { SKIP_REASONS, TIMELINE_EVENT_TYPES, createId } from "notifykit";
 import { and, asc, count as drizzleCount, desc, eq, gte, isNull, isNotNull, lt, lte, sql } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
@@ -1069,6 +1069,9 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
 }
 
 function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
+  const event = (TIMELINE_EVENT_TYPES as readonly string[]).includes(row.event)
+    ? (row.event as TimelineEvent["event"])
+    : ("provider.error" as TimelineEvent["event"]);
   return {
     id: row.id,
     notificationRecordId: row.notificationRecordId,
@@ -1079,7 +1082,7 @@ function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEv
     notificationId: row.notificationId,
     channel: (row.channel ?? undefined) as TimelineEvent["channel"],
     provider: row.provider ?? undefined,
-    event: row.event as TimelineEvent["event"],
+    event,
     message: row.message,
     metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
     timestamp: row.timestamp,

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -17,7 +17,7 @@ import type {
   TimelineEvent,
   UpsertRecipientInput,
 } from "notifykit";
-import { SKIP_REASONS, TIMELINE_EVENT_TYPES, createId } from "notifykit";
+import { SKIP_REASONS, createId } from "notifykit";
 import { and, asc, count as drizzleCount, desc, eq, gte, isNull, isNotNull, lt, lte, sql } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 
@@ -1075,9 +1075,6 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
 }
 
 function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
-  const event = (TIMELINE_EVENT_TYPES as readonly string[]).includes(row.event)
-    ? (row.event as TimelineEvent["event"])
-    : ("provider.error" as TimelineEvent["event"]);
   return {
     id: row.id,
     notificationRecordId: row.notificationRecordId,
@@ -1088,7 +1085,7 @@ function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEv
     notificationId: row.notificationId,
     channel: (row.channel ?? undefined) as TimelineEvent["channel"],
     provider: row.provider ?? undefined,
-    event,
+    event: row.event as TimelineEvent["event"],
     message: row.message,
     metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
     timestamp: row.timestamp,

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -271,6 +271,7 @@ export const timelineEvents = pgTable(
     deliveryIdx: index("idx_notifykit_timeline_delivery")
       .on(table.deliveryId, table.timestamp, table.seq)
       .where(sql`delivery_id IS NOT NULL`),
+    timestampIdx: index("idx_notifykit_timeline_timestamp").on(table.timestamp),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -244,6 +244,35 @@ export const dedupeRecords = pgTable(
   }),
 );
 
+export const timelineEvents = pgTable(
+  "notifykit_timeline_events",
+  {
+    id: text("id").primaryKey(),
+    notificationRecordId: text("notification_record_id").notNull(),
+    deliveryId: text("delivery_id"),
+    recipientId: text("recipient_id").notNull(),
+    tenantId: text("tenant_id"),
+    workspaceId: text("workspace_id"),
+    notificationId: text("notification_id").notNull(),
+    channel: text("channel"),
+    provider: text("provider"),
+    event: text("event").notNull(),
+    message: text("message").notNull(),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    timestamp: timestamp("timestamp", { withTimezone: true, mode: "date" }).notNull(),
+  },
+  (table) => ({
+    notificationRecordIdx: index("idx_notifykit_timeline_notification_record").on(
+      table.notificationRecordId,
+      table.timestamp,
+    ),
+    deliveryIdx: index("idx_notifykit_timeline_delivery").on(
+      table.deliveryId,
+      table.timestamp,
+    ),
+  }),
+);
+
 export const notifyKitPgSchema = {
   recipients,
   notifications,
@@ -254,6 +283,7 @@ export const notifyKitPgSchema = {
   rateLimitEvents,
   scheduledSends,
   dedupeRecords,
+  timelineEvents,
 };
 
 export type NotifyKitPgSchema = typeof notifyKitPgSchema;

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -270,6 +270,9 @@ export const timelineEvents = pgTable(
       table.deliveryId,
       table.timestamp,
     ),
+    timestampIdx: index("idx_notifykit_timeline_timestamp").on(
+      table.timestamp,
+    ),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -273,9 +273,6 @@ export const timelineEvents = pgTable(
       table.timestamp,
       table.seq,
     ),
-    timestampIdx: index("idx_notifykit_timeline_timestamp").on(
-      table.timestamp,
-    ),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -268,11 +268,9 @@ export const timelineEvents = pgTable(
       table.timestamp,
       table.seq,
     ),
-    deliveryIdx: index("idx_notifykit_timeline_delivery").on(
-      table.deliveryId,
-      table.timestamp,
-      table.seq,
-    ),
+    deliveryIdx: index("idx_notifykit_timeline_delivery")
+      .on(table.deliveryId, table.timestamp, table.seq)
+      .where(sql`delivery_id IS NOT NULL`),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/postgres.ts
+++ b/packages/drizzle-adapter/src/schema/postgres.ts
@@ -248,6 +248,7 @@ export const timelineEvents = pgTable(
   "notifykit_timeline_events",
   {
     id: text("id").primaryKey(),
+    seq: integer("seq").notNull(),
     notificationRecordId: text("notification_record_id").notNull(),
     deliveryId: text("delivery_id"),
     recipientId: text("recipient_id").notNull(),
@@ -265,10 +266,12 @@ export const timelineEvents = pgTable(
     notificationRecordIdx: index("idx_notifykit_timeline_notification_record").on(
       table.notificationRecordId,
       table.timestamp,
+      table.seq,
     ),
     deliveryIdx: index("idx_notifykit_timeline_delivery").on(
       table.deliveryId,
       table.timestamp,
+      table.seq,
     ),
     timestampIdx: index("idx_notifykit_timeline_timestamp").on(
       table.timestamp,

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -273,6 +273,9 @@ export const timelineEvents = sqliteTable(
       table.deliveryId,
       table.timestamp,
     ),
+    timestampIdx: index("idx_notifykit_timeline_timestamp").on(
+      table.timestamp,
+    ),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -271,11 +271,9 @@ export const timelineEvents = sqliteTable(
       table.timestamp,
       table.seq,
     ),
-    deliveryIdx: index("idx_notifykit_timeline_delivery").on(
-      table.deliveryId,
-      table.timestamp,
-      table.seq,
-    ),
+    deliveryIdx: index("idx_notifykit_timeline_delivery")
+      .on(table.deliveryId, table.timestamp, table.seq)
+      .where(sql`delivery_id IS NOT NULL`),
     timestampIdx: index("idx_notifykit_timeline_timestamp").on(table.timestamp),
   }),
 );

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -251,6 +251,7 @@ export const timelineEvents = sqliteTable(
   "notifykit_timeline_events",
   {
     id: text("id").primaryKey(),
+    seq: integer("seq").notNull(),
     notificationRecordId: text("notification_record_id").notNull(),
     deliveryId: text("delivery_id"),
     recipientId: text("recipient_id").notNull(),
@@ -268,10 +269,12 @@ export const timelineEvents = sqliteTable(
     notificationRecordIdx: index("idx_notifykit_timeline_notification_record").on(
       table.notificationRecordId,
       table.timestamp,
+      table.seq,
     ),
     deliveryIdx: index("idx_notifykit_timeline_delivery").on(
       table.deliveryId,
       table.timestamp,
+      table.seq,
     ),
     timestampIdx: index("idx_notifykit_timeline_timestamp").on(
       table.timestamp,

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -276,9 +276,6 @@ export const timelineEvents = sqliteTable(
       table.timestamp,
       table.seq,
     ),
-    timestampIdx: index("idx_notifykit_timeline_timestamp").on(
-      table.timestamp,
-    ),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -276,6 +276,7 @@ export const timelineEvents = sqliteTable(
       table.timestamp,
       table.seq,
     ),
+    timestampIdx: index("idx_notifykit_timeline_timestamp").on(table.timestamp),
   }),
 );
 

--- a/packages/drizzle-adapter/src/schema/sqlite.ts
+++ b/packages/drizzle-adapter/src/schema/sqlite.ts
@@ -247,6 +247,35 @@ export const dedupeRecords = sqliteTable(
   }),
 );
 
+export const timelineEvents = sqliteTable(
+  "notifykit_timeline_events",
+  {
+    id: text("id").primaryKey(),
+    notificationRecordId: text("notification_record_id").notNull(),
+    deliveryId: text("delivery_id"),
+    recipientId: text("recipient_id").notNull(),
+    tenantId: text("tenant_id"),
+    workspaceId: text("workspace_id"),
+    notificationId: text("notification_id").notNull(),
+    channel: text("channel"),
+    provider: text("provider"),
+    event: text("event").notNull(),
+    message: text("message").notNull(),
+    metadata: text("metadata", { mode: "json" }).$type<Record<string, unknown>>(),
+    timestamp: integer("timestamp", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    notificationRecordIdx: index("idx_notifykit_timeline_notification_record").on(
+      table.notificationRecordId,
+      table.timestamp,
+    ),
+    deliveryIdx: index("idx_notifykit_timeline_delivery").on(
+      table.deliveryId,
+      table.timestamp,
+    ),
+  }),
+);
+
 export const notifyKitSchema = {
   recipients,
   notifications,
@@ -257,6 +286,7 @@ export const notifyKitSchema = {
   rateLimitEvents,
   scheduledSends,
   dedupeRecords,
+  timelineEvents,
 };
 
 export type NotifyKitSqliteSchema = typeof notifyKitSchema;

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1142,10 +1142,14 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
-        const result = await db
-          .delete(timelineEvents)
+        const rows = await db
+          .select({ n: drizzleCount() })
+          .from(timelineEvents)
           .where(lt(timelineEvents.timestamp, olderThan));
-        return (result as any)?.changes ?? (result as any)?.rowsAffected ?? 0;
+        const n = rows[0]?.n ?? 0;
+        if (n === 0) return 0;
+        await db.delete(timelineEvents).where(lt(timelineEvents.timestamp, olderThan));
+        return n;
       },
     },
   };

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1147,14 +1147,16 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
-        const rows = await db
-          .select({ n: drizzleCount() })
-          .from(timelineEvents)
-          .where(lt(timelineEvents.timestamp, olderThan));
-        const n = rows[0]?.n ?? 0;
-        if (n === 0) return 0;
-        await db.delete(timelineEvents).where(lt(timelineEvents.timestamp, olderThan));
-        return n;
+        return await db.transaction(async (tx) => {
+          const rows = await tx
+            .select({ n: drizzleCount() })
+            .from(timelineEvents)
+            .where(lt(timelineEvents.timestamp, olderThan));
+          const n = rows[0]?.n ?? 0;
+          if (n === 0) return 0;
+          await tx.delete(timelineEvents).where(lt(timelineEvents.timestamp, olderThan));
+          return n;
+        });
       },
     },
   };

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1097,31 +1097,33 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           timestamp: now,
         }));
         if (records.length > 0) {
-          const maxRow = await db
-            .select({ maxSeq: timelineEvents.seq })
-            .from(timelineEvents)
-            .orderBy(desc(timelineEvents.seq))
-            .limit(1);
-          const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
-          for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
-          await db.insert(timelineEvents).values(
-            records.map((r) => ({
-              id: r.id,
-              seq: r.seq,
-              notificationRecordId: r.notificationRecordId,
-              deliveryId: r.deliveryId ?? null,
-              recipientId: r.recipientId,
-              tenantId: r.tenantId ?? null,
-              workspaceId: r.workspaceId ?? null,
-              notificationId: r.notificationId,
-              channel: r.channel ?? null,
-              provider: r.provider ?? null,
-              event: r.event,
-              message: r.message,
-              metadata: r.metadata ?? null,
-              timestamp: r.timestamp,
-            })),
-          );
+          await db.transaction(async (tx) => {
+            const maxRow = await tx
+              .select({ maxSeq: timelineEvents.seq })
+              .from(timelineEvents)
+              .orderBy(desc(timelineEvents.seq))
+              .limit(1);
+            const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
+            for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
+            await tx.insert(timelineEvents).values(
+              records.map((r) => ({
+                id: r.id,
+                seq: r.seq,
+                notificationRecordId: r.notificationRecordId,
+                deliveryId: r.deliveryId ?? null,
+                recipientId: r.recipientId,
+                tenantId: r.tenantId ?? null,
+                workspaceId: r.workspaceId ?? null,
+                notificationId: r.notificationId,
+                channel: r.channel ?? null,
+                provider: r.provider ?? null,
+                event: r.event,
+                message: r.message,
+                metadata: r.metadata ?? null,
+                timestamp: r.timestamp,
+              })),
+            );
+          });
         }
         return records;
       },

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -14,6 +14,7 @@ import type {
   ScheduledSend,
   SecurityScope,
   SkipReason,
+  TimelineEvent,
   UpsertRecipientInput,
 } from "notifykit";
 import { SKIP_REASONS, createId } from "notifykit";
@@ -30,6 +31,7 @@ import {
   rateLimitEvents,
   recipients,
   scheduledSends,
+  timelineEvents,
 } from "./schema/sqlite.js";
 
 function scopeValue(value: string | undefined): string {
@@ -104,6 +106,7 @@ export type DrizzleSqliteAdapter = DatabaseAdapter & {
     rateLimitEvents: typeof rateLimitEvents;
     scheduledSends: typeof scheduledSends;
     dedupeRecords: typeof dedupeRecords;
+    timelineEvents: typeof timelineEvents;
   };
 };
 
@@ -125,6 +128,7 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
       rateLimitEvents,
       scheduledSends,
       dedupeRecords,
+      timelineEvents,
     },
 
     recipients: {
@@ -1073,6 +1077,80 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
         await db.delete(dedupeRecords).where(lt(dedupeRecords.expiresAt, now));
       },
     },
+    timeline: {
+      async append(events): Promise<TimelineEvent[]> {
+        const now = new Date();
+        const records: TimelineEvent[] = events.map((e) => ({
+          id: createId("tl"),
+          notificationRecordId: e.notificationRecordId,
+          deliveryId: e.deliveryId,
+          recipientId: e.recipientId,
+          tenantId: e.tenantId,
+          workspaceId: e.workspaceId,
+          notificationId: e.notificationId,
+          channel: e.channel as TimelineEvent["channel"],
+          provider: e.provider,
+          event: e.event,
+          message: e.message,
+          metadata: e.metadata,
+          timestamp: now,
+        }));
+        if (records.length > 0) {
+          await db.insert(timelineEvents).values(
+            records.map((r) => ({
+              id: r.id,
+              notificationRecordId: r.notificationRecordId,
+              deliveryId: r.deliveryId ?? null,
+              recipientId: r.recipientId,
+              tenantId: r.tenantId ?? null,
+              workspaceId: r.workspaceId ?? null,
+              notificationId: r.notificationId,
+              channel: r.channel ?? null,
+              provider: r.provider ?? null,
+              event: r.event,
+              message: r.message,
+              metadata: r.metadata ?? null,
+              timestamp: r.timestamp,
+            })),
+          );
+        }
+        return records;
+      },
+      async listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]> {
+        const rows = await db
+          .select()
+          .from(timelineEvents)
+          .where(eq(timelineEvents.notificationRecordId, notificationRecordId))
+          .orderBy(asc(timelineEvents.timestamp));
+        return rows.map(rowToTimelineEvent);
+      },
+      async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
+        const rows = await db
+          .select()
+          .from(timelineEvents)
+          .where(eq(timelineEvents.deliveryId, deliveryId))
+          .orderBy(asc(timelineEvents.timestamp));
+        return rows.map(rowToTimelineEvent);
+      },
+    },
+  };
+}
+
+function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
+  return {
+    id: row.id,
+    notificationRecordId: row.notificationRecordId,
+    deliveryId: row.deliveryId ?? undefined,
+    recipientId: row.recipientId,
+    tenantId: row.tenantId ?? undefined,
+    workspaceId: row.workspaceId ?? undefined,
+    notificationId: row.notificationId,
+    channel: (row.channel ?? undefined) as TimelineEvent["channel"],
+    provider: row.provider ?? undefined,
+    event: row.event as TimelineEvent["event"],
+    message: row.message,
+    metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
+    timestamp: row.timestamp,
   };
 }
 

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1133,11 +1133,13 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
         return rows.map(rowToTimelineEvent);
       },
-      async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
+      async listByDeliveryId(deliveryId: string, notificationRecordId?: string): Promise<TimelineEvent[]> {
+        const conditions = [eq(timelineEvents.deliveryId, deliveryId)];
+        if (notificationRecordId) conditions.push(eq(timelineEvents.notificationRecordId, notificationRecordId));
         const rows = await db
           .select()
           .from(timelineEvents)
-          .where(eq(timelineEvents.deliveryId, deliveryId))
+          .where(and(...conditions))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
         return rows.map(rowToTimelineEvent);
       },

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1080,8 +1080,9 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
     timeline: {
       async append(events): Promise<TimelineEvent[]> {
         const now = new Date();
-        const records: TimelineEvent[] = events.map((e) => ({
+        const records: TimelineEvent[] = events.map((e, i) => ({
           id: createId("tl"),
+          seq: i,
           notificationRecordId: e.notificationRecordId,
           deliveryId: e.deliveryId,
           recipientId: e.recipientId,
@@ -1096,9 +1097,17 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           timestamp: now,
         }));
         if (records.length > 0) {
+          const maxRow = await db
+            .select({ maxSeq: timelineEvents.seq })
+            .from(timelineEvents)
+            .orderBy(desc(timelineEvents.seq))
+            .limit(1);
+          const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
+          for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
           await db.insert(timelineEvents).values(
             records.map((r) => ({
               id: r.id,
+              seq: r.seq,
               notificationRecordId: r.notificationRecordId,
               deliveryId: r.deliveryId ?? null,
               recipientId: r.recipientId,
@@ -1121,7 +1130,7 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .select()
           .from(timelineEvents)
           .where(eq(timelineEvents.notificationRecordId, notificationRecordId))
-          .orderBy(asc(timelineEvents.timestamp));
+          .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
         return rows.map(rowToTimelineEvent);
       },
       async listByDeliveryId(deliveryId: string): Promise<TimelineEvent[]> {
@@ -1129,7 +1138,7 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .select()
           .from(timelineEvents)
           .where(eq(timelineEvents.deliveryId, deliveryId))
-          .orderBy(asc(timelineEvents.timestamp));
+          .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
@@ -1145,6 +1154,7 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
 function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
   return {
     id: row.id,
+    seq: row.seq,
     notificationRecordId: row.notificationRecordId,
     deliveryId: row.deliveryId ?? undefined,
     recipientId: row.recipientId,

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -18,7 +18,7 @@ import type {
   UpsertRecipientInput,
 } from "notifykit";
 import { SKIP_REASONS, createId } from "notifykit";
-import { and, asc, count as drizzleCount, desc, eq, gte, isNull, isNotNull, lt, lte } from "drizzle-orm";
+import { and, asc, count as drizzleCount, desc, eq, gte, isNull, isNotNull, lt, lte, sql } from "drizzle-orm";
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
 import {
@@ -1159,7 +1159,6 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
     },
   };
 }
-
 
 function rowToInboxItem(row: typeof inboxItems.$inferSelect): InboxItem {
   return {

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1099,10 +1099,12 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
             timestamp: now,
           }));
           if (records.length > 0) {
+            const nrId = records[0]!.notificationRecordId;
             await db.transaction(async (tx) => {
               const maxRow = await tx
                 .select({ maxSeq: timelineEvents.seq })
                 .from(timelineEvents)
+                .where(eq(timelineEvents.notificationRecordId, nrId))
                 .orderBy(desc(timelineEvents.seq))
                 .limit(1);
               const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1132,6 +1132,12 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .orderBy(asc(timelineEvents.timestamp));
         return rows.map(rowToTimelineEvent);
       },
+      async prune(olderThan: Date): Promise<number> {
+        const result = await db
+          .delete(timelineEvents)
+          .where(lt(timelineEvents.timestamp, olderThan));
+        return (result as any)?.changes ?? (result as any)?.rowsAffected ?? 0;
+      },
     },
   };
 }

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -33,6 +33,7 @@ import {
   scheduledSends,
   timelineEvents,
 } from "./schema/sqlite.js";
+import { rowToTimelineEvent } from "./timeline-utils.js";
 
 function scopeValue(value: string | undefined): string {
   return value ?? "";
@@ -1159,24 +1160,6 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
   };
 }
 
-function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
-  return {
-    id: row.id,
-    seq: row.seq,
-    notificationRecordId: row.notificationRecordId,
-    deliveryId: row.deliveryId ?? undefined,
-    recipientId: row.recipientId,
-    tenantId: row.tenantId ?? undefined,
-    workspaceId: row.workspaceId ?? undefined,
-    notificationId: row.notificationId,
-    channel: (row.channel ?? undefined) as TimelineEvent["channel"],
-    provider: row.provider ?? undefined,
-    event: row.event as TimelineEvent["event"],
-    message: row.message,
-    metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
-    timestamp: row.timestamp,
-  };
-}
 
 function rowToInboxItem(row: typeof inboxItems.$inferSelect): InboxItem {
   return {

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -17,7 +17,7 @@ import type {
   TimelineEvent,
   UpsertRecipientInput,
 } from "notifykit";
-import { SKIP_REASONS, TIMELINE_EVENT_TYPES, createId } from "notifykit";
+import { SKIP_REASONS, createId } from "notifykit";
 import { and, asc, count as drizzleCount, desc, eq, gte, isNull, isNotNull, lt, lte } from "drizzle-orm";
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
@@ -1143,9 +1143,6 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
 }
 
 function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
-  const event = (TIMELINE_EVENT_TYPES as readonly string[]).includes(row.event)
-    ? (row.event as TimelineEvent["event"])
-    : ("provider.error" as TimelineEvent["event"]);
   return {
     id: row.id,
     notificationRecordId: row.notificationRecordId,
@@ -1156,7 +1153,7 @@ function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEv
     notificationId: row.notificationId,
     channel: (row.channel ?? undefined) as TimelineEvent["channel"],
     provider: row.provider ?? undefined,
-    event,
+    event: row.event as TimelineEvent["event"],
     message: row.message,
     metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
     timestamp: row.timestamp,

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -17,7 +17,7 @@ import type {
   TimelineEvent,
   UpsertRecipientInput,
 } from "notifykit";
-import { SKIP_REASONS, createId } from "notifykit";
+import { SKIP_REASONS, TIMELINE_EVENT_TYPES, createId } from "notifykit";
 import { and, asc, count as drizzleCount, desc, eq, gte, isNull, isNotNull, lt, lte } from "drizzle-orm";
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
@@ -1137,6 +1137,9 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
 }
 
 function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEvent {
+  const event = (TIMELINE_EVENT_TYPES as readonly string[]).includes(row.event)
+    ? (row.event as TimelineEvent["event"])
+    : ("provider.error" as TimelineEvent["event"]);
   return {
     id: row.id,
     notificationRecordId: row.notificationRecordId,
@@ -1147,7 +1150,7 @@ function rowToTimelineEvent(row: typeof timelineEvents.$inferSelect): TimelineEv
     notificationId: row.notificationId,
     channel: (row.channel ?? undefined) as TimelineEvent["channel"],
     provider: row.provider ?? undefined,
-    event: row.event as TimelineEvent["event"],
+    event,
     message: row.message,
     metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
     timestamp: row.timestamp,

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1100,34 +1100,32 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           }));
           if (records.length > 0) {
             const nrId = records[0]!.notificationRecordId;
-            await db.transaction(async (tx) => {
-              const maxRow = await tx
-                .select({ maxSeq: timelineEvents.seq })
-                .from(timelineEvents)
-                .where(eq(timelineEvents.notificationRecordId, nrId))
-                .orderBy(desc(timelineEvents.seq))
-                .limit(1);
-              const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
-              for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
-              await tx.insert(timelineEvents).values(
-                records.map((r) => ({
-                  id: r.id,
-                  seq: r.seq,
-                  notificationRecordId: r.notificationRecordId,
-                  deliveryId: r.deliveryId ?? null,
-                  recipientId: r.recipientId,
-                  tenantId: r.tenantId ?? null,
-                  workspaceId: r.workspaceId ?? null,
-                  notificationId: r.notificationId,
-                  channel: r.channel ?? null,
-                  provider: r.provider ?? null,
-                  event: r.event,
-                  message: r.message,
-                  metadata: r.metadata ?? null,
-                  timestamp: r.timestamp,
-                })),
-              );
-            });
+            const maxRow = await db
+              .select({ maxSeq: timelineEvents.seq })
+              .from(timelineEvents)
+              .where(eq(timelineEvents.notificationRecordId, nrId))
+              .orderBy(desc(timelineEvents.seq))
+              .limit(1);
+            const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
+            for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
+            await db.insert(timelineEvents).values(
+              records.map((r) => ({
+                id: r.id,
+                seq: r.seq,
+                notificationRecordId: r.notificationRecordId,
+                deliveryId: r.deliveryId ?? null,
+                recipientId: r.recipientId,
+                tenantId: r.tenantId ?? null,
+                workspaceId: r.workspaceId ?? null,
+                notificationId: r.notificationId,
+                channel: r.channel ?? null,
+                provider: r.provider ?? null,
+                event: r.event,
+                message: r.message,
+                metadata: r.metadata ?? null,
+                timestamp: r.timestamp,
+              })),
+            );
           }
           return records;
         });

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1132,22 +1132,26 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           return records;
         });
       },
-      async listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]> {
-        const rows = await db
+      async listByNotificationRecordId(notificationRecordId: string, limit?: number): Promise<TimelineEvent[]> {
+        let query = db
           .select()
           .from(timelineEvents)
           .where(eq(timelineEvents.notificationRecordId, notificationRecordId))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
+        if (limit != null) query = query.limit(limit) as typeof query;
+        const rows = await query;
         return rows.map(rowToTimelineEvent);
       },
-      async listByDeliveryId(deliveryId: string, notificationRecordId?: string): Promise<TimelineEvent[]> {
+      async listByDeliveryId(deliveryId: string, notificationRecordId?: string, limit?: number): Promise<TimelineEvent[]> {
         const conditions = [eq(timelineEvents.deliveryId, deliveryId)];
         if (notificationRecordId) conditions.push(eq(timelineEvents.notificationRecordId, notificationRecordId));
-        const rows = await db
+        let query = db
           .select()
           .from(timelineEvents)
           .where(and(...conditions))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
+        if (limit != null) query = query.limit(limit) as typeof query;
+        const rows = await query;
         return rows.map(rowToTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -1080,53 +1080,55 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
     },
     timeline: {
       async append(events): Promise<TimelineEvent[]> {
-        const now = new Date();
-        const records: TimelineEvent[] = events.map((e, i) => ({
-          id: createId("tl"),
-          seq: i,
-          notificationRecordId: e.notificationRecordId,
-          deliveryId: e.deliveryId,
-          recipientId: e.recipientId,
-          tenantId: e.tenantId,
-          workspaceId: e.workspaceId,
-          notificationId: e.notificationId,
-          channel: e.channel as TimelineEvent["channel"],
-          provider: e.provider,
-          event: e.event,
-          message: e.message,
-          metadata: e.metadata,
-          timestamp: now,
-        }));
-        if (records.length > 0) {
-          await db.transaction(async (tx) => {
-            const maxRow = await tx
-              .select({ maxSeq: timelineEvents.seq })
-              .from(timelineEvents)
-              .orderBy(desc(timelineEvents.seq))
-              .limit(1);
-            const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
-            for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
-            await tx.insert(timelineEvents).values(
-              records.map((r) => ({
-                id: r.id,
-                seq: r.seq,
-                notificationRecordId: r.notificationRecordId,
-                deliveryId: r.deliveryId ?? null,
-                recipientId: r.recipientId,
-                tenantId: r.tenantId ?? null,
-                workspaceId: r.workspaceId ?? null,
-                notificationId: r.notificationId,
-                channel: r.channel ?? null,
-                provider: r.provider ?? null,
-                event: r.event,
-                message: r.message,
-                metadata: r.metadata ?? null,
-                timestamp: r.timestamp,
-              })),
-            );
-          });
-        }
-        return records;
+        return atomic(async () => {
+          const now = new Date();
+          const records: TimelineEvent[] = events.map((e, i) => ({
+            id: createId("tl"),
+            seq: i,
+            notificationRecordId: e.notificationRecordId,
+            deliveryId: e.deliveryId,
+            recipientId: e.recipientId,
+            tenantId: e.tenantId,
+            workspaceId: e.workspaceId,
+            notificationId: e.notificationId,
+            channel: e.channel as TimelineEvent["channel"],
+            provider: e.provider,
+            event: e.event,
+            message: e.message,
+            metadata: e.metadata,
+            timestamp: now,
+          }));
+          if (records.length > 0) {
+            await db.transaction(async (tx) => {
+              const maxRow = await tx
+                .select({ maxSeq: timelineEvents.seq })
+                .from(timelineEvents)
+                .orderBy(desc(timelineEvents.seq))
+                .limit(1);
+              const baseSeq = maxRow.length > 0 ? maxRow[0]!.maxSeq + 1 : 0;
+              for (let i = 0; i < records.length; i++) records[i]!.seq = baseSeq + i;
+              await tx.insert(timelineEvents).values(
+                records.map((r) => ({
+                  id: r.id,
+                  seq: r.seq,
+                  notificationRecordId: r.notificationRecordId,
+                  deliveryId: r.deliveryId ?? null,
+                  recipientId: r.recipientId,
+                  tenantId: r.tenantId ?? null,
+                  workspaceId: r.workspaceId ?? null,
+                  notificationId: r.notificationId,
+                  channel: r.channel ?? null,
+                  provider: r.provider ?? null,
+                  event: r.event,
+                  message: r.message,
+                  metadata: r.metadata ?? null,
+                  timestamp: r.timestamp,
+                })),
+              );
+            });
+          }
+          return records;
+        });
       },
       async listByNotificationRecordId(notificationRecordId: string): Promise<TimelineEvent[]> {
         const rows = await db

--- a/packages/drizzle-adapter/src/timeline-utils.ts
+++ b/packages/drizzle-adapter/src/timeline-utils.ts
@@ -27,6 +27,7 @@ export function rowToTimelineEvent(row: {
     notificationId: row.notificationId,
     channel: (row.channel ?? undefined) as TimelineEvent["channel"],
     provider: row.provider ?? undefined,
+    // Cast, not validate: allows forward-compatibility when newer writers add event types.
     event: row.event as TimelineEvent["event"],
     message: row.message,
     metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,

--- a/packages/drizzle-adapter/src/timeline-utils.ts
+++ b/packages/drizzle-adapter/src/timeline-utils.ts
@@ -1,0 +1,35 @@
+import type { TimelineEvent } from "notifykit";
+
+export function rowToTimelineEvent(row: {
+  id: string;
+  seq: number;
+  notificationRecordId: string;
+  deliveryId: string | null;
+  recipientId: string;
+  tenantId: string | null;
+  workspaceId: string | null;
+  notificationId: string;
+  channel: string | null;
+  provider: string | null;
+  event: string;
+  message: string;
+  metadata: Record<string, unknown> | null;
+  timestamp: Date;
+}): TimelineEvent {
+  return {
+    id: row.id,
+    seq: row.seq,
+    notificationRecordId: row.notificationRecordId,
+    deliveryId: row.deliveryId ?? undefined,
+    recipientId: row.recipientId,
+    tenantId: row.tenantId ?? undefined,
+    workspaceId: row.workspaceId ?? undefined,
+    notificationId: row.notificationId,
+    channel: (row.channel ?? undefined) as TimelineEvent["channel"],
+    provider: row.provider ?? undefined,
+    event: row.event as TimelineEvent["event"],
+    message: row.message,
+    metadata: (row.metadata ?? undefined) as Record<string, unknown> | undefined,
+    timestamp: row.timestamp,
+  };
+}


### PR DESCRIPTION
## Summary

Implements #10 (M1: Production Inbox + Explainable Delivery).

- Adds a durable `timeline` event stream per notification record, recording every decision and side effect in chronological order
- Records lifecycle events: payload validation, recipient resolution, preference resolution, inbox creation, delivery creation, provider calls (with message IDs), retry attempts, errors, skips, rate limiting, deduplication, quiet hours deferral, and fallback triggers
- Exposes `notify.timeline(notificationRecordId)` with optional `{ deliveryId }` filtering
- Adds `notifykit_timeline_events` table to both SQLite and PostgreSQL schemas (Drizzle + raw DDL)
- Timeline recording is fire-and-forget (non-blocking) to avoid impacting send latency
- Exports `TimelineEvent`, `TimelineEventType`, and `TIMELINE_EVENT_TYPES` from the core package

### Example timeline output
```
payload.validated        → Payload validated successfully
recipient.resolved       → Recipient "u1" resolved
preferences.resolved     → Preference resolution complete: inbox, email enabled
inbox.created            → Inbox item created: "Alice mentioned you"
delivery.created         → Email delivery created via resend
delivery.sent            → Delivery sent on attempt 1
provider.message_id_stored → Provider message ID: msg_abc123
```

## Test plan

- [x] Timeline records full lifecycle for normal send (inbox + email)
- [x] Provider message IDs appear in timeline
- [x] Deduplication is recorded
- [x] Rate limiting is recorded
- [x] Channel skip reasons are recorded
- [x] Retry attempts and provider errors are recorded
- [x] Suppression (all channels disabled) is recorded
- [x] Quiet hours deferral is recorded
- [x] Delivery-level filtering works
- [x] All events carry correct metadata (notificationRecordId, recipientId, timestamps)
- [x] All 479 existing tests pass (no regressions)

Closes #10