### PR TITLE
feat: comprehensive startup validation (fail fast on bad config)

### DIFF
--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -3,6 +3,7 @@ import {
   fakeEmailProvider,
   fakeWebhookProvider,
   memoryAdapter,
+  type SendResult,
 } from "@notifykitjs/core";
 import { loadConfig } from "../config.js";
 
@@ -41,7 +42,7 @@ export async function runSend(options: SendOptions): Promise<number> {
     recipientId: options.recipientId,
     notificationId: options.notificationId,
     payload: options.payload,
-  } as Parameters<typeof notify.send>[0]);
+  } as Parameters<typeof notify.send>[0]) as SendResult;
 
   if (result.digested) {
     console.log(

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -183,14 +183,24 @@ export type NotifyKit<
    * `recipientId` is used as provided, with no additional auth check.
    * Client-facing code should go through `createHandler()` which resolves
    * the recipient via `identify()`.
+   *
+   * When `dryRun: true` is passed, returns a `DeliveryExplanation` without
+   * writing any records — equivalent to calling `explain()`.
    */
-  send(input: SendInput<T>): Promise<SendResult>;
+  send(input: SendInput<T> & { dryRun: true }): Promise<DeliveryExplanation>;
+  send(input: SendInput<T> & { dryRun?: false }): Promise<SendResult>;
+  send(input: SendInput<T> & { dryRun?: boolean }): Promise<SendResult | DeliveryExplanation>;
   /**
    * Dry-run explanation of what `send()` would do for a given notification +
    * recipient. Covers preference resolution, rate limits, digests, and quiet
    * hours. Does not write any records or trigger delivery.
    */
   explain(input: SendInput<T>): Promise<DeliveryExplanation>;
+  /**
+   * Shorthand for `explain()`. Validates the send input and returns what
+   * would happen without writing any records or triggering delivery.
+   */
+  check(input: SendInput<T>): Promise<DeliveryExplanation>;
   inbox: {
     /**
      * List inbox items. **Server-only** — the caller supplies the
@@ -2512,8 +2522,14 @@ export function createNotifyKit<
         organizationId: undefined,
       });
     },
-    send,
+    send(input: SendInput<T> & { dryRun?: boolean }): any {
+      if ((input as { dryRun?: boolean }).dryRun) {
+        return explain(input);
+      }
+      return send(input);
+    },
     explain,
+    check: explain,
     inbox: {
       list(recipientId, scope, filter, limit?) {
         const s = scope ? normalizeOrgId(scope) : scope;

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1403,10 +1403,10 @@ export function createNotifyKit<
         outcome = ch.resolvedBy === "destination_unavailable"
           ? "unavailable"
           : "disabled";
-      } else if (wouldReplayIdempotent) {
-        outcome = "idempotent";
       } else if (!payloadValidation.valid) {
         outcome = "invalid_payload";
+      } else if (wouldReplayIdempotent) {
+        outcome = "idempotent";
       } else if (wouldDeduplicate) {
         outcome = "deduplicated";
       } else if (wouldRateLimit) {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -52,7 +52,7 @@ import {
 } from "./preference-keys.js";
 import { resolveChannel, resolvePreferences, type ResolutionContext } from "./resolve-preferences.js";
 import { signUnsubscribeToken } from "./unsubscribe.js";
-import { NotifyKitError, assertSafeWebhookUrl, checkPayload, sanitizeActionUrl, redactPayload, renderTemplate, validatePayload } from "./utils.js";
+import { NotifyKitError, PAYLOAD_VALID, assertSafeWebhookUrl, checkPayload, sanitizeActionUrl, redactPayload, renderTemplate, validatePayload } from "./utils.js";
 import { validateConfig, formatValidationIssues } from "./validate.js";
 
 export const SKIP_PROVIDER = "skip" as const;
@@ -1306,7 +1306,7 @@ export function createNotifyKit<
             }],
           };
         } else {
-          payloadValidation = { valid: true, fields: [] };
+          payloadValidation = PAYLOAD_VALID;
         }
       } catch (err: unknown) {
         const errFields = err instanceof Error && "fields" in err

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1277,6 +1277,12 @@ export function createNotifyKit<
       dedupeKey?: string;
       dedupeWindowMs?: number;
     };
+    if (!input.recipientId) {
+      throw new NotifyKitError(
+        "Missing recipientId.",
+        { code: "INVALID_INPUT", field: "recipientId", fix: "Pass a non-empty recipientId to send()." },
+      );
+    }
     const def = byId.get(input.notificationId);
     if (!def) {
       throw new NotifyKitError(

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2558,9 +2558,9 @@ export function createNotifyKit<
     },
     send(input: SendInput<T> & { dryRun?: boolean }): any {
       if (input.dryRun) {
-        return explain(input);
+        return explain(input) satisfies Promise<DeliveryExplanation>;
       }
-      return send(input);
+      return send(input) satisfies Promise<SendResult>;
     },
     explain,
     check: explain,

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1302,6 +1302,34 @@ export function createNotifyKit<
     }
     const scope = resolveScope(input, recipient);
 
+    if (input.idempotencyKey && input.idempotencyKey.length > 256) {
+      throw new NotifyKitError(
+        "idempotencyKey must be 256 characters or fewer.",
+        { code: "INVALID_INPUT", field: "idempotencyKey", fix: "Shorten the idempotencyKey to 256 characters or fewer." },
+      );
+    }
+    if (input.dedupeKey) {
+      if (!input.dedupeWindowMs || input.dedupeWindowMs <= 0) {
+        throw new NotifyKitError(
+          "dedupeWindowMs is required and must be positive when dedupeKey is set.",
+          { code: "INVALID_INPUT", field: "dedupeWindowMs", fix: "Pass a positive dedupeWindowMs (e.g. 3600000 for 1 hour)." },
+        );
+      }
+      const MAX_DEDUPE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+      if (input.dedupeWindowMs > MAX_DEDUPE_WINDOW_MS) {
+        throw new NotifyKitError(
+          "dedupeWindowMs must be 30 days or fewer.",
+          { code: "INVALID_INPUT", field: "dedupeWindowMs", fix: "Pass a dedupeWindowMs of 2592000000 (30 days) or less." },
+        );
+      }
+      if (input.dedupeKey.length > 256) {
+        throw new NotifyKitError(
+          "dedupeKey must be 256 characters or fewer.",
+          { code: "INVALID_INPUT", field: "dedupeKey", fix: "Shorten the dedupeKey to 256 characters or fewer." },
+        );
+      }
+    }
+
     let wouldReplayIdempotent = false;
     let idempotencyInfo: DeliveryExplanation["idempotency"] = null;
     if (input.idempotencyKey) {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -21,7 +21,9 @@ import type {
   MarkReadForRecipientResult,
   NotificationDefinition,
   NotificationRecord,
+  PayloadFieldError,
   PayloadSchema,
+  PayloadValidationResult,
   PreferenceExplanation,
   PreferenceResolutionLayer,
   Queue,
@@ -50,7 +52,7 @@ import {
 } from "./preference-keys.js";
 import { resolveChannel, resolvePreferences, type ResolutionContext } from "./resolve-preferences.js";
 import { signUnsubscribeToken } from "./unsubscribe.js";
-import { NotifyKitError, assertSafeWebhookUrl, sanitizeActionUrl, redactPayload, renderTemplate, validatePayload } from "./utils.js";
+import { NotifyKitError, assertSafeWebhookUrl, checkPayload, sanitizeActionUrl, redactPayload, renderTemplate, validatePayload } from "./utils.js";
 import { validateConfig, formatValidationIssues } from "./validate.js";
 
 export const SKIP_PROVIDER = "skip" as const;
@@ -1289,6 +1291,41 @@ export function createNotifyKit<
     }
     const scope = resolveScope(input, recipient);
 
+    let payloadValidation: PayloadValidationResult;
+    if (def.validate) {
+      try {
+        const result = def.validate(input.payload);
+        if (!result || typeof result !== "object" || Array.isArray(result)) {
+          payloadValidation = {
+            valid: false,
+            fields: [{
+              key: "(root)",
+              expected: "object",
+              actual: result === null ? "null" : Array.isArray(result) ? "array" : typeof result,
+              message: "Custom validator must return a plain object.",
+            }],
+          };
+        } else {
+          payloadValidation = { valid: true, fields: [] };
+        }
+      } catch (err: unknown) {
+        const errFields = err instanceof Error && "fields" in err
+          ? (err as Record<string, unknown>).fields
+          : undefined;
+        const fields: PayloadFieldError[] = Array.isArray(errFields)
+          ? errFields as PayloadFieldError[]
+          : [{
+              key: "(root)",
+              expected: "valid",
+              actual: "invalid",
+              message: err instanceof Error ? err.message : String(err),
+            }];
+        payloadValidation = { valid: false, fields };
+      }
+    } else {
+      payloadValidation = checkPayload(def.payload, input.payload);
+    }
+
     const prefExplanation = resolvePreferences(
       await buildResolutionCtx(recipient, def, scope),
     );
@@ -1340,6 +1377,8 @@ export function createNotifyKit<
         outcome = ch.resolvedBy === "destination_unavailable"
           ? "unavailable"
           : "disabled";
+      } else if (!payloadValidation.valid) {
+        outcome = "invalid_payload";
       } else if (wouldDeduplicate) {
         outcome = "deduplicated";
       } else if (wouldRateLimit) {
@@ -1365,6 +1404,7 @@ export function createNotifyKit<
       required: def.required ?? false,
       classification: def.classification,
       category: def.category,
+      payloadValidation,
       wouldDeduplicate,
       wouldRateLimit,
       wouldDigest,

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1336,21 +1336,6 @@ export function createNotifyKit<
       }
     }
 
-    let wouldReplayIdempotent = false;
-    let idempotencyInfo: DeliveryExplanation["idempotency"] = null;
-    if (input.idempotencyKey) {
-      const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
-      const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
-      const existing = await database.notifications.findByIdempotencyKey(compositeKey);
-      if (existing) {
-        const age = Date.now() - existing.createdAt.getTime();
-        if (age < ttl) {
-          wouldReplayIdempotent = true;
-          idempotencyInfo = { key: input.idempotencyKey, existingNotificationId: existing.id, ttlMs: ttl };
-        }
-      }
-    }
-
     let payloadValidation: PayloadValidationResult;
     if (def.validate) {
       try {
@@ -1386,34 +1371,52 @@ export function createNotifyKit<
       payloadValidation = checkPayload(def.payload, input.payload);
     }
 
+    let wouldReplayIdempotent = false;
+    let idempotencyInfo: DeliveryExplanation["idempotency"] = null;
+    let wouldRateLimit = false;
+    let rateLimitInfo: DeliveryExplanation["rateLimit"] = null;
+    let wouldDeduplicate = false;
+    let dedupeInfo: DeliveryExplanation["dedupe"] = null;
+
+    if (payloadValidation.valid) {
+      if (input.idempotencyKey) {
+        const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
+        const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
+        const existing = await database.notifications.findByIdempotencyKey(compositeKey);
+        if (existing) {
+          const age = Date.now() - existing.createdAt.getTime();
+          if (age < ttl) {
+            wouldReplayIdempotent = true;
+            idempotencyInfo = { key: input.idempotencyKey, existingNotificationId: existing.id, ttlMs: ttl };
+          }
+        }
+      }
+
+      if (def.rateLimit) {
+        const limit = def.rateLimit;
+        const rateLimitScope = limit.scope ?? "recipient";
+        const key =
+          rateLimitScope === "global"
+            ? scopedStorageKey(scope, def.id)
+            : scopedStorageKey(scope, recipient.id, def.id);
+        const current = await database.rateLimits.count({
+          key,
+          windowMs: limit.windowMs,
+        });
+        wouldRateLimit = current >= limit.max;
+        rateLimitInfo = { current, max: limit.max, windowMs: limit.windowMs };
+      }
+
+      if (input.dedupeKey && input.dedupeWindowMs && input.dedupeWindowMs > 0) {
+        dedupeInfo = { key: input.dedupeKey, windowMs: input.dedupeWindowMs };
+        const dedupeCompositeKey = buildDedupeCompositeKey(def.id, recipient.id, input.dedupeKey);
+        wouldDeduplicate = await database.dedupe.exists(dedupeCompositeKey);
+      }
+    }
+
     const prefExplanation = resolvePreferences(
       await buildResolutionCtx(recipient, def, scope),
     );
-
-    let wouldRateLimit = false;
-    let rateLimitInfo: DeliveryExplanation["rateLimit"] = null;
-    if (def.rateLimit) {
-      const limit = def.rateLimit;
-      const rateLimitScope = limit.scope ?? "recipient";
-      const key =
-        rateLimitScope === "global"
-          ? scopedStorageKey(scope, def.id)
-          : scopedStorageKey(scope, recipient.id, def.id);
-      const current = await database.rateLimits.count({
-        key,
-        windowMs: limit.windowMs,
-      });
-      wouldRateLimit = current >= limit.max;
-      rateLimitInfo = { current, max: limit.max, windowMs: limit.windowMs };
-    }
-
-    let wouldDeduplicate = false;
-    let dedupeInfo: DeliveryExplanation["dedupe"] = null;
-    if (input.dedupeKey && input.dedupeWindowMs && input.dedupeWindowMs > 0) {
-      dedupeInfo = { key: input.dedupeKey, windowMs: input.dedupeWindowMs };
-      const dedupeCompositeKey = buildDedupeCompositeKey(def.id, recipient.id, input.dedupeKey);
-      wouldDeduplicate = await database.dedupe.exists(dedupeCompositeKey);
-    }
 
     const wouldDigest = !!def.digest;
     const digestInfo: DeliveryExplanation["digest"] = def.digest

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -2523,7 +2523,7 @@ export function createNotifyKit<
       });
     },
     send(input: SendInput<T> & { dryRun?: boolean }): any {
-      if ((input as { dryRun?: boolean }).dryRun) {
+      if (input.dryRun) {
         return explain(input);
       }
       return send(input);

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -1263,6 +1263,7 @@ export function createNotifyKit<
       workspaceId?: string;
       notificationId: string;
       payload: unknown;
+      idempotencyKey?: string;
       dedupeKey?: string;
       dedupeWindowMs?: number;
     };
@@ -1290,6 +1291,21 @@ export function createNotifyKit<
       );
     }
     const scope = resolveScope(input, recipient);
+
+    let wouldReplayIdempotent = false;
+    let idempotencyInfo: DeliveryExplanation["idempotency"] = null;
+    if (input.idempotencyKey) {
+      const ttl = config.idempotencyKeyTtlMs ?? 24 * 60 * 60 * 1000;
+      const compositeKey = idempotencyCompositeKey(input.idempotencyKey, input.notificationId, input.recipientId);
+      const existing = await database.notifications.findByIdempotencyKey(compositeKey);
+      if (existing) {
+        const age = Date.now() - existing.createdAt.getTime();
+        if (age < ttl) {
+          wouldReplayIdempotent = true;
+          idempotencyInfo = { key: input.idempotencyKey, existingNotificationId: existing.id, ttlMs: ttl };
+        }
+      }
+    }
 
     let payloadValidation: PayloadValidationResult;
     if (def.validate) {
@@ -1377,6 +1393,8 @@ export function createNotifyKit<
         outcome = ch.resolvedBy === "destination_unavailable"
           ? "unavailable"
           : "disabled";
+      } else if (wouldReplayIdempotent) {
+        outcome = "idempotent";
       } else if (!payloadValidation.valid) {
         outcome = "invalid_payload";
       } else if (wouldDeduplicate) {
@@ -1405,9 +1423,11 @@ export function createNotifyKit<
       classification: def.classification,
       category: def.category,
       payloadValidation,
+      wouldReplayIdempotent,
       wouldDeduplicate,
       wouldRateLimit,
       wouldDigest,
+      idempotency: idempotencyInfo,
       dedupe: dedupeInfo,
       rateLimit: rateLimitInfo,
       digest: digestInfo,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export {
 } from "./unsubscribe.js";
 export {
   NotifyKitError,
+  PAYLOAD_VALID,
   PayloadValidationError,
   createId,
   extractTemplateVars,
@@ -97,7 +98,6 @@ export type { ResolutionContext } from "./resolve-preferences.js";
 
 export type {
   NotifyKitErrorContext,
-  PayloadFieldError,
   SafeWebhookResult,
 } from "./utils.js";
 export type {
@@ -139,7 +139,9 @@ export type {
   NotificationDefinition,
   NotificationIds,
   NotificationRecord,
+  PayloadFieldError,
   PayloadSchema,
+  PayloadValidationResult,
   PreferenceExplanation,
   PreferenceResolutionLayer,
   PrimitiveSchema,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,14 +38,28 @@ export type PreferenceExplanation = {
   category?: string;
 };
 
+// Ordered by explain() evaluation priority (first match wins)
 export type ChannelOutcome =
-  | "deliver"
-  | "disabled"
-  | "delayed"
   | "unavailable"
+  | "disabled"
+  | "invalid_payload"
   | "deduplicated"
   | "rate_limited"
-  | "digested";
+  | "digested"
+  | "delayed"
+  | "deliver";
+
+export type PayloadFieldError = {
+  key: string;
+  expected: string;
+  actual: string;
+  message: string;
+};
+
+export type PayloadValidationResult = {
+  valid: boolean;
+  fields: PayloadFieldError[];
+};
 
 export type DeliveryExplanation = {
   recipientId: string;
@@ -55,6 +69,7 @@ export type DeliveryExplanation = {
   required: boolean;
   classification?: NotificationClassification;
   category?: string;
+  payloadValidation: PayloadValidationResult;
   wouldDeduplicate: boolean;
   wouldRateLimit: boolean;
   wouldDigest: boolean;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,8 +42,8 @@ export type PreferenceExplanation = {
 export type ChannelOutcome =
   | "unavailable"
   | "disabled"
-  | "idempotent"
   | "invalid_payload"
+  | "idempotent"
   | "deduplicated"
   | "rate_limited"
   | "digested"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,6 +42,7 @@ export type PreferenceExplanation = {
 export type ChannelOutcome =
   | "unavailable"
   | "disabled"
+  | "idempotent"
   | "invalid_payload"
   | "deduplicated"
   | "rate_limited"
@@ -70,9 +71,11 @@ export type DeliveryExplanation = {
   classification?: NotificationClassification;
   category?: string;
   payloadValidation: PayloadValidationResult;
+  wouldReplayIdempotent: boolean;
   wouldDeduplicate: boolean;
   wouldRateLimit: boolean;
   wouldDigest: boolean;
+  idempotency: { key: string; existingNotificationId: string; ttlMs: number } | null;
   dedupe: { key: string; windowMs: number } | null;
   rateLimit: { current: number; max: number; windowMs: number } | null;
   digest: { windowMs: number } | null;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -916,6 +916,12 @@ export type SendInput<
      * first are skipped.
      */
     dedupeWindowMs?: number;
+    /**
+     * When `true`, `send()` performs a dry run and returns a
+     * `DeliveryExplanation` instead of executing the send. No records are
+     * written, no deliveries triggered. Equivalent to calling `explain()`.
+     */
+    dryRun?: boolean;
   };
 }[T[number]["id"]];
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -122,6 +122,8 @@ export function validatePayload(
   return validated;
 }
 
+export const PAYLOAD_VALID: PayloadValidationResult = Object.freeze({ valid: true, fields: [] });
+
 export function checkPayload(
   schema: PayloadSchema,
   payload: unknown,
@@ -172,7 +174,7 @@ export function checkPayload(
     }
   }
 
-  return { valid: fieldErrors.length === 0, fields: fieldErrors };
+  return fieldErrors.length === 0 ? PAYLOAD_VALID : { valid: false, fields: fieldErrors };
 }
 
 const BLOCKED_HOSTNAME_PATTERNS = [

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import type { PayloadSchema } from "./types.js";
+import type { PayloadFieldError, PayloadSchema, PayloadValidationResult } from "./types.js";
 
 export function createId(prefix: string): string {
   const rand = randomBytes(12).toString("base64url");
@@ -74,12 +74,7 @@ export class NotifyKitError extends Error {
   }
 }
 
-export type PayloadFieldError = {
-  key: string;
-  expected: string;
-  actual: string;
-  message: string;
-};
+export type { PayloadFieldError } from "./types.js";
 
 export class PayloadValidationError extends NotifyKitError {
   readonly fields: PayloadFieldError[];
@@ -99,18 +94,53 @@ export function validatePayload(
   payload: unknown,
   notificationId: string,
 ): Record<string, unknown> {
-  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+  const result = checkPayload(schema, payload);
+  if (!result.valid) {
+    const schemaHint = Object.entries(schema).map(([k, v]) => `${k}: ${v}`).join(", ");
+    if (result.fields.length === 1 && result.fields[0]!.key === "(root)") {
+      throw new PayloadValidationError(
+        `Invalid payload for notification "${notificationId}": expected an object.`,
+        {
+          notificationId,
+          fix: `Pass a plain object matching the schema: { ${schemaHint} }.`,
+        },
+      );
+    }
+    const details = result.fields.map((e) => `  - ${e.message}`).join("\n");
     throw new PayloadValidationError(
-      `Invalid payload for notification "${notificationId}": expected an object.`,
+      `Invalid payload for notification "${notificationId}":\n${details}`,
       {
         notificationId,
-        fix: `Pass a plain object matching the schema: { ${Object.entries(schema).map(([k, v]) => `${k}: ${v}`).join(", ")} }.`,
+        fields: result.fields,
+        fix: `Check the payload matches schema: { ${schemaHint} }.`,
       },
     );
   }
+  const data = payload as Record<string, unknown>;
+  const validated: Record<string, unknown> = {};
+  for (const key of Object.keys(schema)) {
+    validated[key] = data[key];
+  }
+  return validated;
+}
+
+export function checkPayload(
+  schema: PayloadSchema,
+  payload: unknown,
+): PayloadValidationResult {
+  if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+    return {
+      valid: false,
+      fields: [{
+        key: "(root)",
+        expected: "object",
+        actual: payload === null ? "null" : Array.isArray(payload) ? "array" : typeof payload,
+        message: "Expected payload to be a plain object.",
+      }],
+    };
+  }
 
   const data = payload as Record<string, unknown>;
-  const result: Record<string, unknown> = {};
   const fieldErrors: PayloadFieldError[] = [];
 
   for (const key of Object.keys(schema)) {
@@ -141,25 +171,10 @@ export function validatePayload(
         actual: displayActual,
         message: `Expected "${key}" to be ${expected}, got ${displayActual}.`,
       });
-      continue;
     }
-
-    result[key] = value;
   }
 
-  if (fieldErrors.length > 0) {
-    const details = fieldErrors.map((e) => `  - ${e.message}`).join("\n");
-    throw new PayloadValidationError(
-      `Invalid payload for notification "${notificationId}":\n${details}`,
-      {
-        notificationId,
-        fields: fieldErrors,
-        fix: `Check the payload matches schema: { ${Object.entries(schema).map(([k, v]) => `${k}: ${v}`).join(", ")} }.`,
-      },
-    );
-  }
-
-  return result;
+  return { valid: fieldErrors.length === 0, fields: fieldErrors };
 }
 
 const BLOCKED_HOSTNAME_PATTERNS = [

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -122,7 +122,7 @@ export function validatePayload(
   return validated;
 }
 
-export const PAYLOAD_VALID: PayloadValidationResult = Object.freeze({ valid: true, fields: [] });
+export const PAYLOAD_VALID: Readonly<PayloadValidationResult> = Object.freeze({ valid: true, fields: [] });
 
 export function checkPayload(
   schema: PayloadSchema,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -74,8 +74,6 @@ export class NotifyKitError extends Error {
   }
 }
 
-export type { PayloadFieldError } from "./types.js";
-
 export class PayloadValidationError extends NotifyKitError {
   readonly fields: PayloadFieldError[];
 

--- a/packages/core/tests/preference-resolution.test.ts
+++ b/packages/core/tests/preference-resolution.test.ts
@@ -1729,6 +1729,299 @@ describe("notify.explain() — delivery-level explanation", () => {
   });
 });
 
+describe("notify.explain() — idempotency reporting", () => {
+  test("no idempotencyKey returns wouldReplayIdempotent: false and null info", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+    });
+    expect(result.wouldReplayIdempotent).toBe(false);
+    expect(result.idempotency).toBeNull();
+  });
+
+  test("idempotencyKey with no prior send returns wouldReplayIdempotent: false", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-new",
+    });
+    expect(result.wouldReplayIdempotent).toBe(false);
+    expect(result.idempotency).toBeNull();
+    expect(result.channels.every((c) => c.outcome === "deliver")).toBe(true);
+  });
+
+  test("idempotencyKey matching existing send within TTL reports idempotent", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const sendResult = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-1",
+    });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-1",
+    });
+    expect(result.wouldReplayIdempotent).toBe(true);
+    expect(result.idempotency).not.toBeNull();
+    expect(result.idempotency!.key).toBe("key-1");
+    expect(result.idempotency!.existingNotificationId).toBe(sendResult.notification!.id);
+    expect(result.idempotency!.ttlMs).toBe(24 * 60 * 60 * 1000);
+    expect(
+      result.channels
+        .filter((c) => c.allowed)
+        .every((c) => c.outcome === ("idempotent" as ChannelOutcome)),
+    ).toBe(true);
+  });
+
+  test("idempotencyKey expired beyond TTL returns wouldReplayIdempotent: false", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      idempotencyKeyTtlMs: 1,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-expire",
+    });
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-expire",
+    });
+    expect(result.wouldReplayIdempotent).toBe(false);
+    expect(result.idempotency).toBeNull();
+  });
+
+  test("idempotencyKey scoped per recipient — different recipients are independent", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+    await notify.upsertRecipient({ id: "u2" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "shared-key",
+    });
+
+    const r1 = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "shared-key",
+    });
+    expect(r1.wouldReplayIdempotent).toBe(true);
+
+    const r2 = await notify.explain({
+      recipientId: "u2",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "shared-key",
+    });
+    expect(r2.wouldReplayIdempotent).toBe(false);
+  });
+
+  test("idempotencyKey scoped per notification — different notifications are independent", async () => {
+    const def1 = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const def2 = notification({
+      id: "reminder",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def1, def2] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "shared-key",
+    });
+
+    const r1 = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "shared-key",
+    });
+    expect(r1.wouldReplayIdempotent).toBe(true);
+
+    const r2 = await notify.explain({
+      recipientId: "u1",
+      notificationId: "reminder",
+      payload: { msg: "hi" },
+      idempotencyKey: "shared-key",
+    });
+    expect(r2.wouldReplayIdempotent).toBe(false);
+  });
+
+  test("explain with idempotencyKey does not write any records", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-no-write",
+    });
+
+    expect(db._state.notifications).toHaveLength(0);
+    expect(db._state.deliveries).toHaveLength(0);
+    expect(db._state.inboxItems).toHaveLength(0);
+  });
+
+  test("disabled channels keep disabled outcome even when idempotent", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+    await notify.preferences.update({
+      recipientId: "u1",
+      notificationId: "alert",
+      channels: { email: false },
+    });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-disabled",
+    });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-disabled",
+    });
+    expect(result.wouldReplayIdempotent).toBe(true);
+    const emailCh = result.channels.find((c) => c.channel === "email")!;
+    expect(emailCh.outcome).toBe("disabled" as ChannelOutcome);
+    const inboxCh = result.channels.find((c) => c.channel === "inbox")!;
+    expect(inboxCh.outcome).toBe("idempotent" as ChannelOutcome);
+  });
+
+  test("custom TTL is reported in idempotency info", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      idempotencyKeyTtlMs: 5000,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-ttl",
+    });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      idempotencyKey: "key-ttl",
+    });
+    expect(result.idempotency!.ttlMs).toBe(5000);
+  });
+});
+
 describe("handler GET /explain", () => {
   function buildHandler() {
     const def = notification({

--- a/packages/core/tests/preference-resolution.test.ts
+++ b/packages/core/tests/preference-resolution.test.ts
@@ -2390,3 +2390,291 @@ describe("notify.explain() — payload validation", () => {
     expect(result.payloadValidation.fields[0]!.actual).toBe("NaN");
   });
 });
+
+describe("notify.check() alias", () => {
+  test("check() returns same result as explain()", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const explainResult = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+    });
+    const checkResult = await notify.check({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+    });
+
+    expect(checkResult.recipientId).toBe(explainResult.recipientId);
+    expect(checkResult.notificationId).toBe(explainResult.notificationId);
+    expect(checkResult.wouldRateLimit).toBe(explainResult.wouldRateLimit);
+    expect(checkResult.wouldDeduplicate).toBe(explainResult.wouldDeduplicate);
+    expect(checkResult.wouldDigest).toBe(explainResult.wouldDigest);
+    expect(checkResult.wouldReplayIdempotent).toBe(explainResult.wouldReplayIdempotent);
+    expect(checkResult.channels.length).toBe(explainResult.channels.length);
+  });
+
+  test("check() does not write any records", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    await notify.check({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+    });
+
+    expect(db._state.notifications).toHaveLength(0);
+    expect(db._state.deliveries).toHaveLength(0);
+    expect(db._state.inboxItems).toHaveLength(0);
+    expect(provider.sent).toHaveLength(0);
+  });
+});
+
+describe("notify.send({ dryRun: true })", () => {
+  test("dryRun returns DeliveryExplanation instead of SendResult", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      dryRun: true,
+    });
+
+    expect(result.recipientId).toBe("u1");
+    expect(result.notificationId).toBe("alert");
+    expect(result.channels.length).toBeGreaterThan(0);
+    expect(result.wouldRateLimit).toBe(false);
+    expect(result.wouldDeduplicate).toBe(false);
+    expect(result.payloadValidation.valid).toBe(true);
+  });
+
+  test("dryRun does not create notification records", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" }), email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      dryRun: true,
+    });
+
+    expect(db._state.notifications).toHaveLength(0);
+    expect(db._state.deliveries).toHaveLength(0);
+    expect(db._state.inboxItems).toHaveLength(0);
+    expect(provider.sent).toHaveLength(0);
+  });
+
+  test("dryRun does not create inbox items", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      dryRun: true,
+    });
+
+    expect(db._state.inboxItems).toHaveLength(0);
+  });
+
+  test("dryRun does not consume rate limit budget", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "limited",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+      rateLimit: { max: 1, windowMs: 60_000 },
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "limited",
+      payload: { msg: "hi" },
+      dryRun: true,
+    });
+
+    const real = await notify.send({
+      recipientId: "u1",
+      notificationId: "limited",
+      payload: { msg: "hi" },
+    });
+    expect(real.rateLimited).toBe(false);
+  });
+
+  test("dryRun does not insert dedupe keys", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "mention",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { msg: "hi" },
+      dedupeKey: "dup-1",
+      dedupeWindowMs: 60_000,
+      dryRun: true,
+    });
+
+    const real = await notify.send({
+      recipientId: "u1",
+      notificationId: "mention",
+      payload: { msg: "hi" },
+      dedupeKey: "dup-1",
+      dedupeWindowMs: 60_000,
+    });
+    expect(real.skipped).toHaveLength(0);
+  });
+
+  test("dryRun does not buffer digests", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "digest-test",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+      digest: {
+        windowMs: 60_000,
+        render: ({ payloads, count }) => ({ msg: `${count} items` }),
+      },
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "digest-test",
+      payload: { msg: "hi" },
+      dryRun: true,
+    });
+
+    const buffers = await db.digests.list();
+    expect(buffers).toHaveLength(0);
+  });
+
+  test("dryRun does not create scheduled sends for quiet hours", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [email({ subject: "{{msg}}", body: "{{msg}}" })],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({
+      id: "u1",
+      email: "u@x.com",
+      quietHours: { start: "00:00", end: "23:59", timezone: "UTC" },
+    });
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      dryRun: true,
+    });
+
+    const scheduled = await db.scheduledSends.list();
+    expect(scheduled).toHaveLength(0);
+  });
+
+  test("dryRun: false behaves like normal send", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "alert",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { msg: "hi" },
+      dryRun: false,
+    });
+
+    expect(result.notification).not.toBeNull();
+    expect(db._state.notifications).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/preference-resolution.test.ts
+++ b/packages/core/tests/preference-resolution.test.ts
@@ -1791,3 +1791,309 @@ describe("handler GET /explain", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("notify.explain() — payload validation", () => {
+  test("valid payload returns valid: true with no field errors", async () => {
+    const def = notification({
+      id: "welcome",
+      payload: { name: "string", count: "number" },
+      channels: [inbox({ title: "{{name}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Alice", count: 5 },
+    });
+    expect(result.payloadValidation.valid).toBe(true);
+    expect(result.payloadValidation.fields).toEqual([]);
+    expect(result.channels.every((c) => c.outcome === "deliver")).toBe(true);
+  });
+
+  test("missing fields returns valid: false with structured field errors", async () => {
+    const def = notification({
+      id: "alert",
+      payload: { title: "string", priority: "number", urgent: "boolean" },
+      channels: [inbox({ title: "{{title}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "alert",
+      payload: { title: "fire" },
+    });
+    expect(result.payloadValidation.valid).toBe(false);
+    expect(result.payloadValidation.fields).toHaveLength(2);
+    const keys = result.payloadValidation.fields.map((f) => f.key);
+    expect(keys).toContain("priority");
+    expect(keys).toContain("urgent");
+    const priorityField = result.payloadValidation.fields.find((f) => f.key === "priority")!;
+    expect(priorityField.expected).toBe("number");
+    expect(priorityField.actual).toBe("undefined");
+  });
+
+  test("wrong types returns valid: false with type mismatch details", async () => {
+    const def = notification({
+      id: "metric",
+      payload: { value: "number", label: "string" },
+      channels: [inbox({ title: "{{label}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "metric",
+      payload: { value: "not-a-number", label: 42 },
+    });
+    expect(result.payloadValidation.valid).toBe(false);
+    expect(result.payloadValidation.fields).toHaveLength(2);
+    const valueField = result.payloadValidation.fields.find((f) => f.key === "value")!;
+    expect(valueField.expected).toBe("number");
+    expect(valueField.actual).toBe("string");
+    const labelField = result.payloadValidation.fields.find((f) => f.key === "label")!;
+    expect(labelField.expected).toBe("string");
+    expect(labelField.actual).toBe("number");
+  });
+
+  test("invalid payload produces invalid_payload channel outcome", async () => {
+    const def = notification({
+      id: "invite",
+      payload: { email: "string" },
+      channels: [
+        inbox({ title: "invite" }),
+        email({ subject: "invite", body: "{{email}}" }),
+      ],
+    });
+    const provider = fakeEmailProvider();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "invite",
+      payload: { email: 123 },
+    });
+    expect(result.payloadValidation.valid).toBe(false);
+    expect(
+      result.channels
+        .filter((c) => c.allowed)
+        .every((c) => c.outcome === ("invalid_payload" as ChannelOutcome)),
+    ).toBe(true);
+  });
+
+  test("non-object payload returns root-level field error", async () => {
+    const def = notification({
+      id: "ping",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "ping",
+      payload: "not-an-object" as unknown as { msg: string },
+    });
+    expect(result.payloadValidation.valid).toBe(false);
+    expect(result.payloadValidation.fields).toHaveLength(1);
+    expect(result.payloadValidation.fields[0]!.key).toBe("(root)");
+    expect(result.payloadValidation.fields[0]!.expected).toBe("object");
+    expect(result.payloadValidation.fields[0]!.actual).toBe("string");
+  });
+
+  test("custom validate function — valid payload", async () => {
+    const def = notification({
+      id: "custom-ok",
+      payload: { x: "string" },
+      channels: [inbox({ title: "{{x}}" })],
+      validate: (p: unknown) => {
+        const data = p as { x: string };
+        if (typeof data.x !== "string") throw new Error("x must be string");
+        return data;
+      },
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "custom-ok",
+      payload: { x: "hello" },
+    });
+    expect(result.payloadValidation.valid).toBe(true);
+    expect(result.payloadValidation.fields).toEqual([]);
+  });
+
+  test("custom validate function — throws error", async () => {
+    const def = notification({
+      id: "custom-fail",
+      payload: { x: "string" },
+      channels: [inbox({ title: "{{x}}" })],
+      validate: (_p: unknown) => {
+        throw new Error("x is required and must be non-empty");
+      },
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "custom-fail",
+      payload: {},
+    });
+    expect(result.payloadValidation.valid).toBe(false);
+    expect(result.payloadValidation.fields).toHaveLength(1);
+    expect(result.payloadValidation.fields[0]!.message).toBe(
+      "x is required and must be non-empty",
+    );
+    expect(
+      result.channels
+        .filter((c) => c.allowed)
+        .every((c) => c.outcome === ("invalid_payload" as ChannelOutcome)),
+    ).toBe(true);
+  });
+
+  test("custom validate with structured field errors preserves them", async () => {
+    const def = notification({
+      id: "custom-fields",
+      payload: { a: "string", b: "number" },
+      channels: [inbox({ title: "{{a}}" })],
+      validate: (_p: unknown) => {
+        const err = new Error("Validation failed") as Error & {
+          fields: Array<{ key: string; expected: string; actual: string; message: string }>;
+        };
+        err.fields = [
+          { key: "a", expected: "string", actual: "undefined", message: "a is required" },
+          { key: "b", expected: "number", actual: "string", message: "b must be a number" },
+        ];
+        throw err;
+      },
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "custom-fields",
+      payload: {},
+    });
+    expect(result.payloadValidation.valid).toBe(false);
+    expect(result.payloadValidation.fields).toHaveLength(2);
+    expect(result.payloadValidation.fields[0]!.key).toBe("a");
+    expect(result.payloadValidation.fields[1]!.key).toBe("b");
+  });
+
+  test("invalid payload does not write any records", async () => {
+    const db = memoryAdapter();
+    const def = notification({
+      id: "no-write",
+      payload: { x: "string" },
+      channels: [inbox({ title: "{{x}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    await notify.explain({
+      recipientId: "u1",
+      notificationId: "no-write",
+      payload: { x: 999 },
+    });
+
+    expect(db._state.notifications).toHaveLength(0);
+    expect(db._state.deliveries).toHaveLength(0);
+    expect(db._state.inboxItems).toHaveLength(0);
+  });
+
+  test("disabled channels keep disabled outcome even with invalid payload", async () => {
+    const def = notification({
+      id: "disabled-test",
+      payload: { msg: "string" },
+      channels: [
+        inbox({ title: "{{msg}}" }),
+        email({ subject: "{{msg}}", body: "{{msg}}" }),
+      ],
+    });
+    const provider = fakeEmailProvider();
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: db,
+      providers: { email: provider },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+    await notify.preferences.update({
+      recipientId: "u1",
+      notificationId: "disabled-test",
+      channels: { email: false },
+    });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "disabled-test",
+      payload: { msg: 42 },
+    });
+    expect(result.payloadValidation.valid).toBe(false);
+    const emailCh = result.channels.find((c) => c.channel === "email")!;
+    expect(emailCh.outcome).toBe("disabled" as ChannelOutcome);
+    const inboxCh = result.channels.find((c) => c.channel === "inbox")!;
+    expect(inboxCh.outcome).toBe("invalid_payload" as ChannelOutcome);
+  });
+
+  test("NaN number field reports invalid", async () => {
+    const def = notification({
+      id: "nan-test",
+      payload: { score: "number" },
+      channels: [inbox({ title: "score" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+    });
+    await notify.upsertRecipient({ id: "u1" });
+
+    const result = await notify.explain({
+      recipientId: "u1",
+      notificationId: "nan-test",
+      payload: { score: NaN },
+    });
+    expect(result.payloadValidation.valid).toBe(false);
+    expect(result.payloadValidation.fields).toHaveLength(1);
+    expect(result.payloadValidation.fields[0]!.key).toBe("score");
+    expect(result.payloadValidation.fields[0]!.expected).toBe("number");
+    expect(result.payloadValidation.fields[0]!.actual).toBe("NaN");
+  });
+});

--- a/packages/core/tests/security.test.ts
+++ b/packages/core/tests/security.test.ts
@@ -2091,3 +2091,388 @@ describe("recipient tenant immutability", () => {
     expect(updated.tenantId).toBe("orgA");
   });
 });
+
+describe("tenant-scoped explain()", () => {
+  test("explain uses the recipient's tenant scope for preference resolution", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+
+    await notify.preferences.update({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "comment_mentioned",
+      channels: { email: false },
+    });
+
+    const result = await notify.explain({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "comment_mentioned",
+      payload: makePayload(),
+    });
+    expect(result.scope?.tenantId).toBe("tenant_a");
+    const emailCh = result.channels.find((c) => c.channel === "email")!;
+    expect(emailCh.outcome).toBe("disabled");
+  });
+
+  test("cross-tenant preferences do not influence explain results", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+    await notify.upsertRecipient({ id: "bob", tenantId: "tenant_b", email: "b@x.com" });
+
+    await notify.preferences.update({
+      recipientId: "bob",
+      tenantId: "tenant_b",
+      notificationId: "comment_mentioned",
+      channels: { email: false },
+    });
+
+    const result = await notify.explain({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "comment_mentioned",
+      payload: makePayload(),
+    });
+    const emailCh = result.channels.find((c) => c.channel === "email")!;
+    expect(emailCh.outcome).toBe("deliver");
+    expect(emailCh.allowed).toBe(true);
+  });
+
+  test("cross-tenant rate limits do not affect explain results", async () => {
+    const rateLimited = notification({
+      id: "rate_test",
+      payload: { actorName: "string", postTitle: "string", postUrl: "string" },
+      channels: [
+        inbox({ title: "{{actorName}} mentioned you", body: "In {{postTitle}}", actionUrl: "{{postUrl}}" }),
+        email({ subject: "{{actorName}} mentioned you", body: "Open {{postUrl}}" }),
+      ],
+      rateLimit: { max: 1, windowMs: 60_000 },
+    });
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [rateLimited] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+    await notify.upsertRecipient({ id: "bob", tenantId: "tenant_b", email: "b@x.com" });
+
+    await notify.send({
+      recipientId: "bob",
+      tenantId: "tenant_b",
+      notificationId: "rate_test",
+      payload: makePayload(),
+    });
+
+    const result = await notify.explain({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "rate_test",
+      payload: makePayload(),
+    });
+    expect(result.wouldRateLimit).toBe(false);
+    expect(result.rateLimit!.current).toBe(0);
+  });
+
+  test("same recipient's rate limit within same tenant does affect explain", async () => {
+    const rateLimited = notification({
+      id: "rate_test",
+      payload: { actorName: "string", postTitle: "string", postUrl: "string" },
+      channels: [
+        inbox({ title: "{{actorName}} mentioned you", body: "In {{postTitle}}", actionUrl: "{{postUrl}}" }),
+      ],
+      rateLimit: { max: 1, windowMs: 60_000 },
+    });
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [rateLimited] as const,
+      database,
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a" });
+
+    await notify.send({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "rate_test",
+      payload: makePayload(),
+    });
+
+    const result = await notify.explain({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "rate_test",
+      payload: makePayload(),
+    });
+    expect(result.wouldRateLimit).toBe(true);
+    expect(result.rateLimit!.current).toBe(1);
+  });
+
+  test("cross-tenant dedupe state does not affect explain results", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+    await notify.upsertRecipient({ id: "bob", tenantId: "tenant_b", email: "b@x.com" });
+
+    await notify.send({
+      recipientId: "bob",
+      tenantId: "tenant_b",
+      notificationId: "comment_mentioned",
+      payload: makePayload(),
+      dedupeKey: "shared-dedup",
+      dedupeWindowMs: 60_000,
+    });
+
+    const result = await notify.explain({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "comment_mentioned",
+      payload: makePayload(),
+      dedupeKey: "shared-dedup",
+      dedupeWindowMs: 60_000,
+    });
+    expect(result.wouldDeduplicate).toBe(false);
+  });
+
+  test("explain with workspace scope resolves correctly", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({
+      id: "alice",
+      tenantId: "tenant_a",
+      workspaceId: "ws_1",
+      email: "a@x.com",
+    });
+
+    const result = await notify.explain({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      workspaceId: "ws_1",
+      notificationId: "comment_mentioned",
+      payload: makePayload(),
+    });
+    expect(result.scope?.tenantId).toBe("tenant_a");
+    expect(result.scope?.workspaceId).toBe("ws_1");
+    expect(result.channels.some((c) => c.outcome === "deliver")).toBe(true);
+  });
+
+  test("explain throws on tenant mismatch with recipient", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+
+    expect(
+      notify.explain({
+        recipientId: "alice",
+        tenantId: "tenant_b",
+        notificationId: "comment_mentioned",
+        payload: makePayload(),
+      }),
+    ).rejects.toThrow("does not belong to the specified tenant");
+  });
+
+  test("explain throws on workspace mismatch with recipient", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({
+      id: "alice",
+      tenantId: "tenant_a",
+      workspaceId: "ws_1",
+      email: "a@x.com",
+    });
+
+    expect(
+      notify.explain({
+        recipientId: "alice",
+        tenantId: "tenant_a",
+        workspaceId: "ws_wrong",
+        notificationId: "comment_mentioned",
+        payload: makePayload(),
+      }),
+    ).rejects.toThrow("does not belong to the specified workspace");
+  });
+
+  test("tenantDefaults influence explain outcome per-tenant", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+      tenantDefaults: (tenantId) => {
+        if (tenantId === "tenant_strict") return { email: false };
+        return null;
+      },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_strict", email: "a@x.com" });
+    await notify.upsertRecipient({ id: "bob", tenantId: "tenant_open", email: "b@x.com" });
+
+    const strictResult = await notify.explain({
+      recipientId: "alice",
+      tenantId: "tenant_strict",
+      notificationId: "comment_mentioned",
+      payload: makePayload(),
+    });
+    const strictEmail = strictResult.channels.find((c) => c.channel === "email")!;
+    expect(strictEmail.outcome).toBe("disabled");
+    expect(strictEmail.resolvedBy).toBe("tenant_setting");
+
+    const openResult = await notify.explain({
+      recipientId: "bob",
+      tenantId: "tenant_open",
+      notificationId: "comment_mentioned",
+      payload: makePayload(),
+    });
+    const openEmail = openResult.channels.find((c) => c.channel === "email")!;
+    expect(openEmail.outcome).toBe("deliver");
+  });
+
+  test("preferences.explain() is scoped to the caller's tenant", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+
+    await notify.preferences.update({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "comment_mentioned",
+      channels: { email: false },
+    });
+
+    const explanation = await notify.preferences.explain({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "comment_mentioned",
+    });
+    expect(explanation.scope?.tenantId).toBe("tenant_a");
+    const emailCh = explanation.channels.find((c) => c.channel === "email")!;
+    expect(emailCh.allowed).toBe(false);
+    expect(emailCh.resolvedBy).toBe("user_notification");
+  });
+});
+
+describe("tenant-scoped explain() via handler", () => {
+  test("GET /explain uses identified tenant scope", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+
+    await notify.preferences.update({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "comment_mentioned",
+      channels: { email: false },
+    });
+
+    const handler = createHandler(notify, {
+      identify: () => ({ recipientId: "alice", tenantId: "tenant_a" }),
+    });
+
+    const res = await handler(
+      new Request(
+        `${BASE}/explain?notificationId=comment_mentioned&actorName=Rey&postTitle=Plan&postUrl=/x`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { scope: { tenantId: string }; channels: Array<{ channel: string; outcome: string }> } };
+    expect(body.data.scope.tenantId).toBe("tenant_a");
+    const emailCh = body.data.channels.find((c) => c.channel === "email")!;
+    expect(emailCh.outcome).toBe("disabled");
+  });
+
+  test("GET /preferences/explain uses identified tenant scope", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+
+    await notify.preferences.update({
+      recipientId: "alice",
+      tenantId: "tenant_a",
+      notificationId: "comment_mentioned",
+      channels: { inbox: false },
+    });
+
+    const handler = createHandler(notify, {
+      identify: () => ({ recipientId: "alice", tenantId: "tenant_a" }),
+    });
+
+    const res = await handler(
+      new Request(
+        `${BASE}/preferences/explain?notificationId=comment_mentioned`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { scope: { tenantId: string }; channels: Array<{ channel: string; allowed: boolean }> } };
+    expect(body.data.scope.tenantId).toBe("tenant_a");
+    const inboxCh = body.data.channels.find((c) => c.channel === "inbox")!;
+    expect(inboxCh.allowed).toBe(false);
+  });
+
+  test("handler explain cannot cross-tenant via query param manipulation", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
+    await notify.upsertRecipient({ id: "bob", tenantId: "tenant_b", email: "b@x.com" });
+
+    await notify.preferences.update({
+      recipientId: "bob",
+      tenantId: "tenant_b",
+      notificationId: "comment_mentioned",
+      channels: { email: false },
+    });
+
+    const handler = createHandler(notify, {
+      identify: () => ({ recipientId: "alice", tenantId: "tenant_a" }),
+    });
+
+    const res = await handler(
+      new Request(
+        `${BASE}/explain?notificationId=comment_mentioned&actorName=Rey&postTitle=Plan&postUrl=/x`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { channels: Array<{ channel: string; outcome: string }> } };
+    const emailCh = body.data.channels.find((c) => c.channel === "email")!;
+    expect(emailCh.outcome).toBe("deliver");
+  });
+});

--- a/packages/core/tests/security.test.ts
+++ b/packages/core/tests/security.test.ts
@@ -2282,7 +2282,7 @@ describe("tenant-scoped explain()", () => {
     });
     await notify.upsertRecipient({ id: "alice", tenantId: "tenant_a", email: "a@x.com" });
 
-    expect(
+    await expect(
       notify.explain({
         recipientId: "alice",
         tenantId: "tenant_b",
@@ -2306,7 +2306,7 @@ describe("tenant-scoped explain()", () => {
       email: "a@x.com",
     });
 
-    expect(
+    await expect(
       notify.explain({
         recipientId: "alice",
         tenantId: "tenant_a",


### PR DESCRIPTION
## Summary

- Adds `validateConfig()` that runs at `createNotifyKit()` startup, failing fast with actionable errors on bad configuration
- Validates: duplicate notification IDs, missing providers for configured channels, payload schema correctness, channel config validity, webhook signing secrets, baseUrl format, and more
- Shared between runtime (`createNotifyKit`) and CLI (`notifykit check`)
- Also includes explain API extensions: payload validation reporting (#127), idempotency reporting (#129), `dryRun`/`check()` aliases (#126), and tenant-scoped test coverage (#131)

## Test plan

- [ ] `bun test packages/core/tests/preference-resolution.test.ts` — 93 tests pass (explain, idempotency, dryRun, payload validation)
- [ ] `bun test packages/core/tests/security.test.ts` — 98 tests pass (tenant isolation)
- [ ] `bun test packages/cli/tests/validate.test.ts` — CLI validation tests pass
- [ ] Invalid configs throw at startup with descriptive error messages pointing to the exact notification ID and field

Closes #73