### PR TITLE
feat: complete docs site

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "next": "^15.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "shiki": "^4.0.2",
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -330,15 +331,39 @@
 
     "@notifykitjs/resend": ["@notifykitjs/resend@workspace:packages/resend"],
 
+    "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
     "arkregex": ["arkregex@0.0.5", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw=="],
 
@@ -350,13 +375,25 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "create-notifykit-app": ["create-notifykit-app@workspace:packages/create-app"],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "drizzle-example": ["drizzle-example@workspace:examples/drizzle"],
 
@@ -370,19 +407,49 @@
 
     "handler-example": ["handler-example@workspace:examples/handler"],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "next": ["next@15.5.15", "", { "dependencies": { "@next/env": "15.5.15", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.15", "@next/swc-darwin-x64": "15.5.15", "@next/swc-linux-arm64-gnu": "15.5.15", "@next/swc-linux-arm64-musl": "15.5.15", "@next/swc-linux-x64-gnu": "15.5.15", "@next/swc-linux-x64-musl": "15.5.15", "@next/swc-win32-arm64-msvc": "15.5.15", "@next/swc-win32-x64-msvc": "15.5.15", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ=="],
 
     "notifykit-docs": ["notifykit-docs@workspace:docs"],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -392,9 +459,17 @@
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
+    "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -404,9 +479,25 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "valibot": ["valibot@1.3.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg=="],
 
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
     "zod": ["zod@4.4.2", "", {}, "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 

--- a/docs/app/_components/code.tsx
+++ b/docs/app/_components/code.tsx
@@ -1,0 +1,38 @@
+import { codeToHtml } from "shiki";
+
+type Props = {
+  code: string;
+  lang?: string;
+  filename?: string;
+};
+
+export async function Code({ code, lang = "typescript", filename }: Props) {
+  const html = await codeToHtml(code.trim(), {
+    lang,
+    themes: { light: "github-light-default", dark: "github-dark-default" },
+  });
+
+  return (
+    <figure className="code-block">
+      {filename && <figcaption className="code-filename">{filename}</figcaption>}
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+      <CopyButton code={code.trim()} />
+    </figure>
+  );
+}
+
+function CopyButton({ code }: { code: string }) {
+  return (
+    <button
+      className="code-copy"
+      data-code={code}
+      aria-label="Copy to clipboard"
+      title="Copy"
+    >
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" />
+        <path d="M10.5 5.5V3.5a1.5 1.5 0 0 0-1.5-1.5H3.5A1.5 1.5 0 0 0 2 3.5V9a1.5 1.5 0 0 0 1.5 1.5h2" />
+      </svg>
+    </button>
+  );
+}

--- a/docs/app/_components/copy-button-script.tsx
+++ b/docs/app/_components/copy-button-script.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function CopyButtonScript() {
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".code-copy");
+      if (!btn) return;
+      const code = btn.dataset.code;
+      if (!code) return;
+      navigator.clipboard.writeText(code).then(() => {
+        btn.classList.add("copied");
+        setTimeout(() => btn.classList.remove("copied"), 1500);
+      });
+    }
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, []);
+
+  return null;
+}

--- a/docs/app/_components/side-nav.tsx
+++ b/docs/app/_components/side-nav.tsx
@@ -8,20 +8,57 @@ type Group = { heading: string; entries: Entry[] };
 
 const NAV: Group[] = [
   {
-    heading: "Start here",
+    heading: "Getting Started",
     entries: [
       { href: "/", label: "Overview" },
       { href: "/docs/installation", label: "Installation" },
+      { href: "/docs/quickstart", label: "Quickstart" },
     ],
   },
   {
-    heading: "Guides",
+    heading: "Core Concepts",
     entries: [
       { href: "/docs/defining", label: "Defining notifications" },
       { href: "/docs/sending", label: "Sending" },
+      { href: "/docs/channels", label: "Channels" },
       { href: "/docs/preferences", label: "Preferences & unsubscribe" },
+      { href: "/docs/digests", label: "Digests & rate limits" },
+      { href: "/docs/quiet-hours", label: "Quiet hours" },
+      { href: "/docs/deduplication", label: "Dedup & idempotency" },
+      { href: "/docs/fallbacks", label: "Fallback channels" },
+    ],
+  },
+  {
+    heading: "Framework Integration",
+    entries: [
+      { href: "/docs/nextjs", label: "Next.js" },
+      { href: "/docs/react", label: "React hooks & components" },
+      { href: "/docs/realtime", label: "Realtime" },
+    ],
+  },
+  {
+    heading: "Production",
+    entries: [
+      { href: "/docs/database", label: "Database adapters" },
+      { href: "/docs/providers", label: "Email & webhook providers" },
+      { href: "/docs/multi-tenancy", label: "Multi-tenancy" },
       { href: "/docs/security", label: "Security model" },
-      { href: "/docs/providers", label: "Production providers" },
+    ],
+  },
+  {
+    heading: "Debugging",
+    entries: [
+      { href: "/docs/explain", label: "Explain & dry run" },
+      { href: "/docs/timeline", label: "Timeline" },
+      { href: "/docs/hooks", label: "Hooks & observability" },
+    ],
+  },
+  {
+    heading: "Reference",
+    entries: [
+      { href: "/docs/api", label: "API reference" },
+      { href: "/docs/types", label: "TypeScript types" },
+      { href: "/docs/handler-routes", label: "Handler routes" },
     ],
   },
   {
@@ -34,16 +71,7 @@ export function SideNav() {
   const pathname = usePathname();
   return (
     <nav className="docs-nav" aria-label="Docs">
-      <Link
-        href="/"
-        style={{
-          fontWeight: 700,
-          fontSize: "1.1rem",
-          display: "inline-block",
-          marginBottom: "0.5rem",
-          color: "var(--fg)",
-        }}
-      >
+      <Link href="/" className="docs-nav-logo">
         NotifyKit
       </Link>
       {NAV.map((group) => (

--- a/docs/app/docs/api/page.tsx
+++ b/docs/app/docs/api/page.tsx
@@ -1,0 +1,191 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "API reference" };
+
+export default function ApiPage() {
+  return (
+    <article>
+      <h1>API reference</h1>
+      <p>
+        Complete reference for the <code>createNotifyKit()</code> instance.
+        All methods below are available on the object returned by{" "}
+        <code>createNotifyKit()</code>.
+      </p>
+
+      <h2>notify.send(input)</h2>
+      <p>
+        Send a notification. Returns a <code>SendResult</code> with all
+        outcomes. Pass <code>dryRun: true</code> to get a{" "}
+        <code>DeliveryExplanation</code> instead.
+      </p>
+      <Code
+        code={`const result = await notify.send({
+  recipientId: string,
+  notificationId: string,      // must match a registered definition
+  payload: { ... },            // typed per notification
+  tenantId?: string,
+  organizationId?: string,     // alias for tenantId
+  workspaceId?: string,
+  idempotencyKey?: string,
+  dedupeKey?: string,
+  dedupeWindowMs?: number,
+  dryRun?: boolean,
+})`}
+      />
+
+      <h3>SendResult</h3>
+      <Code
+        code={`type SendResult = {
+  notification: NotificationRecord | null
+  inboxItems: InboxItem[]
+  deliveries: DeliveryRecord[]
+  skippedChannels: SkippedDelivery[]
+  deferredChannels: Array<{ channel: ChannelType; resumesAt: Date }>
+  digested: boolean
+  rateLimited: boolean
+  deduplicated: boolean
+  idempotentReplay: boolean
+}`}
+      />
+
+      <h2>notify.explain(input)</h2>
+      <p>
+        Dry-run a send. Same input as <code>send()</code>, returns{" "}
+        <code>DeliveryExplanation</code>. No records written.
+      </p>
+
+      <h2>notify.check(input)</h2>
+      <p>Alias for <code>explain()</code>.</p>
+
+      <h2>notify.upsertRecipient(input)</h2>
+      <Code
+        code={`await notify.upsertRecipient({
+  id: string,
+  email?: string,
+  phone?: string,
+  name?: string,
+  quietHours?: QuietHours | null,
+  tenantId?: string,
+  organizationId?: string,
+  workspaceId?: string,
+})`}
+      />
+
+      <h2>notify.preferences</h2>
+      <Code
+        code={`// List all preferences for a recipient
+await notify.preferences.list(recipientId, scope?)
+
+// Get preference for a specific notification
+await notify.preferences.get({ recipientId, notificationId, ...scope })
+
+// Update a preference
+await notify.preferences.update({
+  recipientId,
+  notificationId,
+  channels: { email: false, inbox: true },
+  ...scope,
+})
+
+// Explain preference resolution
+await notify.preferences.explain({ recipientId, notificationId, ...scope })`}
+      />
+
+      <h2>notify.inbox</h2>
+      <Code
+        code={`// List inbox items for a recipient
+await notify.inbox.list(recipientId, scope?, filter?, limit?)
+
+// Mark one item as read
+await notify.inbox.markReadForRecipient(itemId, recipientId, scope?)
+
+// Mark all items as read
+await notify.inbox.markAllRead(recipientId, scope?)
+
+// Archive / unarchive
+await notify.inbox.archiveForRecipient(itemId, recipientId, scope?)
+await notify.inbox.unarchiveForRecipient(itemId, recipientId, scope?)
+
+// Delete
+await notify.inbox.deleteForRecipient(itemId, recipientId, scope?)
+
+// Unread count
+await notify.inbox.unreadCount(recipientId, scope?)`}
+      />
+
+      <h2>notify.deliveries</h2>
+      <Code
+        code={`// List deliveries (optionally filtered by recipient)
+await notify.deliveries.list(recipientId?, scope?, limit?)
+
+// Get a specific delivery
+await notify.deliveries.get(deliveryId)
+
+// List deliveries for a notification record
+await notify.deliveries.listByNotificationRecordId(notificationRecordId)`}
+      />
+
+      <h2>notify.timeline</h2>
+      <Code
+        code={`// List timeline events for a notification
+await notify.timeline.list(notificationRecordId, limit?)
+
+// List timeline events for a delivery
+await notify.timeline.listByDelivery(deliveryId, notificationRecordId?, limit?)
+
+// Prune old events
+await notify.timeline.prune(olderThan: Date)`}
+      />
+
+      <h2>notify.drain()</h2>
+      <p>
+        Wait for all in-flight queue jobs to settle. Call before process
+        shutdown to avoid losing pending deliveries.
+      </p>
+
+      <h2>notify.flushScheduledSends()</h2>
+      <p>
+        Fire all scheduled sends whose <code>scheduledFor</code> has passed.
+        Returns the results of each fired send.
+      </p>
+
+      <h2>notify.flushDigests()</h2>
+      <p>
+        Flush all digest buckets whose window has expired. Returns the
+        results of each flushed digest.
+      </p>
+
+      <h2>notify.redactPayload(notificationId, payload)</h2>
+      <p>
+        Returns a copy of the payload with fields in the notification&apos;s{" "}
+        <code>redact</code> array replaced by <code>&quot;[REDACTED]&quot;</code>.
+      </p>
+
+      <h2>notify.notifications</h2>
+      <p>
+        Access registered notification definitions:
+      </p>
+      <Code
+        code={`// Get all registered definitions
+notify.notifications // readonly array
+
+// Get metadata for the handler's public API
+notify.notificationMetadata
+// [{ id, channels, payload, category, description, required, classification }]`}
+      />
+
+      <div className="page-nav">
+        <Link href="/docs/hooks">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Hooks & observability</span>
+        </Link>
+        <Link href="/docs/types">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">TypeScript types</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/api/page.tsx
+++ b/docs/app/docs/api/page.tsx
@@ -117,26 +117,22 @@ await notify.inbox.unreadCount(recipientId, scope?)`}
 
       <h2>notify.deliveries</h2>
       <Code
-        code={`// List deliveries (optionally filtered by recipient)
-await notify.deliveries.list(recipientId?, scope?, limit?)
-
-// Get a specific delivery
-await notify.deliveries.get(deliveryId)
-
-// List deliveries for a notification record
-await notify.deliveries.listByNotificationRecordId(notificationRecordId)`}
+        code={`// List deliveries (optionally filtered by recipient and scope)
+await notify.deliveries.list(recipientId?, scope?, limit?)`}
       />
 
-      <h2>notify.timeline</h2>
+      <h2>notify.timeline(notificationRecordId, options?)</h2>
       <Code
         code={`// List timeline events for a notification
-await notify.timeline.list(notificationRecordId, limit?)
+await notify.timeline(notificationRecordId)
+await notify.timeline(notificationRecordId, { limit: 100 })
 
-// List timeline events for a delivery
-await notify.timeline.listByDelivery(deliveryId, notificationRecordId?, limit?)
+// List timeline events for a specific delivery
+await notify.timeline(notificationRecordId, { deliveryId, limit: 50 })
 
-// Prune old events
-await notify.timeline.prune(olderThan: Date)`}
+// Prune old events (uses configured timelineRetentionMs if omitted)
+await notify.pruneTimeline(olderThan)
+await notify.pruneTimeline()`}
       />
 
       <h2>notify.drain()</h2>

--- a/docs/app/docs/channels/page.tsx
+++ b/docs/app/docs/channels/page.tsx
@@ -1,0 +1,150 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Channels" };
+
+export default function ChannelsPage() {
+  return (
+    <article>
+      <h1>Channels</h1>
+      <p>
+        A channel is a delivery mechanism. Each notification definition lists
+        the channels it should be sent through. NotifyKit ships four channel
+        types — inbox, email, SMS, and webhook.
+      </p>
+
+      <h2>Inbox</h2>
+      <p>
+        The inbox channel writes a row to your database. It&apos;s user-pulled
+        (the recipient fetches it via the React hook or REST API), so it&apos;s
+        never subject to quiet hours or delivery failures.
+      </p>
+      <Code
+        code={`import { channel } from "@notifykitjs/core"
+
+const inbox = channel.inbox()
+
+// In a notification definition:
+inbox({
+  title: "{{actorName}} mentioned you",
+  body: "In {{postTitle}}",        // optional
+  actionUrl: "{{postUrl}}",        // optional — renders as a link
+})`}
+      />
+      <p>
+        Inbox items support read/unread state, archiving, and deletion. All
+        mutations publish realtime events when a{" "}
+        <Link href="/docs/realtime">realtime adapter</Link> is configured.
+      </p>
+
+      <h2>Email</h2>
+      <p>
+        The email channel queues a delivery job that your configured{" "}
+        <Link href="/docs/providers">email provider</Link> sends. It supports
+        subject, body (plain text), and the reserved{" "}
+        <code>{`{{_unsubscribeUrl}}`}</code> template variable.
+      </p>
+      <Code
+        code={`const email = channel.email()
+
+email({
+  subject: "{{actorName}} mentioned you in {{postTitle}}",
+  body: "Open {{postUrl}} to reply.\\n\\nUnsubscribe: {{_unsubscribeUrl}}",
+})`}
+      />
+      <p>
+        Email deliveries go through the full pipeline: queue, retry with
+        backoff, fallback on terminal failure.
+      </p>
+
+      <h2>SMS</h2>
+      <p>
+        The SMS channel sends a text message through your configured{" "}
+        SMS provider. The recipient must have a <code>phone</code> field set.
+      </p>
+      <Code
+        code={`const sms = channel.sms()
+
+sms({
+  body: "Your verification code is {{code}}",
+})`}
+      />
+
+      <h2>Webhook</h2>
+      <p>
+        The webhook channel POSTs a signed JSON envelope to a URL. Use it for
+        Slack integrations, custom destinations, or forwarding to external
+        services.
+      </p>
+      <Code
+        code={`const webhook = channel.webhook()
+
+webhook({
+  url: "https://hooks.slack.com/services/T.../B.../xxx",
+  headers: { "Content-Type": "application/json" },
+})`}
+      />
+      <p>
+        When a <code>secret</code> is configured on the webhook provider,
+        every request includes an <code>x-notifykit-signature: sha256=&lt;hex&gt;</code>{" "}
+        header. Receivers verify by HMAC-SHA256-ing the raw body with the
+        shared secret.
+      </p>
+
+      <h2>Channel behavior during send</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Channel</th>
+            <th>Delivery</th>
+            <th>Quiet hours</th>
+            <th>Preferences</th>
+            <th>Retries</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Inbox</td>
+            <td>Immediate (DB write)</td>
+            <td>Not affected</td>
+            <td>Respects opt-out</td>
+            <td>N/A</td>
+          </tr>
+          <tr>
+            <td>Email</td>
+            <td>Via queue + provider</td>
+            <td>Deferred</td>
+            <td>Respects opt-out</td>
+            <td>Configurable</td>
+          </tr>
+          <tr>
+            <td>SMS</td>
+            <td>Via queue + provider</td>
+            <td>Deferred</td>
+            <td>Respects opt-out</td>
+            <td>Configurable</td>
+          </tr>
+          <tr>
+            <td>Webhook</td>
+            <td>Via queue + provider</td>
+            <td>Deferred</td>
+            <td>Respects opt-out</td>
+            <td>Configurable</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="page-nav">
+        <Link href="/docs/sending">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Sending</span>
+        </Link>
+        <Link href="/docs/preferences">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Preferences & unsubscribe</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/database/page.tsx
+++ b/docs/app/docs/database/page.tsx
@@ -1,0 +1,165 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Database adapters" };
+
+export default function DatabasePage() {
+  return (
+    <article>
+      <h1>Database adapters</h1>
+      <p>
+        NotifyKit stores all state (recipients, notifications, inbox items,
+        deliveries, preferences) in your database via a pluggable adapter.
+        The memory adapter is great for development; Drizzle adapters are
+        available for SQLite and PostgreSQL in production.
+      </p>
+
+      <h2>Memory adapter</h2>
+      <p>
+        Zero-config, no database required. State lives in-process and resets
+        on restart. Perfect for local dev and tests.
+      </p>
+      <Code
+        code={`import { memoryAdapter } from "@notifykitjs/core"
+
+const notify = createNotifyKit({
+  // ...
+  database: memoryAdapter(),
+})`}
+      />
+
+      <h2>Drizzle SQLite</h2>
+      <Code
+        lang="bash"
+        code={`npm install @notifykitjs/drizzle drizzle-orm better-sqlite3`}
+      />
+      <Code
+        filename="lib/notifykit.ts"
+        code={`import Database from "better-sqlite3"
+import { drizzle } from "drizzle-orm/better-sqlite3"
+import { createSqliteTables, drizzleSqliteAdapter } from "@notifykitjs/drizzle"
+
+const sqlite = new Database("app.db")
+const db = drizzle(sqlite)
+
+// Create tables (run once, or use drizzle-kit migrations in production)
+await createSqliteTables(db)
+
+export const notify = createNotifyKit({
+  // ...
+  database: drizzleSqliteAdapter(db),
+})`}
+      />
+
+      <h2>Drizzle PostgreSQL</h2>
+      <Code
+        lang="bash"
+        code={`npm install @notifykitjs/drizzle drizzle-orm postgres`}
+      />
+      <Code
+        filename="lib/notifykit.ts"
+        code={`import postgres from "postgres"
+import { drizzle } from "drizzle-orm/postgres-js"
+import { createPgTables, drizzlePostgresAdapter } from "@notifykitjs/drizzle"
+
+const client = postgres(process.env.DATABASE_URL!)
+const db = drizzle(client)
+
+// Create tables (run once, or use drizzle-kit migrations)
+await createPgTables(db)
+
+export const notify = createNotifyKit({
+  // ...
+  database: drizzlePostgresAdapter(db),
+})`}
+      />
+
+      <h2>Joining NotifyKit tables with your app</h2>
+      <p>
+        The Drizzle adapter exports the full schema so you can join
+        NotifyKit tables against your own:
+      </p>
+      <Code
+        code={`import { notifyKitSchema } from "@notifykitjs/drizzle"
+import { eq } from "drizzle-orm"
+
+// Get all inbox items for a user with their notification details
+const items = await db
+  .select()
+  .from(notifyKitSchema.inboxItems)
+  .where(eq(notifyKitSchema.inboxItems.recipientId, user.id))
+  .orderBy(notifyKitSchema.inboxItems.createdAt)`}
+      />
+
+      <h2>Schema overview</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Table</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>notifykit_recipients</code></td>
+            <td>Recipient profiles (email, phone, quiet hours)</td>
+          </tr>
+          <tr>
+            <td><code>notifykit_notifications</code></td>
+            <td>Notification records (one per send)</td>
+          </tr>
+          <tr>
+            <td><code>notifykit_inbox_items</code></td>
+            <td>Inbox entries with read/archive state</td>
+          </tr>
+          <tr>
+            <td><code>notifykit_deliveries</code></td>
+            <td>Delivery attempts (email, SMS, webhook)</td>
+          </tr>
+          <tr>
+            <td><code>notifykit_preferences</code></td>
+            <td>Per-recipient channel preferences</td>
+          </tr>
+          <tr>
+            <td><code>notifykit_scheduled_sends</code></td>
+            <td>Deferred sends (quiet hours)</td>
+          </tr>
+          <tr>
+            <td><code>notifykit_rate_limit_events</code></td>
+            <td>Rate limit counters</td>
+          </tr>
+          <tr>
+            <td><code>notifykit_digest_buffers</code></td>
+            <td>Digest accumulation buckets</td>
+          </tr>
+          <tr>
+            <td><code>notifykit_timeline_events</code></td>
+            <td>Debug timeline for each notification</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Custom adapter</h2>
+      <p>
+        Implement the <code>DatabaseAdapter</code> interface to use any
+        database. The interface has sections for recipients, notifications,
+        inbox, deliveries, preferences, digests, rate limits, scheduled sends,
+        dedupe, and timeline. See the{" "}
+        <Link href="/docs/types">TypeScript types</Link> page for the full
+        interface definition.
+      </p>
+
+      <div className="page-nav">
+        <Link href="/docs/realtime">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Realtime</span>
+        </Link>
+        <Link href="/docs/providers">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Email & webhook providers</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/deduplication/page.tsx
+++ b/docs/app/docs/deduplication/page.tsx
@@ -1,0 +1,149 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Deduplication & idempotency" };
+
+export default function DeduplicationPage() {
+  return (
+    <article>
+      <h1>Deduplication &amp; idempotency</h1>
+      <p>
+        Two distinct mechanisms prevent duplicate notifications. They solve
+        different problems and can be used together.
+      </p>
+
+      <h2>Deduplication (semantic)</h2>
+      <p>
+        Prevents semantically identical notifications within a time window.
+        Example: &quot;user X mentioned you&quot; shouldn&apos;t fire twice if
+        two code paths trigger it for the same mention.
+      </p>
+      <Code
+        code={`await notify.send({
+  recipientId: user.id,
+  notificationId: "comment_mentioned",
+  payload: { actorName: "Rey", postUrl: "/posts/42" },
+  dedupeKey: "mention:post_42:user_rey",
+  dedupeWindowMs: 5 * 60_000, // 5 minutes
+})`}
+      />
+      <p>
+        The composite key is scoped to <code>(dedupeKey, notificationId,
+        recipientId)</code>. The first send within the window succeeds; any
+        subsequent send with the same composite key is skipped with reason{" "}
+        <code>&quot;duplicate&quot;</code>.
+      </p>
+
+      <h3>Dedup result</h3>
+      <Code
+        code={`const result = await notify.send({ ... dedupeKey, dedupeWindowMs })
+
+if (result.deduplicated) {
+  // send was skipped — no notification created
+  console.log("duplicate within window")
+}`}
+      />
+
+      <h2>Idempotency (retry-safe)</h2>
+      <p>
+        Prevents the same API call from being processed twice. Use when your
+        caller might retry (network timeout, worker crash). The same logical
+        operation returns the original result on replay.
+      </p>
+      <Code
+        code={`await notify.send({
+  recipientId: user.id,
+  notificationId: "order_shipped",
+  payload: { orderNumber: "ORD-123", trackingUrl: "..." },
+  idempotencyKey: "ship:ORD-123",
+})`}
+      />
+      <p>
+        The composite key is <code>(idempotencyKey, notificationId,
+        recipientId)</code>. A duplicate call within the TTL window returns
+        the original <code>NotificationRecord</code> without re-processing.
+      </p>
+
+      <h3>TTL</h3>
+      <p>
+        Idempotency keys expire after a configurable TTL (default: 24 hours).
+        After expiry, the same key can be reused.
+      </p>
+      <Code
+        code={`createNotifyKit({
+  // ...
+  idempotencyTtlMs: 48 * 60 * 60_000, // 48 hours
+})`}
+      />
+
+      <h2>Comparison</h2>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Deduplication</th>
+            <th>Idempotency</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Purpose</strong></td>
+            <td>Prevent same logical event from notifying twice</td>
+            <td>Make retries safe</td>
+          </tr>
+          <tr>
+            <td><strong>Key</strong></td>
+            <td><code>dedupeKey</code> (caller-provided)</td>
+            <td><code>idempotencyKey</code> (caller-provided)</td>
+          </tr>
+          <tr>
+            <td><strong>Window</strong></td>
+            <td><code>dedupeWindowMs</code> (per-call)</td>
+            <td><code>idempotencyTtlMs</code> (global config)</td>
+          </tr>
+          <tr>
+            <td><strong>On duplicate</strong></td>
+            <td>Skip entirely, no record created</td>
+            <td>Return the existing notification record</td>
+          </tr>
+          <tr>
+            <td><strong>Skip reason</strong></td>
+            <td><code>&quot;duplicate&quot;</code></td>
+            <td><code>&quot;idempotent_replay&quot;</code></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Using both together</h2>
+      <Code
+        code={`await notify.send({
+  recipientId: user.id,
+  notificationId: "comment_mentioned",
+  payload: { actorName: "Rey", postUrl: "/posts/42" },
+  // Semantic dedup: don't notify about the same mention twice
+  dedupeKey: "mention:post_42:user_rey",
+  dedupeWindowMs: 10 * 60_000,
+  // Retry safety: if this exact call retries, return the original
+  idempotencyKey: "job:abc123",
+})`}
+      />
+      <p>
+        Evaluation order: idempotency check runs first. If the key already
+        exists, the original result is returned. If not, dedup check runs.
+        If the dedup key exists, the send is skipped.
+      </p>
+
+      <div className="page-nav">
+        <Link href="/docs/quiet-hours">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Quiet hours</span>
+        </Link>
+        <Link href="/docs/fallbacks">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Fallback channels</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/deduplication/page.tsx
+++ b/docs/app/docs/deduplication/page.tsx
@@ -73,7 +73,7 @@ if (result.deduplicated) {
       <Code
         code={`createNotifyKit({
   // ...
-  idempotencyTtlMs: 48 * 60 * 60_000, // 48 hours
+  idempotencyKeyTtlMs: 48 * 60 * 60_000, // 48 hours
 })`}
       />
 
@@ -100,7 +100,7 @@ if (result.deduplicated) {
           <tr>
             <td><strong>Window</strong></td>
             <td><code>dedupeWindowMs</code> (per-call)</td>
-            <td><code>idempotencyTtlMs</code> (global config)</td>
+            <td><code>idempotencyKeyTtlMs</code> (global config)</td>
           </tr>
           <tr>
             <td><strong>On duplicate</strong></td>

--- a/docs/app/docs/defining/page.tsx
+++ b/docs/app/docs/defining/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Code } from "../../_components/code";
 
 export const metadata: Metadata = { title: "Defining notifications" };
 
@@ -10,13 +11,13 @@ export default function DefiningPage() {
       <p>
         A notification has an <code>id</code>, a <code>payload</code> schema,
         and a list of <code>channels</code>. Define them in code. Your
-        notification ids and payload shapes become typed values the rest of
+        notification IDs and payload shapes become typed values the rest of
         your app can rely on.
       </p>
 
       <h2>Basic definition</h2>
-      <pre>
-        <code>{`import { channel, notification } from "@notifykitjs/core"
+      <Code
+        code={`import { channel, notification } from "@notifykitjs/core"
 
 const inbox = channel.inbox()
 const email = channel.email()
@@ -39,8 +40,8 @@ export const commentMentioned = notification({
       body: "Open {{postUrl}} to reply.",
     }),
   ],
-})`}</code>
-      </pre>
+})`}
+      />
 
       <h2>Payload schema</h2>
       <p>
@@ -49,8 +50,8 @@ export const commentMentioned = notification({
         type-check payloads at the <code>send()</code> call site and validate
         at runtime.
       </p>
-      <pre>
-        <code>{`notification({
+      <Code
+        code={`notification({
   id: "order_shipped",
   payload: {
     orderNumber: "string",
@@ -58,109 +59,95 @@ export const commentMentioned = notification({
     expedited:   "boolean",
   },
   channels: [...],
-})`}</code>
-      </pre>
+})`}
+      />
+      <p>
+        For complex validation (nested objects, arrays, refinements), use the{" "}
+        <code>validate</code> field with Zod, Valibot, or ArkType:
+      </p>
+      <Code
+        code={`import { z } from "zod"
+import { withZod } from "@notifykitjs/core/zod"
+
+notification({
+  id: "invoice_created",
+  payload: { invoiceId: "string", amount: "number" },
+  validate: withZod(z.object({
+    invoiceId: z.string().uuid(),
+    amount: z.number().positive(),
+  })),
+  channels: [...],
+})`}
+      />
 
       <h2>Templates</h2>
       <p>
         Every channel&apos;s string fields support <code>{`{{key}}`}</code>{" "}
-        interpolation against the payload. Missing keys render as empty
-        strings.
+        interpolation against the payload. Missing keys render as empty strings.
       </p>
       <p>
         Email <code>body</code> additionally gets a reserved{" "}
-        <code>{`{{_unsubscribeUrl}}`}</code> key when unsubscribe is
+        <code>{`{{_unsubscribeUrl}}`}</code> variable when unsubscribe is
         configured — see{" "}
         <Link href="/docs/preferences">Preferences &amp; unsubscribe</Link>.
       </p>
 
-      <h2>Channels</h2>
-      <ul>
-        <li>
-          <code>channel.inbox()</code> — writes a row to the adapter. Shows
-          up in the <code>useInbox()</code> hook and{" "}
-          <code>&lt;Inbox /&gt;</code> component. User-pulled viewing.
-        </li>
-        <li>
-          <code>channel.email()</code> — goes through the queue +
-          retry + unsubscribe pipeline.
-        </li>
-        <li>
-          <code>channel.webhook()</code> — POSTs a signed JSON envelope to{" "}
-          <code>url</code> with optional <code>headers</code>. Same
-          queue/retry/fallback path as email.
-        </li>
-      </ul>
+      <h2>Optional fields</h2>
+      <Code
+        code={`notification({
+  id: "team_invite",
+  payload: { inviterName: "string", teamName: "string" },
+  channels: [...],
 
-      <h2>Guarding against spam: digest + rateLimit</h2>
+  // Metadata
+  description: "Sent when a user is invited to a team",
+  category: "social",
+  classification: "product",
+  version: 1,
+
+  // Behavior
+  required: true,                         // bypasses preferences
+  defaultChannels: { email: true, inbox: true },
+  redact: ["inviterName"],                // mask in logs
+
+  // Delivery control
+  rateLimit: { max: 5, windowMs: 60_000 },
+  digest: { windowMs: 300_000, render: ... },
+  fallback: inbox({ title: "You have a team invite" }),
+})`}
+      />
+
+      <h2>Registering definitions</h2>
       <p>
-        Two optional fields do the heavy lifting for noisy notifications.
+        Pass all notification definitions to <code>createNotifyKit()</code>.
+        The <code>as const</code> assertion is required for full type inference:
       </p>
-      <pre>
-        <code>{`notification({
-  id: "comment_mentioned",
-  payload: {
-    actorName: "string",
-    postTitle: "string",
-    // count is part of the payload because the digest's render() produces it
-    // and the inbox template references it.
-    count: "number",
-  },
-  channels: [
-    inbox({ title: "{{count}} new comments on {{postTitle}}" }),
-  ],
-  // Coalesce multiple sends in a rolling window into one notification.
-  digest: {
-    windowMs: 5 * 60_000,
-    key: ({ payload }) => payload.postTitle,
-    render: ({ payloads, count }) => ({
-      actorName: payloads[payloads.length - 1]!.actorName,
-      postTitle: payloads[0]!.postTitle,
-      count,
-    }),
-  },
-  // Hard cap — anything over the limit is dropped (not buffered).
-  rateLimit: { max: 20, windowMs: 60 * 60_000 },
-})`}</code>
-      </pre>
-      <div className="callout">
-        <strong>Rate limit runs before digest.</strong> If a send is over the
-        limit it&apos;s dropped outright. Users never get a sneaky mega-digest
-        because an attacker flooded the bucket.
+      <Code
+        code={`import { createNotifyKit } from "@notifykitjs/core"
+import { commentMentioned } from "./notifications/comment-mentioned"
+import { orderShipped } from "./notifications/order-shipped"
+import { teamInvite } from "./notifications/team-invite"
+
+export const notify = createNotifyKit({
+  notifications: [commentMentioned, orderShipped, teamInvite] as const,
+  // ...
+})`}
+      />
+      <p>
+        Now <code>notify.send()</code> only accepts valid notification IDs and
+        the correct payload shape for each.
+      </p>
+
+      <div className="page-nav">
+        <Link href="/docs/quickstart">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Quickstart</span>
+        </Link>
+        <Link href="/docs/sending">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Sending</span>
+        </Link>
       </div>
-
-      <h2>Fallback channels</h2>
-      <p>
-        When a primary delivery fails after all retries, a fallback inbox
-        item keeps the user informed:
-      </p>
-      <pre>
-        <code>{`notification({
-  id: "password_reset",
-  payload: { link: "string" },
-  channels: [email({ subject: "Reset password", body: "{{link}}" })],
-  fallback: inbox({
-    title: "Password reset (your email bounced)",
-    body: "Open {{link}} to continue.",
-  }),
-})`}</code>
-      </pre>
-
-      <h2>CLI check</h2>
-      <p>
-        <code>notifykit check</code> validates every{" "}
-        <code>{`{{key}}`}</code> in every channel template against the
-        declared payload schema. Typos become CI failures, not 3am incidents:
-      </p>
-      <pre>
-        <code>{`$ notifykit check
-Found 1 issue(s):
-  comment_mentioned · inbox[0].title: Template references "{{actorNmae}}" but payload has no "actorNmae" field.`}</code>
-      </pre>
-
-      <p>
-        Next: <Link href="/docs/sending">Sending →</Link>
-      </p>
     </article>
   );
 }

--- a/docs/app/docs/digests/page.tsx
+++ b/docs/app/docs/digests/page.tsx
@@ -1,0 +1,163 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Digests & rate limits" };
+
+export default function DigestsPage() {
+  return (
+    <article>
+      <h1>Digests &amp; rate limits</h1>
+      <p>
+        Noisy notifications are the fastest way to lose users. Digests
+        coalesce multiple sends into one. Rate limits hard-cap delivery.
+        Both are configured per-notification with two fields.
+      </p>
+
+      <h2>Digests</h2>
+      <p>
+        A digest accumulates sends within a rolling time window and
+        flushes them as a single notification. Use it when the same event
+        can fire many times in quick succession (comments, likes, updates).
+      </p>
+      <Code
+        code={`notification({
+  id: "new_comments",
+  payload: {
+    actorName: "string",
+    postTitle: "string",
+    count: "number",
+  },
+  channels: [
+    inbox({ title: "{{count}} new comments on {{postTitle}}" }),
+    email({
+      subject: "{{count}} new comments on {{postTitle}}",
+      body: "Latest from {{actorName}}. Open the post to read them all.",
+    }),
+  ],
+  digest: {
+    // Buffer sends for 5 minutes before flushing
+    windowMs: 5 * 60_000,
+
+    // Group by post — different posts get separate digests
+    key: ({ payload }) => payload.postTitle,
+
+    // Combine buffered payloads into one final payload
+    render: ({ payloads, count }) => ({
+      actorName: payloads[payloads.length - 1]!.actorName,
+      postTitle: payloads[0]!.postTitle,
+      count,
+    }),
+  },
+})`}
+      />
+
+      <h3>How it works</h3>
+      <ol>
+        <li>
+          First send within a window creates a buffer entry with{" "}
+          <code>flushAt = now + windowMs</code>.
+        </li>
+        <li>
+          Subsequent sends with the same digest key append their payload to the
+          buffer. No notification is created yet.
+        </li>
+        <li>
+          When the window expires, the engine calls <code>render()</code> with
+          all accumulated payloads, then executes a normal send with the
+          rendered result.
+        </li>
+      </ol>
+
+      <div className="callout callout-tip">
+        <strong>Digest key scoping.</strong> The digest key function only
+        controls grouping within the same (recipientId, notificationId, scope)
+        boundary. Two different recipients always get separate digests.
+      </div>
+
+      <h3>Flush scheduling</h3>
+      <p>
+        The engine schedules a <code>setTimeout</code> to flush each bucket
+        when using <code>setTimeoutQueue()</code>. With external queues
+        (BullMQ, SQS), you&apos;re responsible for calling{" "}
+        <code>notify.flushDigests()</code> on a timer.
+      </p>
+
+      <h2>Rate limits</h2>
+      <p>
+        A rate limit drops sends that exceed a threshold within a sliding
+        window. Unlike digests, dropped sends are gone — they&apos;re not
+        buffered.
+      </p>
+      <Code
+        code={`notification({
+  id: "comment_mentioned",
+  payload: { actorName: "string", postUrl: "string" },
+  channels: [inbox({ title: "{{actorName}} mentioned you" })],
+  rateLimit: {
+    max: 20,              // at most 20 sends...
+    windowMs: 60 * 60_000, // ...per hour
+    scope: "recipient",    // per-recipient (default)
+  },
+})`}
+      />
+
+      <h3>Scope options</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Scope</th>
+            <th>Counts</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>&quot;recipient&quot;</code> (default)</td>
+            <td>Sends to the same recipient for this notification</td>
+          </tr>
+          <tr>
+            <td><code>&quot;global&quot;</code></td>
+            <td>All sends for this notification across all recipients</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Evaluation order</h3>
+      <div className="callout">
+        <strong>Rate limit runs before digest.</strong> If a send exceeds the
+        limit, it&apos;s dropped before it ever enters the digest buffer. This
+        prevents attackers from flooding a user&apos;s digest bucket.
+      </div>
+
+      <h2>Combining both</h2>
+      <Code
+        code={`notification({
+  id: "activity_feed",
+  payload: { summary: "string", count: "number" },
+  channels: [inbox({ title: "{{count}} new activities" })],
+  // Hard cap: no more than 100 raw sends per hour
+  rateLimit: { max: 100, windowMs: 60 * 60_000 },
+  // Of the ones that pass, batch into 10-minute digests
+  digest: {
+    windowMs: 10 * 60_000,
+    render: ({ payloads, count }) => ({
+      summary: \`\${count} things happened\`,
+      count,
+    }),
+  },
+})`}
+      />
+
+      <div className="page-nav">
+        <Link href="/docs/preferences">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Preferences & unsubscribe</span>
+        </Link>
+        <Link href="/docs/quiet-hours">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Quiet hours</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/explain/page.tsx
+++ b/docs/app/docs/explain/page.tsx
@@ -1,0 +1,184 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Explain & dry run" };
+
+export default function ExplainPage() {
+  return (
+    <article>
+      <h1>Explain &amp; dry run</h1>
+      <p>
+        Before sending, you can ask NotifyKit exactly what <em>would</em>{" "}
+        happen. The <code>explain()</code> method (and its <code>dryRun</code>{" "}
+        equivalent) returns a full <code>DeliveryExplanation</code> without
+        writing any records or triggering any deliveries.
+      </p>
+
+      <h2>Using explain()</h2>
+      <Code
+        code={`const explanation = await notify.explain({
+  recipientId: user.id,
+  notificationId: "comment_mentioned",
+  payload: { actorName: "Rey", postTitle: "Launch Plan", postUrl: "/posts/42" },
+})
+
+console.log(explanation)`}
+      />
+
+      <h2>Using dryRun</h2>
+      <p>
+        Alternatively, pass <code>dryRun: true</code> to <code>send()</code>:
+      </p>
+      <Code
+        code={`const explanation = await notify.send({
+  recipientId: user.id,
+  notificationId: "comment_mentioned",
+  payload: { actorName: "Rey", postTitle: "Launch Plan", postUrl: "/posts/42" },
+  dryRun: true,
+})`}
+      />
+      <p>
+        Both are identical. There&apos;s also a <code>notify.check()</code>{" "}
+        alias that reads better in some contexts.
+      </p>
+
+      <h2>DeliveryExplanation shape</h2>
+      <Code
+        code={`type DeliveryExplanation = {
+  recipientId: string
+  notificationId: string
+  scope?: SecurityScope
+  channels: Array<ChannelResolution & { outcome: ChannelOutcome }>
+  required: boolean
+  classification?: "transactional" | "product" | "marketing"
+  category?: string
+  payloadValidation: { valid: boolean; fields: PayloadFieldError[] }
+  wouldReplayIdempotent: boolean
+  wouldDeduplicate: boolean
+  wouldRateLimit: boolean
+  wouldDigest: boolean
+  idempotency: { key: string; existingNotificationId: string; ttlMs: number } | null
+  dedupe: { key: string; windowMs: number } | null
+  rateLimit: { current: number; max: number; windowMs: number } | null
+  digest: { windowMs: number } | null
+  quietHours: { active: boolean; resumesAt: Date | null } | null
+}`}
+      />
+
+      <h2>Channel outcomes</h2>
+      <p>
+        Each channel in the explanation has an <code>outcome</code> field:
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Outcome</th>
+            <th>Meaning</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>&quot;deliver&quot;</code></td>
+            <td>Would be delivered normally</td>
+          </tr>
+          <tr>
+            <td><code>&quot;disabled&quot;</code></td>
+            <td>Disabled by user preferences</td>
+          </tr>
+          <tr>
+            <td><code>&quot;unavailable&quot;</code></td>
+            <td>Recipient lacks destination (no email/phone)</td>
+          </tr>
+          <tr>
+            <td><code>&quot;invalid_payload&quot;</code></td>
+            <td>Payload validation would fail</td>
+          </tr>
+          <tr>
+            <td><code>&quot;idempotent&quot;</code></td>
+            <td>Would replay an existing send</td>
+          </tr>
+          <tr>
+            <td><code>&quot;deduplicated&quot;</code></td>
+            <td>Would be deduplicated</td>
+          </tr>
+          <tr>
+            <td><code>&quot;rate_limited&quot;</code></td>
+            <td>Would exceed rate limit</td>
+          </tr>
+          <tr>
+            <td><code>&quot;digested&quot;</code></td>
+            <td>Would be buffered into a digest</td>
+          </tr>
+          <tr>
+            <td><code>&quot;delayed&quot;</code></td>
+            <td>Would be deferred by quiet hours</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Preference resolution trail</h2>
+      <p>
+        Each channel also includes the full preference resolution trail —
+        every layer that was consulted and what value it returned:
+      </p>
+      <Code
+        code={`// explanation.channels[0].trail:
+[
+  { layer: "app_default", value: true },
+  { layer: "notification_default", value: undefined },
+  { layer: "tenant_setting", value: undefined },
+  { layer: "user_notification", value: false },  // ← user disabled it
+]
+// resolvedBy: "user_notification"
+// allowed: false`}
+      />
+
+      <h2>Preferences explain</h2>
+      <p>
+        For a focused view on just preference resolution (without the full
+        delivery pipeline):
+      </p>
+      <Code
+        code={`const prefExplanation = await notify.preferences.explain({
+  recipientId: user.id,
+  notificationId: "comment_mentioned",
+})
+
+// Returns PreferenceExplanation with channels, resolution trails,
+// required status, classification, and category info.`}
+      />
+
+      <h2>Use cases</h2>
+      <ul>
+        <li>
+          <strong>Debugging</strong> — &quot;Why didn&apos;t this user get an
+          email?&quot; Run explain and check the preference trail.
+        </li>
+        <li>
+          <strong>Admin tooling</strong> — Show operators what would happen
+          before they trigger a broadcast.
+        </li>
+        <li>
+          <strong>Testing</strong> — Assert expected behavior without
+          actually sending.
+        </li>
+        <li>
+          <strong>Preference UIs</strong> — Show users the effect of their
+          settings in real time.
+        </li>
+      </ul>
+
+      <div className="page-nav">
+        <Link href="/docs/security">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Security model</span>
+        </Link>
+        <Link href="/docs/timeline">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Timeline</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/fallbacks/page.tsx
+++ b/docs/app/docs/fallbacks/page.tsx
@@ -1,0 +1,140 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Fallback channels" };
+
+export default function FallbacksPage() {
+  return (
+    <article>
+      <h1>Fallback channels</h1>
+      <p>
+        When a primary channel fails after all retries, a fallback catches
+        the notification so it&apos;s never silently lost. Fallbacks also
+        trigger when a recipient lacks a destination address or when a
+        channel is skipped by preferences.
+      </p>
+
+      <h2>Simple inbox fallback</h2>
+      <p>
+        The simplest pattern: if email fails, drop an inbox item so the user
+        still sees the notification.
+      </p>
+      <Code
+        code={`notification({
+  id: "password_reset",
+  payload: { resetUrl: "string" },
+  channels: [
+    email({
+      subject: "Reset your password",
+      body: "Click here: {{resetUrl}}",
+    }),
+  ],
+  fallback: inbox({
+    title: "Password reset (email delivery failed)",
+    body: "Open {{resetUrl}} to reset your password.",
+  }),
+})`}
+      />
+
+      <h2>Rule-based fallbacks</h2>
+      <p>
+        For more control, pass an array of rules. Each rule specifies a
+        trigger condition and a target channel:
+      </p>
+      <Code
+        code={`notification({
+  id: "security_alert",
+  payload: { event: "string", ip: "string" },
+  channels: [
+    email({ subject: "Security alert: {{event}}", body: "From IP {{ip}}" }),
+    sms({ body: "Security alert: {{event}} from {{ip}}" }),
+  ],
+  fallback: [
+    // If email fails, try SMS
+    { if: "channel.failed", from: "email", then: sms({ body: "Security: {{event}}" }) },
+    // If SMS also fails, at least write to inbox
+    { if: "channel.failed", from: "sms", then: inbox({ title: "Security: {{event}}" }) },
+    // If recipient has no email address, go straight to SMS
+    { if: "missing_address", from: "email", then: sms({ body: "Security: {{event}}" }) },
+  ],
+})`}
+      />
+
+      <h2>Trigger conditions</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Trigger</th>
+            <th>Fires when</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>&quot;channel.failed&quot;</code></td>
+            <td>A channel exhausts all retry attempts</td>
+          </tr>
+          <tr>
+            <td><code>&quot;missing_address&quot;</code></td>
+            <td>Recipient lacks the destination (no email, no phone)</td>
+          </tr>
+          <tr>
+            <td><code>&quot;skipped&quot;</code></td>
+            <td>Channel was skipped by preferences</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>The <code>from</code> field</h3>
+      <p>
+        Optionally scope the rule to a specific source channel. Without{" "}
+        <code>from</code>, the rule matches any channel that hits the trigger
+        condition.
+      </p>
+
+      <h2>Fallback and retries</h2>
+      <p>
+        Fallback only triggers after all retries are exhausted. The timeline
+        shows the full sequence:
+      </p>
+      <Code
+        code={`// Timeline for a failed email with inbox fallback:
+// 1. delivery.created    — email queued
+// 2. delivery.attempt    — attempt 1 failed
+// 3. delivery.attempt    — attempt 2 failed
+// 4. delivery.attempt    — attempt 3 failed (terminal)
+// 5. delivery.failed     — email marked failed
+// 6. fallback.triggered  — fallback rule matched
+// 7. inbox.created       — fallback inbox item written`}
+        lang="plaintext"
+      />
+
+      <h2>Interactions</h2>
+      <ul>
+        <li>
+          Fallback channels respect preferences. If the fallback targets inbox
+          and the user has inbox disabled for this notification, it&apos;s skipped.
+        </li>
+        <li>
+          <code>required: true</code> notifications bypass preference checks on
+          fallback channels too.
+        </li>
+        <li>
+          Fallback deliveries appear in the timeline and are tracked like any
+          other delivery.
+        </li>
+      </ul>
+
+      <div className="page-nav">
+        <Link href="/docs/deduplication">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Dedup & idempotency</span>
+        </Link>
+        <Link href="/docs/nextjs">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Next.js</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/handler-routes/page.tsx
+++ b/docs/app/docs/handler-routes/page.tsx
@@ -1,0 +1,154 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Handler routes" };
+
+export default function HandlerRoutesPage() {
+  return (
+    <article>
+      <h1>Handler routes</h1>
+      <p>
+        The handler (<code>createHandler</code> / <code>createRouteHandler</code>)
+        exposes a REST API that the React client consumes. This page
+        documents every route.
+      </p>
+
+      <h2>Configuration</h2>
+      <Code
+        code={`import { createHandler } from "@notifykitjs/core"
+
+const handler = createHandler(notify, {
+  identify: async (request) => ({ recipientId, tenantId?, workspaceId? } | null),
+  authorize?: async (ctx, permission) => boolean,
+  unsubscribeSecret?: string,
+  cors?: string | string[],
+  protectNotifications?: boolean,
+  requestRateLimit?: { max: number; windowMs: number },
+  webhooks?: Record<string, (headers: Headers, body: string) => boolean | Promise<boolean>>,
+  onWebhookEvent?: (provider: string, payload: unknown) => void | Promise<void>,
+})`}
+      />
+
+      <h2>Inbox routes</h2>
+
+      <h3>GET /inbox</h3>
+      <p>List inbox items for the authenticated user.</p>
+      <table>
+        <thead>
+          <tr><th>Param</th><th>Type</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>?archived</code></td><td>boolean</td><td>Filter by archive state</td></tr>
+          <tr><td><code>?limit</code></td><td>number</td><td>Max items to return</td></tr>
+        </tbody>
+      </table>
+
+      <h3>POST /inbox/:id/read</h3>
+      <p>Mark an inbox item as read. Returns the updated item or 403 if it belongs to another user.</p>
+
+      <h3>POST /inbox/read-all</h3>
+      <p>Mark all inbox items as read. Returns <code>{`{ count }`}</code>.</p>
+
+      <h3>POST /inbox/:id/archive</h3>
+      <p>Archive an inbox item.</p>
+
+      <h3>POST /inbox/:id/unarchive</h3>
+      <p>Unarchive an inbox item.</p>
+
+      <h3>DELETE /inbox/:id</h3>
+      <p>Delete an inbox item permanently.</p>
+
+      <h2>Preference routes</h2>
+
+      <h3>GET /preferences</h3>
+      <p>List all preferences for the authenticated user.</p>
+
+      <h3>POST /preferences</h3>
+      <p>Update a preference.</p>
+      <Code
+        code={`// Request body:
+{
+  "notificationId": "comment_mentioned",
+  "channels": { "email": false }
+}`}
+      />
+
+      <h2>Notification metadata</h2>
+
+      <h3>GET /notifications</h3>
+      <p>
+        List registered notification definitions (id, channels, payload schema,
+        category, description). Public by default. Set{" "}
+        <code>protectNotifications: true</code> to require auth.
+      </p>
+
+      <h2>Delivery routes</h2>
+
+      <h3>GET /deliveries</h3>
+      <p>
+        List delivery records. Requires <code>deliveries.list</code>{" "}
+        permission or admin role. Non-admin users can only see their own
+        records. Sensitive fields (body, subject, to) are redacted.
+      </p>
+
+      <h2>Unsubscribe routes</h2>
+
+      <h3>GET /unsubscribe?token=...</h3>
+      <p>
+        Human click from email footer. Verifies HMAC token and renders an
+        HTML confirmation page. Flips{" "}
+        <code>preferences.channels.email = false</code> for the bound
+        (recipientId, notificationId) pair.
+      </p>
+
+      <h3>POST /unsubscribe</h3>
+      <p>
+        RFC 8058 one-click unsubscribe. Accepts token via query param, form
+        body, or JSON body. Returns a 200 HTML confirmation.
+      </p>
+
+      <h2>Realtime (SSE)</h2>
+
+      <h3>GET /events</h3>
+      <p>
+        Server-Sent Events stream for the authenticated user. Streams inbox
+        mutations in real time. The React client connects here automatically.
+      </p>
+
+      <h2>Webhook routes</h2>
+
+      <h3>POST /webhooks/:provider</h3>
+      <p>
+        Inbound webhook from email providers (delivery status updates,
+        bounces, opens, clicks). Each provider is verified by the configured
+        verifier function. Returns 401 for invalid signatures, 404 for
+        unknown providers.
+      </p>
+
+      <h2>CORS</h2>
+      <p>
+        All routes respond to <code>OPTIONS</code> with the configured CORS
+        headers when the <code>cors</code> option is set.
+      </p>
+
+      <h2>Rate limiting</h2>
+      <p>
+        When <code>requestRateLimit</code> is configured, authenticated
+        routes enforce a per-identity sliding window. Exceeding the limit
+        returns <code>429 Too Many Requests</code>.
+      </p>
+
+      <div className="page-nav">
+        <Link href="/docs/types">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">TypeScript types</span>
+        </Link>
+        <Link href="/demo">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Live demo</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/handler-routes/page.tsx
+++ b/docs/app/docs/handler-routes/page.tsx
@@ -47,7 +47,7 @@ const handler = createHandler(notify, {
       <h3>POST /inbox/:id/read</h3>
       <p>Mark an inbox item as read. Returns the updated item or 403 if it belongs to another user.</p>
 
-      <h3>POST /inbox/read-all</h3>
+      <h3>POST /inbox/mark-all-read</h3>
       <p>Mark all inbox items as read. Returns <code>{`{ count }`}</code>.</p>
 
       <h3>POST /inbox/:id/archive</h3>

--- a/docs/app/docs/hooks/page.tsx
+++ b/docs/app/docs/hooks/page.tsx
@@ -1,0 +1,186 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Hooks & observability" };
+
+export default function HooksPage() {
+  return (
+    <article>
+      <h1>Hooks &amp; observability</h1>
+      <p>
+        Every significant moment in the notification pipeline fires a hook.
+        Use them to pipe data into your metrics, audit log, error tracker,
+        or any external system.
+      </p>
+
+      <h2>Configuring hooks</h2>
+      <Code
+        code={`const notify = createNotifyKit({
+  // ...
+  on: {
+    "notification.created": ({ notification, redactedPayload }) => {
+      metrics.inc("notifications.created", {
+        notificationId: notification.notificationId,
+      })
+    },
+
+    "notification.rate_limited": ({ notificationId, recipientId, limit }) => {
+      logger.warn("rate limited", { notificationId, recipientId, limit })
+    },
+
+    "notification.deduplicated": ({ notificationId, recipientId, dedupeKey }) => {
+      logger.info("deduplicated", { notificationId, recipientId, dedupeKey })
+    },
+
+    "inbox.created": ({ inboxItem }) => {
+      metrics.inc("inbox.created")
+    },
+
+    "inbox.updated": ({ inboxItem }) => {
+      // fired on markRead, archive, unarchive
+    },
+
+    "inbox.deleted": ({ itemId, recipientId }) => {
+      audit.log("inbox.deleted", { itemId, recipientId })
+    },
+
+    "inbox.all_read": ({ recipientId, count }) => {
+      metrics.inc("inbox.mark_all_read", { count })
+    },
+
+    "delivery.sent": ({ delivery, redactedPayload }) => {
+      metrics.inc("delivery.sent", {
+        channel: delivery.channel,
+        provider: delivery.provider,
+      })
+    },
+
+    "delivery.failed": ({ delivery, error, redactedPayload }) => {
+      metrics.inc("delivery.failed", {
+        channel: delivery.channel,
+        provider: delivery.provider,
+      })
+      sentry.captureException(error, {
+        extra: { deliveryId: delivery.id, channel: delivery.channel },
+      })
+    },
+
+    "notification.suppressed": ({ notificationId, recipientId, skipped }) => {
+      // All channels were skipped — notification had no effect
+      logger.info("suppressed", { notificationId, recipientId, skipped })
+    },
+  },
+})`}
+      />
+
+      <h2>Available hooks</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Hook</th>
+            <th>Fires when</th>
+            <th>Context</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>notification.created</code></td>
+            <td>A notification record is written</td>
+            <td><code>notification</code>, <code>redactedPayload</code></td>
+          </tr>
+          <tr>
+            <td><code>notification.deduplicated</code></td>
+            <td>Send skipped by dedup</td>
+            <td><code>notificationId</code>, <code>recipientId</code>, <code>dedupeKey</code>, <code>windowMs</code></td>
+          </tr>
+          <tr>
+            <td><code>notification.rate_limited</code></td>
+            <td>Send dropped by rate limit</td>
+            <td><code>notificationId</code>, <code>recipientId</code>, <code>limit</code></td>
+          </tr>
+          <tr>
+            <td><code>notification.suppressed</code></td>
+            <td>All channels skipped</td>
+            <td><code>notificationId</code>, <code>recipientId</code>, <code>skippedChannels</code>, <code>skipped</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.created</code></td>
+            <td>Inbox item written</td>
+            <td><code>inboxItem</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.updated</code></td>
+            <td>Inbox item marked read/archived/unarchived</td>
+            <td><code>inboxItem</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.archived</code></td>
+            <td>Inbox item archived</td>
+            <td><code>inboxItem</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.unarchived</code></td>
+            <td>Inbox item unarchived</td>
+            <td><code>inboxItem</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.deleted</code></td>
+            <td>Inbox item deleted</td>
+            <td><code>itemId</code>, <code>recipientId</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.all_read</code></td>
+            <td>markAllRead() called</td>
+            <td><code>recipientId</code>, <code>count</code></td>
+          </tr>
+          <tr>
+            <td><code>delivery.sent</code></td>
+            <td>Provider confirmed delivery</td>
+            <td><code>delivery</code>, <code>redactedPayload</code></td>
+          </tr>
+          <tr>
+            <td><code>delivery.failed</code></td>
+            <td>All retries exhausted</td>
+            <td><code>delivery</code>, <code>error</code>, <code>redactedPayload</code></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Async safety</h2>
+      <p>
+        Hooks can be <code>async</code>. The engine awaits them — a slow hook
+        blocks the pipeline. For fire-and-forget behavior, don&apos;t return
+        the promise:
+      </p>
+      <Code
+        code={`on: {
+  "delivery.sent": ({ delivery }) => {
+    // Fire and forget — don't await, don't block send()
+    void analyticsClient.track("email_sent", { deliveryId: delivery.id })
+  },
+}`}
+      />
+
+      <h2>Payload redaction</h2>
+      <p>
+        Hooks that expose payload data receive <code>redactedPayload</code>{" "}
+        — a copy with sensitive fields (declared in the notification&apos;s{" "}
+        <code>redact</code> array) replaced by <code>&quot;[REDACTED]&quot;</code>.
+        This makes it safe to pipe hook data directly into external systems
+        without leaking PII.
+      </p>
+
+      <div className="page-nav">
+        <Link href="/docs/timeline">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Timeline</span>
+        </Link>
+        <Link href="/docs/api">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">API reference</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/installation/page.tsx
+++ b/docs/app/docs/installation/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Code } from "../../_components/code";
 
 export const metadata: Metadata = { title: "Installation" };
 
@@ -13,32 +14,35 @@ export default function InstallationPage() {
       </p>
 
       <h2>Starter scaffold</h2>
-      <pre>
-        <code>{`npx create-notifykit-app my-app
+      <Code
+        lang="bash"
+        code={`npx create-notifykit-app my-app
 cd my-app
 cp .env.example .env.local
-# generate a 32-byte hex secret and paste as NOTIFYKIT_SECRET
+# generate a 32-byte hex secret:
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# paste as NOTIFYKIT_SECRET in .env.local
 
 npm install
-npm run dev`}</code>
-      </pre>
+npm run dev`}
+      />
       <p>
         Open <code>http://localhost:3000</code>. Sign in as the demo user,
         send yourself a test notification, manage preferences at{" "}
         <code>/settings/notifications</code>. The scaffold uses the in-memory
-        adapter and a fake email provider so it works offline before any
-        secrets are configured.
+        adapter and a fake email provider so it works offline.
       </p>
 
       <h2>Or install into an existing Next.js app</h2>
-      <pre>
-        <code>{`npm install @notifykitjs/core @notifykitjs/next @notifykitjs/react`}</code>
-      </pre>
-      <p>A minimal setup:</p>
-      <pre>
-        <code>{`// lib/notifykit.ts
-import {
+      <Code
+        lang="bash"
+        code={`npm install @notifykitjs/core @notifykitjs/next @notifykitjs/react`}
+      />
+      <p>A minimal setup needs three files:</p>
+
+      <Code
+        filename="lib/notifykit.ts"
+        code={`import {
   channel,
   createNotifyKit,
   fakeEmailProvider,
@@ -69,11 +73,11 @@ export const notify = createNotifyKit({
     secret: process.env.NOTIFYKIT_SECRET!,
     baseUrl: "http://localhost:3000/api/notifykit",
   },
-})`}</code>
-      </pre>
-      <pre>
-        <code>{`// app/api/notifykit/[...route]/route.ts
-import { createRouteHandler } from "@notifykitjs/next"
+})`}
+      />
+      <Code
+        filename="app/api/notifykit/[...route]/route.ts"
+        code={`import { createRouteHandler } from "@notifykitjs/next"
 import { notify } from "@/lib/notifykit"
 import { getCurrentUserId } from "@/lib/session"
 
@@ -81,26 +85,11 @@ export const { GET, POST, DELETE, OPTIONS, dynamic } = createRouteHandler({
   notifykit: notify,
   identify: () => getCurrentUserId(),
   unsubscribeSecret: process.env.NOTIFYKIT_SECRET,
-})`}</code>
-      </pre>
-      <pre>
-        <code>{`// middleware.ts (optional — adds CORS for cross-origin clients)
-import { createNotifyKitMiddleware } from "@notifykitjs/next/middleware"
-import type { NextRequest } from "next/server"
-
-const withNotifyKit = createNotifyKitMiddleware({
-  cors: { origin: "https://your-app.com" },
-})
-
-export function middleware(request: NextRequest) {
-  return withNotifyKit(request)
-}
-
-export const config = { matcher: "/api/notifykit/:path*" }`}</code>
-      </pre>
-      <pre>
-        <code>{`// app/layout.tsx
-import { NotifyKitProvider } from "@notifykitjs/react"
+})`}
+      />
+      <Code
+        filename="app/layout.tsx"
+        code={`import { NotifyKitProvider } from "@notifykitjs/react"
 
 export default function RootLayout({ children }) {
   return (
@@ -112,8 +101,8 @@ export default function RootLayout({ children }) {
       </body>
     </html>
   )
-}`}</code>
-      </pre>
+}`}
+      />
 
       <h2>Requirements</h2>
       <ul>
@@ -121,7 +110,7 @@ export default function RootLayout({ children }) {
           Node 18+ or another runtime with <code>fetch</code> and
           Node-compatible <code>crypto</code> APIs.
         </li>
-        <li>TypeScript 5.0+ for the full type inference.</li>
+        <li>TypeScript 5.0+ for full type inference.</li>
         <li>
           Next.js 14+ (App Router) if you&apos;re using the handler and React
           bindings. Other frameworks work too — the handler is plain Web
@@ -129,9 +118,32 @@ export default function RootLayout({ children }) {
         </li>
       </ul>
 
-      <p>
-        Next: <Link href="/docs/defining">Defining notifications →</Link>
-      </p>
+      <h2>Packages</h2>
+      <table>
+        <thead>
+          <tr><th>Package</th><th>Purpose</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>@notifykitjs/core</code></td><td>Engine, channels, providers, types</td></tr>
+          <tr><td><code>@notifykitjs/next</code></td><td>Route handler, server actions, middleware</td></tr>
+          <tr><td><code>@notifykitjs/react</code></td><td>Hooks, components, client SDK</td></tr>
+          <tr><td><code>@notifykitjs/drizzle</code></td><td>SQLite + Postgres database adapters</td></tr>
+          <tr><td><code>@notifykitjs/resend</code></td><td>Resend email provider</td></tr>
+          <tr><td><code>@notifykitjs/realtime-pg</code></td><td>PostgreSQL NOTIFY realtime adapter</td></tr>
+          <tr><td><code>@notifykitjs/realtime-ws</code></td><td>WebSocket realtime adapter</td></tr>
+        </tbody>
+      </table>
+
+      <div className="page-nav">
+        <Link href="/">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Overview</span>
+        </Link>
+        <Link href="/docs/quickstart">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Quickstart</span>
+        </Link>
+      </div>
     </article>
   );
 }

--- a/docs/app/docs/multi-tenancy/page.tsx
+++ b/docs/app/docs/multi-tenancy/page.tsx
@@ -1,0 +1,134 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Multi-tenancy" };
+
+export default function MultiTenancyPage() {
+  return (
+    <article>
+      <h1>Multi-tenancy</h1>
+      <p>
+        NotifyKit has first-class support for multi-tenant applications.
+        Every operation can be scoped by <code>tenantId</code> (or its alias{" "}
+        <code>organizationId</code>) and <code>workspaceId</code>. Data
+        isolation is enforced at the framework level — not just by convention.
+      </p>
+
+      <h2>Scoping sends</h2>
+      <p>
+        Pass the tenant/workspace scope with every send:
+      </p>
+      <Code
+        code={`await notify.send({
+  recipientId: user.id,
+  tenantId: org.id,          // or organizationId: org.id
+  workspaceId: workspace.id, // optional
+  notificationId: "comment_mentioned",
+  payload: { actorName: "Rey", postUrl: "/posts/42" },
+})`}
+      />
+      <p>
+        The scope is stored on the notification record, inbox items, and
+        delivery rows. All subsequent reads are filtered by it.
+      </p>
+
+      <h2>Scoping the handler</h2>
+      <p>
+        In the client-facing handler, return the scope from{" "}
+        <code>identify()</code>:
+      </p>
+      <Code
+        code={`createRouteHandler({
+  notifykit: notify,
+  identify: async (request) => {
+    const session = await auth(request)
+    if (!session) return null
+
+    return {
+      recipientId: session.user.id,
+      tenantId: session.organizationId,
+      workspaceId: session.workspaceId,
+    }
+  },
+})`}
+      />
+      <p>
+        The handler enforces these scopes on every operation. A user in
+        org A cannot see inbox items or preferences belonging to org B.
+        Cross-tenant requests return <code>403</code> or filter to an empty
+        set.
+      </p>
+
+      <h2>Tenant-level preference defaults</h2>
+      <p>
+        Different tenants may want different default channel states. Use{" "}
+        <code>tenantDefaults</code> to override app-level defaults per tenant:
+      </p>
+      <Code
+        code={`const notify = createNotifyKit({
+  // ...
+  defaults: {
+    channels: { inbox: true, email: true },
+  },
+  tenantDefaults: async (tenantId) => {
+    const org = await db.query.organizations.findFirst({
+      where: eq(organizations.id, tenantId),
+    })
+    if (org?.plan === "free") {
+      return { email: false } // free plans don't get email by default
+    }
+    return null // use app defaults
+  },
+})`}
+      />
+
+      <h2>Preference resolution order</h2>
+      <p>
+        The preference engine resolves channel state through layers. Each
+        layer can override the one above it:
+      </p>
+      <ol>
+        <li><strong>App default</strong> — <code>defaults.channels</code></li>
+        <li><strong>Category default</strong> — <code>defaults.categories[cat]</code></li>
+        <li><strong>Notification default</strong> — <code>notification.defaultChannels</code></li>
+        <li><strong>Tenant setting</strong> — <code>tenantDefaults(tenantId)</code></li>
+        <li><strong>User global</strong> — user&apos;s global preference for all notifications</li>
+        <li><strong>User category</strong> — user&apos;s preference for a category</li>
+        <li><strong>User notification</strong> — user&apos;s preference for this specific notification</li>
+        <li><strong>Required override</strong> — <code>required: true</code> forces delivery</li>
+        <li><strong>Destination unavailable</strong> — no email/phone → skip</li>
+      </ol>
+
+      <h2>Scoping recipients</h2>
+      <p>
+        Recipients can belong to a tenant:
+      </p>
+      <Code
+        code={`await notify.upsertRecipient({
+  id: user.id,
+  tenantId: org.id,
+  email: user.email,
+  name: user.name,
+})`}
+      />
+      <p>
+        When a recipient has a <code>tenantId</code>, inbox items and
+        preferences are stored with that scope. This supports the common
+        pattern where one user belongs to multiple organizations with
+        separate notification state per org.
+      </p>
+
+      <div className="page-nav">
+        <Link href="/docs/providers">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Email & webhook providers</span>
+        </Link>
+        <Link href="/docs/security">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Security model</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/nextjs/page.tsx
+++ b/docs/app/docs/nextjs/page.tsx
@@ -1,0 +1,149 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Next.js" };
+
+export default function NextjsPage() {
+  return (
+    <article>
+      <h1>Next.js integration</h1>
+      <p>
+        The <code>@notifykitjs/next</code> package provides a route handler,
+        server actions, and optional middleware for CORS. It works with
+        Next.js 14+ App Router.
+      </p>
+
+      <h2>Install</h2>
+      <Code
+        lang="bash"
+        code={`npm install @notifykitjs/core @notifykitjs/next @notifykitjs/react`}
+      />
+
+      <h2>Route handler</h2>
+      <p>
+        Create a catch-all route that exposes the NotifyKit REST API for the
+        React client:
+      </p>
+      <Code
+        filename="app/api/notifykit/[...route]/route.ts"
+        code={`import { createRouteHandler } from "@notifykitjs/next"
+import { notify } from "@/lib/notifykit"
+import { auth } from "@/lib/auth"
+
+export const { GET, POST, DELETE, OPTIONS, dynamic } = createRouteHandler({
+  notifykit: notify,
+  identify: async (request) => {
+    const session = await auth(request)
+    if (!session) return null // → 401
+
+    return {
+      recipientId: session.user.id,
+      tenantId: session.organizationId,     // optional
+      workspaceId: session.workspaceId,     // optional
+    }
+  },
+  unsubscribeSecret: process.env.NOTIFYKIT_SECRET,
+})`}
+      />
+      <p>
+        The <code>identify</code> function resolves the current user from the
+        request. Return <code>null</code> to reject unauthenticated requests
+        with a 401.
+      </p>
+
+      <h2>Server actions</h2>
+      <p>
+        For tighter integration without REST calls, use server actions directly:
+      </p>
+      <Code
+        filename="lib/notifykit-actions.ts"
+        code={`import { createServerActions } from "@notifykitjs/next"
+import { notify } from "@/lib/notifykit"
+import { getSessionUserId } from "@/lib/session"
+
+export const notifyActions = createServerActions({
+  notifykit: notify,
+  identify: () => getSessionUserId(),
+})`}
+      />
+      <Code
+        filename="app/settings/notifications/page.tsx"
+        code={`import { notifyActions } from "@/lib/notifykit-actions"
+
+export default async function NotificationSettings() {
+  const preferences = await notifyActions.preferences.list()
+  // render preferences UI...
+}`}
+      />
+
+      <h2>Middleware (CORS)</h2>
+      <p>
+        When your client is on a different origin (e.g. a mobile web view
+        hitting your API):
+      </p>
+      <Code
+        filename="middleware.ts"
+        code={`import { createNotifyKitMiddleware } from "@notifykitjs/next/middleware"
+import type { NextRequest } from "next/server"
+
+const withNotifyKit = createNotifyKitMiddleware({
+  cors: { origin: "https://app.example.com" },
+})
+
+export function middleware(request: NextRequest) {
+  return withNotifyKit(request)
+}
+
+export const config = { matcher: "/api/notifykit/:path*" }`}
+      />
+
+      <h2>Provider pattern</h2>
+      <p>
+        Wrap your app in <code>NotifyKitProvider</code> to make hooks work.
+        Point it at the route handler:
+      </p>
+      <Code
+        filename="app/layout.tsx"
+        code={`import { NotifyKitProvider } from "@notifykitjs/react"
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <NotifyKitProvider options={{ baseUrl: "/api/notifykit" }}>
+          {children}
+        </NotifyKitProvider>
+      </body>
+    </html>
+  )
+}`}
+      />
+
+      <h2>Full file tree</h2>
+      <Code
+        lang="plaintext"
+        code={`app/
+├── api/notifykit/[...route]/route.ts   ← REST handler
+├── layout.tsx                          ← NotifyKitProvider
+├── inbox/page.tsx                      ← useInbox() + <Inbox />
+├── settings/notifications/page.tsx     ← usePreferences()
+lib/
+├── notifykit.ts                        ← createNotifyKit + definitions
+├── notifykit-actions.ts                ← server actions (optional)
+└── session.ts                          ← your auth helper`}
+      />
+
+      <div className="page-nav">
+        <Link href="/docs/fallbacks">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Fallback channels</span>
+        </Link>
+        <Link href="/docs/react">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">React hooks & components</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/preferences/page.tsx
+++ b/docs/app/docs/preferences/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Code } from "../../_components/code";
 
 export const metadata: Metadata = { title: "Preferences & unsubscribe" };
 
@@ -10,26 +11,28 @@ export default function PreferencesPage() {
       <p>
         Every send checks a <code>(recipientId, notificationId)</code>{" "}
         preference row before it writes to a channel. If the recipient has
-        opted out of a channel for that notification, the channel is
-        skipped and reported in <code>SendResult.skippedChannels</code>.
+        opted out, the channel is skipped and reported in{" "}
+        <code>result.skippedChannels</code>.
       </p>
 
       <h2>Reading &amp; writing preferences</h2>
-      <pre>
-        <code>{`// Server-side:
+      <Code
+        code={`// Server-side:
 await notify.preferences.update({
   recipientId: user.id,
   notificationId: "comment_mentioned",
   channels: { email: false },
 })
 
-const prefs = await notify.preferences.list(user.id)
-
-// Client-side (React):
+const prefs = await notify.preferences.list(user.id)`}
+      />
+      <Code
+        code={`// Client-side (React):
 import { usePreferences } from "@notifykitjs/react"
 
 function Settings() {
   const { items, update, isEnabled } = usePreferences()
+
   return (
     <input
       type="checkbox"
@@ -42,41 +45,55 @@ function Settings() {
       }
     />
   )
-}`}</code>
-      </pre>
+}`}
+      />
       <p>
         The React hook is optimistic — toggling the checkbox updates the UI
-        before the server confirms, and reverts on error.
+        before the server confirms, then reverts on error.
       </p>
 
       <h2>Auto-generating a preferences UI</h2>
       <p>
         The public <code>GET /api/notifykit/notifications</code> route
-        returns every registered notification&apos;s id, channels, and
-        payload schema. Drive your settings table off it — add a
-        notification in <code>lib/notifykit.ts</code> and it shows up in the
-        UI automatically:
+        returns every registered notification&apos;s ID, channels, category,
+        and payload schema. Drive your settings table off it:
       </p>
-      <pre>
-        <code>{`const meta = await client.notifications.list()
+      <Code
+        code={`const meta = await client.notifications.list()
 // [
-//   { id: "comment_mentioned", channels: ["inbox","email"], payload: {...} },
-//   { id: "order_shipped",     channels: ["email"],         payload: {...} },
-// ]`}</code>
-      </pre>
+//   { id: "comment_mentioned", channels: ["inbox","email"], category: "social" },
+//   { id: "order_shipped", channels: ["email"], category: "billing" },
+// ]`}
+      />
+      <p>
+        Add a notification in <code>lib/notifykit.ts</code> and it shows up
+        in the UI automatically.
+      </p>
+
+      <h2>Required notifications</h2>
+      <p>
+        Mark a notification as <code>required: true</code> to bypass
+        preference checks. Use for transactional notifications like password
+        resets, 2FA codes, or billing receipts:
+      </p>
+      <Code
+        code={`notification({
+  id: "password_reset",
+  payload: { resetUrl: "string" },
+  channels: [email({ subject: "Reset password", body: "{{resetUrl}}" })],
+  required: true, // always delivers regardless of preferences
+})`}
+      />
 
       <h2>Unsubscribe links</h2>
       <p>
         When you pass an <code>unsubscribe</code> config to{" "}
         <code>createNotifyKit()</code>, every email template can reference{" "}
-        <code>{`{{_unsubscribeUrl}}`}</code> and it expands to a
-        HMAC-signed URL bound to the <em>specific recipient and
-        notification</em>. The handler&apos;s <code>/unsubscribe</code> route
-        verifies the signature and flips{" "}
-        <code>preferences.channels.email = false</code>.
+        <code>{`{{_unsubscribeUrl}}`}</code>. It expands to an HMAC-signed
+        URL bound to the specific recipient and notification.
       </p>
-      <pre>
-        <code>{`createNotifyKit({
+      <Code
+        code={`createNotifyKit({
   // ...
   unsubscribe: {
     secret: process.env.NOTIFYKIT_SECRET!,
@@ -84,49 +101,66 @@ function Settings() {
   },
 })
 
-createHandler(notify, {
-  identify: getSessionUserId,
-  unsubscribeSecret: process.env.NOTIFYKIT_SECRET,
-})
-
 // In your email template:
 email({
   subject: "...",
-  body: "...\\n\\n---\\nUnsubscribe: {{_unsubscribeUrl}}",
-})`}</code>
-      </pre>
+  body: "...\\n\\nUnsubscribe: {{_unsubscribeUrl}}",
+})`}
+      />
 
-      <h3>What the route accepts</h3>
-      <ul>
+      <h3>How unsubscribe works</h3>
+      <ol>
         <li>
-          <code>GET /api/notifykit/unsubscribe?token=...</code> — human click
-          from the email footer. Returns a minimal HTML confirmation page.
+          <strong>GET /unsubscribe?token=...</strong> — Human click from email.
+          Verifies HMAC, flips <code>email: false</code>, renders a
+          confirmation page.
         </li>
         <li>
-          <code>POST /api/notifykit/unsubscribe</code> — RFC 8058 one-click
-          (mail clients). Token in query, form body, or JSON body. Returns a
-          minimal 200 confirmation page.
+          <strong>POST /unsubscribe</strong> — RFC 8058 one-click (mail client
+          header). Same verification, returns 200.
         </li>
-      </ul>
+      </ol>
 
       <h3>Security properties</h3>
       <ul>
-        <li>HMAC-SHA256, timing-safe compare.</li>
-        <li>Signature is the auth — the route bypasses <code>identify()</code>.</li>
-        <li>
-          No expiry. RFC 8058 requires unsubscribe links to keep working
-          indefinitely.
-        </li>
-        <li>
-          Per-notification granularity. Unsubscribing from{" "}
-          <code>comment_mentioned</code> doesn&apos;t kill{" "}
-          <code>password_reset</code>.
-        </li>
+        <li>HMAC-SHA256, timing-safe compare</li>
+        <li>Signature is the auth — bypasses <code>identify()</code></li>
+        <li>No expiry (RFC 8058 requirement)</li>
+        <li>Per-notification granularity — unsubscribing from one doesn&apos;t kill others</li>
       </ul>
 
+      <h2>Preference resolution layers</h2>
       <p>
-        Next: <Link href="/docs/providers">Production providers →</Link>
+        When the engine checks whether a channel should fire, it walks
+        through layers from lowest to highest priority:
       </p>
+      <ol>
+        <li>App default (<code>defaults.channels</code>)</li>
+        <li>Category default (<code>defaults.categories[cat]</code>)</li>
+        <li>Notification default (<code>notification.defaultChannels</code>)</li>
+        <li>Tenant setting (<code>tenantDefaults(tenantId)</code>)</li>
+        <li>User global preference</li>
+        <li>User category preference</li>
+        <li>User notification preference (most specific wins)</li>
+        <li>Required override (<code>required: true</code> forces delivery)</li>
+        <li>Destination unavailable (no email → skip)</li>
+      </ol>
+      <p>
+        Use <code>notify.preferences.explain()</code> to see the full
+        resolution trail for any (recipient, notification) pair. See{" "}
+        <Link href="/docs/explain">Explain &amp; dry run</Link>.
+      </p>
+
+      <div className="page-nav">
+        <Link href="/docs/channels">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Channels</span>
+        </Link>
+        <Link href="/docs/digests">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Digests & rate limits</span>
+        </Link>
+      </div>
     </article>
   );
 }

--- a/docs/app/docs/providers/page.tsx
+++ b/docs/app/docs/providers/page.tsx
@@ -1,89 +1,64 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Code } from "../../_components/code";
 
-export const metadata: Metadata = { title: "Production providers" };
+export const metadata: Metadata = { title: "Email & webhook providers" };
 
 export default function ProvidersPage() {
   return (
     <article>
-      <h1>Production providers</h1>
+      <h1>Email &amp; webhook providers</h1>
       <p>
         The zero-config defaults — memory adapter, fake email — are great
-        for getting started. For production, swap in a real database and
-        real email provider. Each is a one-line change.
+        for getting started. For production, swap in real providers. Each is
+        a one-line change.
       </p>
 
-      <h2>Database: Drizzle SQLite</h2>
-      <pre>
-        <code>{`npm install @notifykitjs/drizzle drizzle-orm better-sqlite3`}</code>
-      </pre>
-      <pre>
-        <code>{`import Database from "better-sqlite3"
-import { drizzle } from "drizzle-orm/better-sqlite3"
-import { createSqliteTables, drizzleSqliteAdapter } from "@notifykitjs/drizzle"
-
-const db = drizzle(new Database("app.db"))
-await createSqliteTables(db)  // one-off; use drizzle-kit in production
-
-export const notify = createNotifyKit({
-  // ...
-  database: drizzleSqliteAdapter(db),
-})`}</code>
-      </pre>
-      <p>
-        The exported schema (<code>notifyKitSchema</code>) lets you join
-        NotifyKit tables against your own app tables — match{" "}
-        <code>notifykit_recipients.id</code> to your{" "}
-        <code>users.id</code>.
-      </p>
-      <p>
-        Postgres is also supported. Swap the schema and adapter imports
-        from <code>sqlite</code> to <code>postgres</code> and you&apos;re
-        done. MySQL support is planned.
-      </p>
-
-      <h2>Email: Resend</h2>
-      <pre>
-        <code>{`npm install @notifykitjs/resend`}</code>
-      </pre>
-      <pre>
-        <code>{`import { resendProvider } from "@notifykitjs/resend"
+      <h2>Resend</h2>
+      <Code
+        lang="bash"
+        code={`npm install @notifykitjs/resend`}
+      />
+      <Code
+        code={`import { resendProvider } from "@notifykitjs/resend"
 
 export const notify = createNotifyKit({
   // ...
   providers: {
     email: resendProvider({
       apiKey: process.env.RESEND_API_KEY!,
-      from:   process.env.RESEND_FROM!,
-      replyTo: "support@acme.com",  // optional
+      from: process.env.RESEND_FROM!,   // "App <noreply@app.com>"
+      replyTo: "support@app.com",       // optional
     }),
   },
-})`}</code>
-      </pre>
+})`}
+      />
       <p>
-        The Resend provider uses <code>fetch</code> internally with a
-        10-second default timeout. Non-2xx responses throw, so the normal
-        retry + fallback pipeline handles them.
+        Uses <code>fetch</code> internally with a 10-second timeout.
+        Non-2xx responses throw, triggering the retry + fallback pipeline.
       </p>
 
-      <h2>Custom providers</h2>
+      <h2>Custom email provider</h2>
       <p>
-        Either interface is tiny. Wrap Postmark, SES, or any outbound HTTP
-        service in ~20 lines:
+        The <code>EmailProvider</code> interface is tiny. Wrap Postmark, SES,
+        SendGrid, or any HTTP service in ~20 lines:
       </p>
-      <pre>
-        <code>{`import type { EmailProvider } from "@notifykitjs/core"
+      <Code
+        code={`import type { EmailProvider } from "@notifykitjs/core"
 
-export function postmarkProvider(opts: { token: string; from: string }): EmailProvider {
+export function postmarkProvider(opts: {
+  token: string
+  from: string
+}): EmailProvider {
   return {
     id: "postmark",
     async send(input) {
       const res = await fetch("https://api.postmarkapp.com/email", {
         method: "POST",
         headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-          "x-postmark-server-token": opts.token,
+          "Accept": "application/json",
+          "Content-Type": "application/json",
+          "X-Postmark-Server-Token": opts.token,
         },
         body: JSON.stringify({
           From: opts.from,
@@ -97,18 +72,16 @@ export function postmarkProvider(opts: { token: string; from: string }): EmailPr
       return { providerMessageId: json.MessageID }
     },
   }
-}`}</code>
-      </pre>
+}`}
+      />
 
-      <h2>Webhook providers</h2>
+      <h2>Webhook provider</h2>
       <p>
-        The <code>webhook</code> channel ships its own provider —{" "}
-        <code>webhookProvider({"{ secret }"})</code> — that POSTs a signed
-        JSON envelope. Every channel of type <code>webhook</code> in any
-        notification uses it:
+        The webhook channel ships its own provider that POSTs a signed JSON
+        envelope:
       </p>
-      <pre>
-        <code>{`import { webhookProvider } from "@notifykitjs/core"
+      <Code
+        code={`import { webhookProvider } from "@notifykitjs/core"
 
 createNotifyKit({
   // ...
@@ -117,50 +90,110 @@ createNotifyKit({
       secret: process.env.WEBHOOK_SIGNING_SECRET,
     }),
   },
-})`}</code>
-      </pre>
+})`}
+      />
       <p>
-        Receivers verify by HMAC-SHA256-ing the raw body with the shared
-        secret. Same pattern as Stripe, GitHub, any serious webhook
-        producer.
+        Every request includes an <code>x-notifykit-signature: sha256=&lt;hex&gt;</code>{" "}
+        header. Receivers verify by HMAC-SHA256-ing the raw body with the
+        shared secret — same pattern as Stripe and GitHub.
       </p>
 
-      <h2>Queues</h2>
-      <p>
-        The default <code>inlineQueue()</code> runs deliveries synchronously
-        in <code>send()</code>. Switch to <code>setTimeoutQueue()</code> for
-        local dev async, or implement the <code>Queue</code> interface
-        against BullMQ, SQS, Cloudflare Queues, whatever you already run:
-      </p>
-      <pre>
-        <code>{`import type { Queue } from "@notifykitjs/core"
+      <h3>Verifying webhooks on the receiving end</h3>
+      <Code
+        code={`import { verifyWebhookSignature } from "@notifykitjs/core"
 
-const myQueue: Queue = {
+app.post("/webhooks/notifykit", (req, res) => {
+  const signature = req.headers["x-notifykit-signature"]
+  const valid = verifyWebhookSignature(req.rawBody, signature, SECRET)
+  if (!valid) return res.status(401).end()
+  // process the notification...
+})`}
+      />
+
+      <h2>SMS provider</h2>
+      <p>
+        Same pattern as email. Implement the <code>SmsProvider</code>{" "}
+        interface:
+      </p>
+      <Code
+        code={`import type { SmsProvider } from "@notifykitjs/core"
+
+export function twilioProvider(opts: {
+  accountSid: string
+  authToken: string
+  from: string
+}): SmsProvider {
+  return {
+    id: "twilio",
+    async send(input) {
+      const res = await fetch(
+        \`https://api.twilio.com/2010-04-01/Accounts/\${opts.accountSid}/Messages.json\`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: \`Basic \${btoa(\`\${opts.accountSid}:\${opts.authToken}\`)}\`,
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: new URLSearchParams({
+            From: opts.from,
+            To: input.to,
+            Body: input.body,
+          }),
+        },
+      )
+      if (!res.ok) throw new Error(\`Twilio: \${res.status}\`)
+      const json = await res.json() as { sid: string }
+      return { providerMessageId: json.sid }
+    },
+  }
+}`}
+      />
+
+      <h2>Queues &amp; retries</h2>
+      <p>
+        The default <code>inlineQueue()</code> runs deliveries synchronously.
+        Switch to <code>setTimeoutQueue()</code> for async, or implement the{" "}
+        <code>Queue</code> interface for BullMQ, SQS, or Cloudflare Queues:
+      </p>
+      <Code
+        code={`import type { Queue } from "@notifykitjs/core"
+
+const bullQueue: Queue = {
   async enqueue(job, run) {
-    await bullmq.add("notifykit", job, { attempts: 1 /* engine handles retries */ })
+    await queue.add("notifykit", { job, run: run.toString() })
   },
   async drain() {
-    await bullmq.drain()
+    await queue.drain()
   },
-}
-
-// Somewhere in a worker process:
-bullmq.process("notifykit", async (job) => {
-  // The engine exposes the same worker via whichever path you set up.
-  // Simplest: re-run send() handling; more advanced: call the worker
-  // function you passed to enqueue().
-})`}</code>
-      </pre>
+}`}
+      />
       <div className="callout">
-        Retries, backoff, and terminal-failure semantics live in the engine,
-        not the queue. A queue&apos;s only job is to decide <em>when</em> a
-        worker runs. This means every queue implementation gets retries and
-        fallback channels for free.
+        <strong>Retries live in the engine, not the queue.</strong> A queue&apos;s
+        only job is to decide <em>when</em> a worker runs. Every queue
+        implementation gets retries and fallback channels for free.
       </div>
 
-      <p>
-        Back to <Link href="/docs/installation">Installation</Link>.
-      </p>
+      <h2>Retry configuration</h2>
+      <Code
+        code={`createNotifyKit({
+  // ...
+  retry: {
+    maxAttempts: 5,
+    delayMs: (attempt) => Math.min(1000 * 2 ** (attempt - 1), 30_000),
+  },
+})`}
+      />
+
+      <div className="page-nav">
+        <Link href="/docs/database">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Database adapters</span>
+        </Link>
+        <Link href="/docs/multi-tenancy">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Multi-tenancy</span>
+        </Link>
+      </div>
     </article>
   );
 }

--- a/docs/app/docs/quickstart/page.tsx
+++ b/docs/app/docs/quickstart/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Quickstart" };
+
+export default function QuickstartPage() {
+  return (
+    <article>
+      <h1>Quickstart</h1>
+      <p>
+        Get a working notification system in under 5 minutes. This guide
+        uses the starter scaffold — a Next.js app with everything wired up.
+      </p>
+
+      <h2>Create the app</h2>
+      <Code
+        lang="bash"
+        code={`npx create-notifykit-app my-app
+cd my-app
+cp .env.example .env.local
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# paste the output as NOTIFYKIT_SECRET in .env.local
+npm install
+npm run dev`}
+      />
+      <p>
+        Open <code>http://localhost:3000</code>. The scaffold uses the
+        in-memory adapter and a fake email provider — everything works
+        offline.
+      </p>
+
+      <h2>What you get</h2>
+      <ul>
+        <li>A <code>lib/notifykit.ts</code> with sample notification definitions</li>
+        <li>An API route handler at <code>/api/notifykit/[...route]</code></li>
+        <li>A settings page with preferences UI</li>
+        <li>An inbox page with real-time updates</li>
+        <li>HMAC-signed unsubscribe links in emails</li>
+      </ul>
+
+      <h2>Send your first notification</h2>
+      <p>
+        From a server action, API route, or anywhere on the server:
+      </p>
+      <Code
+        code={`import { notify } from "@/lib/notifykit"
+
+await notify.upsertRecipient({
+  id: user.id,
+  email: user.email,
+  name: user.name,
+})
+
+const result = await notify.send({
+  recipientId: user.id,
+  notificationId: "welcome",
+  payload: { name: user.name },
+})
+
+console.log(result.inboxItems) // inbox row created
+console.log(result.deliveries) // email delivery record`}
+      />
+
+      <h2>Go to production</h2>
+      <p>
+        When you&apos;re ready to ship, swap three things:
+      </p>
+      <ol>
+        <li>
+          <strong>Database</strong> — replace <code>memoryAdapter()</code> with{" "}
+          <Link href="/docs/database">Drizzle SQLite or Postgres</Link>
+        </li>
+        <li>
+          <strong>Email provider</strong> — replace <code>fakeEmailProvider()</code> with{" "}
+          <Link href="/docs/providers">Resend, Postmark, or your own</Link>
+        </li>
+        <li>
+          <strong>Auth</strong> — wire your real session into <code>identify()</code> in the{" "}
+          <Link href="/docs/nextjs">route handler</Link>
+        </li>
+      </ol>
+
+      <div className="page-nav">
+        <Link href="/docs/installation">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Installation</span>
+        </Link>
+        <Link href="/docs/defining">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Defining notifications</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/quiet-hours/page.tsx
+++ b/docs/app/docs/quiet-hours/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Quiet hours" };
+
+export default function QuietHoursPage() {
+  return (
+    <article>
+      <h1>Quiet hours</h1>
+      <p>
+        Quiet hours define a daily window during which push-style channels
+        (email, SMS, webhook) defer delivery. Inbox is unaffected — it&apos;s
+        user-pulled, so the item is just there whenever they look.
+      </p>
+
+      <h2>Setting quiet hours</h2>
+      <p>
+        Quiet hours are a property of the recipient. Set them at upsert time:
+      </p>
+      <Code
+        code={`await notify.upsertRecipient({
+  id: user.id,
+  email: user.email,
+  quietHours: {
+    start: "22:00",         // HH:MM, 24h format
+    end: "08:00",           // can cross midnight
+    timezone: "America/New_York",
+  },
+})`}
+      />
+      <p>
+        To clear quiet hours, pass <code>quietHours: null</code>. Omitting
+        the field leaves the existing value unchanged.
+      </p>
+
+      <h2>How deferral works</h2>
+      <ol>
+        <li>
+          When <code>send()</code> runs, the engine checks whether the
+          current moment falls within the recipient&apos;s quiet window.
+        </li>
+        <li>
+          If so, a <code>ScheduledSend</code> row is written with{" "}
+          <code>scheduledFor</code> set to the next quiet-hours end time.
+        </li>
+        <li>
+          The inbox channel still fires immediately — only email, SMS, and
+          webhook are deferred.
+        </li>
+        <li>
+          The <code>SendResult</code> includes <code>deferredChannels</code>{" "}
+          listing what was delayed and when it will resume.
+        </li>
+      </ol>
+
+      <h2>Flushing scheduled sends</h2>
+      <p>
+        Deferred sends need something to pick them up when the window ends.
+        With <code>setTimeoutQueue()</code>, this happens automatically via
+        internal timers. For production deployments with external queues:
+      </p>
+      <Code
+        code={`// Call on a cron or interval (e.g. every minute):
+const flushed = await notify.flushScheduledSends()
+// Returns an array of SendResults for each fired scheduled send`}
+      />
+      <p>
+        The flush uses an atomic claim mechanism — multiple workers can
+        safely call it concurrently without duplicate delivery.
+      </p>
+
+      <h2>Interaction with other features</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th>Interaction</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Required notifications</td>
+            <td>Still deferred. Quiet hours override even required sends.</td>
+          </tr>
+          <tr>
+            <td>Digests</td>
+            <td>
+              Digest flush respects quiet hours. If the flush fires during
+              quiet time, the rendered notification is deferred.
+            </td>
+          </tr>
+          <tr>
+            <td>Rate limits</td>
+            <td>
+              Rate limit counts at send time, not delivery time. A deferred
+              send still consumes a rate limit slot when <code>send()</code>
+              is called.
+            </td>
+          </tr>
+          <tr>
+            <td>Explain / dry run</td>
+            <td>
+              <code>explain()</code> reports <code>quietHours.active: true</code>{" "}
+              and <code>resumesAt</code> without writing a scheduled row.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="page-nav">
+        <Link href="/docs/digests">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Digests & rate limits</span>
+        </Link>
+        <Link href="/docs/deduplication">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Dedup & idempotency</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/react/page.tsx
+++ b/docs/app/docs/react/page.tsx
@@ -1,0 +1,216 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "React hooks & components" };
+
+export default function ReactPage() {
+  return (
+    <article>
+      <h1>React hooks &amp; components</h1>
+      <p>
+        The <code>@notifykitjs/react</code> package provides hooks and
+        pre-built components for building notification UIs. Everything is
+        typed against your notification definitions.
+      </p>
+
+      <h2>Setup</h2>
+      <Code
+        lang="bash"
+        code={`npm install @notifykitjs/react`}
+      />
+      <p>
+        Wrap your app in the provider (see{" "}
+        <Link href="/docs/nextjs">Next.js integration</Link>):
+      </p>
+      <Code
+        code={`import { NotifyKitProvider } from "@notifykitjs/react"
+
+<NotifyKitProvider options={{ baseUrl: "/api/notifykit" }}>
+  {children}
+</NotifyKitProvider>`}
+      />
+
+      <h2>useInbox()</h2>
+      <p>
+        Fetches and manages the current user&apos;s inbox. Automatically
+        connects to realtime updates when a realtime adapter is configured
+        server-side.
+      </p>
+      <Code
+        code={`import { useInbox } from "@notifykitjs/react"
+
+function InboxPage() {
+  const {
+    items,           // InboxItem[]
+    status,          // "idle" | "loading" | "ready" | "error"
+    error,           // string | null
+    unreadCount,     // number
+    realtimeStatus,  // "connected" | "connecting" | "disconnected"
+    refresh,         // () => Promise<InboxItem[]>
+    markRead,        // (id: string) => Promise<InboxItem | null>
+    markAllRead,     // () => Promise<number>
+    archive,         // (id: string) => Promise<InboxItem | null>
+    unarchive,       // (id: string) => Promise<InboxItem | null>
+    deleteItem,      // (id: string) => Promise<void>
+  } = useInbox()
+
+  return (
+    <ul>
+      {items.map(item => (
+        <li key={item.id}>
+          <strong>{item.title}</strong>
+          {item.body && <p>{item.body}</p>}
+          {!item.readAt && (
+            <button onClick={() => markRead(item.id)}>Mark read</button>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}`}
+      />
+
+      <h3>Options</h3>
+      <Code
+        code={`// Disable auto-loading (useful for conditional rendering)
+const inbox = useInbox({ autoLoad: false })
+
+// Then manually load when ready:
+useEffect(() => { inbox.refresh() }, [])`}
+      />
+
+      <h2>usePreferences()</h2>
+      <p>
+        Fetches and manages the current user&apos;s notification preferences.
+        Updates are optimistic — the UI updates immediately, then reverts on
+        error.
+      </p>
+      <Code
+        code={`import { usePreferences } from "@notifykitjs/react"
+
+function NotificationSettings() {
+  const {
+    items,       // RecipientPreference[]
+    status,      // "idle" | "loading" | "ready" | "error"
+    error,       // string | null
+    refresh,     // () => Promise<RecipientPreference[]>
+    update,      // (input) => Promise<RecipientPreference>
+    isEnabled,   // (notificationId, channel) => boolean
+  } = usePreferences()
+
+  return (
+    <label>
+      <input
+        type="checkbox"
+        checked={isEnabled("comment_mentioned", "email")}
+        onChange={(e) => update({
+          notificationId: "comment_mentioned",
+          channels: { email: e.target.checked },
+        })}
+      />
+      Email me when someone mentions me
+    </label>
+  )
+}`}
+      />
+
+      <h2>Pre-built components</h2>
+
+      <h3>&lt;NotificationBell /&gt;</h3>
+      <p>Renders the unread count. Pass a custom renderer for full control:</p>
+      <Code
+        code={`import { NotificationBell } from "@notifykitjs/react"
+
+// Default: renders "(3)" when 3 unread
+<NotificationBell />
+
+// Custom:
+<NotificationBell render={({ unreadCount }) => (
+  <div className="bell-icon">
+    {unreadCount > 0 && <span className="badge">{unreadCount}</span>}
+  </div>
+)} />`}
+      />
+
+      <h3>&lt;Inbox /&gt;</h3>
+      <p>
+        Renders the full inbox list with mark-read buttons. Customize with{" "}
+        <code>renderItem</code> and <code>emptyState</code>:
+      </p>
+      <Code
+        code={`import { Inbox } from "@notifykitjs/react"
+
+<Inbox
+  emptyState={<p>You're all caught up!</p>}
+  renderItem={({ item, markRead }) => (
+    <div className="notification-card">
+      <h4>{item.title}</h4>
+      <p>{item.body}</p>
+      {item.actionUrl && <a href={item.actionUrl}>View</a>}
+      {!item.readAt && (
+        <button onClick={() => markRead(item.id)}>Dismiss</button>
+      )}
+    </div>
+  )}
+/>`}
+      />
+
+      <h2>Client SDK (advanced)</h2>
+      <p>
+        For non-React environments or custom integrations, use the client
+        directly:
+      </p>
+      <Code
+        code={`import { createNotifyKitClient } from "@notifykitjs/react"
+
+const client = createNotifyKitClient({ baseUrl: "/api/notifykit" })
+
+// Inbox operations
+const items = await client.inbox.list()
+await client.inbox.markRead(items[0].id)
+await client.inbox.markAllRead()
+await client.inbox.archive(items[0].id)
+await client.inbox.deleteItem(items[0].id)
+
+// Preferences
+const prefs = await client.preferences.list()
+await client.preferences.update({
+  notificationId: "comment_mentioned",
+  channels: { email: false },
+})
+
+// Notification metadata (for building settings UIs)
+const notifications = await client.notifications.list()
+// [{ id: "comment_mentioned", channels: ["inbox","email"], ... }]`}
+      />
+
+      <h2>Realtime</h2>
+      <p>
+        When a <Link href="/docs/realtime">realtime adapter</Link> is
+        configured server-side, <code>useInbox()</code> automatically
+        connects and receives live updates. New inbox items appear
+        instantly, and the unread count updates in real time.
+      </p>
+      <p>
+        The <code>realtimeStatus</code> field tells you the connection state:
+      </p>
+      <ul>
+        <li><code>&quot;connected&quot;</code> — receiving live updates</li>
+        <li><code>&quot;connecting&quot;</code> — handshake in progress</li>
+        <li><code>&quot;disconnected&quot;</code> — no realtime (falls back to polling on refresh)</li>
+      </ul>
+
+      <div className="page-nav">
+        <Link href="/docs/nextjs">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Next.js</span>
+        </Link>
+        <Link href="/docs/realtime">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Realtime</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/realtime/page.tsx
+++ b/docs/app/docs/realtime/page.tsx
@@ -1,0 +1,192 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Realtime" };
+
+export default function RealtimePage() {
+  return (
+    <article>
+      <h1>Realtime</h1>
+      <p>
+        NotifyKit supports real-time updates so inbox items and unread counts
+        appear instantly in the client. Three adapters are available: in-memory
+        (single process), PostgreSQL NOTIFY (multi-process), and WebSocket
+        (custom transport).
+      </p>
+
+      <h2>In-memory adapter</h2>
+      <p>
+        For single-process deployments (one Next.js server, no horizontal
+        scaling):
+      </p>
+      <Code
+        code={`import { memoryRealtimeAdapter } from "@notifykitjs/core"
+
+const notify = createNotifyKit({
+  // ...
+  realtime: memoryRealtimeAdapter(),
+})`}
+      />
+      <p>
+        Events are dispatched in-process. If you have multiple server
+        instances, each only sees events from its own sends.
+      </p>
+
+      <h2>PostgreSQL NOTIFY adapter</h2>
+      <p>
+        For multi-process deployments sharing a Postgres database. Uses
+        <code> LISTEN/NOTIFY</code> — no additional infrastructure needed.
+      </p>
+      <Code
+        lang="bash"
+        code={`npm install @notifykitjs/realtime-pg`}
+      />
+      <Code
+        code={`import { pgRealtimeAdapter } from "@notifykitjs/realtime-pg"
+import { Pool } from "pg"
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+
+// The adapter needs a dedicated connection for LISTEN
+const listenClient = await pool.connect()
+
+const realtime = pgRealtimeAdapter({
+  connection: {
+    listen: (channel, handler) => {
+      listenClient.on("notification", (msg) => {
+        if (msg.channel === channel) handler(msg.payload!)
+      })
+      return listenClient.query(\`LISTEN \${channel}\`)
+    },
+    unlisten: (channel) => listenClient.query(\`UNLISTEN \${channel}\`),
+    notify: (channel, payload) =>
+      pool.query("SELECT pg_notify($1, $2)", [channel, payload]),
+  },
+  heartbeatMs: 60_000, // detect dead connections
+  onError: (err) => console.error("realtime error:", err),
+})
+
+await realtime.start()
+
+const notify = createNotifyKit({
+  // ...
+  realtime,
+})`}
+      />
+      <div className="callout callout-warn">
+        <strong>8KB limit.</strong> PostgreSQL NOTIFY payloads are limited to
+        ~8KB. If an event exceeds this (e.g. a large inbox item body), the
+        adapter automatically falls back to sending an{" "}
+        <code>inbox.refetch</code> event that tells clients to re-fetch.
+      </div>
+
+      <h2>WebSocket adapter</h2>
+      <p>
+        For custom transports or when you need fine-grained control over
+        connections:
+      </p>
+      <Code
+        lang="bash"
+        code={`npm install @notifykitjs/realtime-ws`}
+      />
+      <Code
+        code={`import { webSocketRealtimeAdapter } from "@notifykitjs/realtime-ws"
+
+const realtime = webSocketRealtimeAdapter({
+  authenticate: async (request) => {
+    const token = new URL(request.url).searchParams.get("token")
+    const session = await verifyToken(token)
+    if (!session) return null
+    return {
+      recipientId: session.userId,
+      tenantId: session.orgId,
+    }
+  },
+  allowedOrigins: ["https://app.example.com"],
+  heartbeatMs: 30_000,
+  maxConnections: 10_000,
+})`}
+      />
+
+      <h3>Handling connections</h3>
+      <Code
+        code={`// In your WebSocket server (e.g. with Bun, Node ws, or Deno):
+server.on("upgrade", async (request, ws) => {
+  const identity = await realtime.handleUpgrade(request, ws)
+  if (!identity) {
+    ws.close(4001, "Unauthorized")
+    return
+  }
+
+  ws.on("message", (data) => realtime.handleMessage(ws, data.toString()))
+  ws.on("close", () => realtime.handleClose(ws))
+})`}
+      />
+
+      <h2>How it works</h2>
+      <ol>
+        <li>
+          When an inbox mutation occurs (create, read, archive, delete), the
+          engine calls <code>realtime.publish(recipientId, scope, event)</code>.
+        </li>
+        <li>
+          The adapter delivers the event to all listeners subscribed to that
+          (recipientId, scope) pair.
+        </li>
+        <li>
+          The handler&apos;s SSE route (<code>GET /api/notifykit/events</code>)
+          subscribes on behalf of the authenticated user and streams events
+          to the browser.
+        </li>
+        <li>
+          The React client (<code>useInbox()</code>) connects to this SSE
+          endpoint and updates state as events arrive.
+        </li>
+      </ol>
+
+      <h2>Event types</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Payload</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>inbox.created</code></td>
+            <td>The new <code>InboxItem</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.updated</code></td>
+            <td>The updated <code>InboxItem</code> (read, archived, etc.)</td>
+          </tr>
+          <tr>
+            <td><code>inbox.deleted</code></td>
+            <td><code>{`{ itemId }`}</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.all_read</code></td>
+            <td><code>{`{ count }`}</code></td>
+          </tr>
+          <tr>
+            <td><code>inbox.refetch</code></td>
+            <td>Empty — client should re-fetch the full list</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="page-nav">
+        <Link href="/docs/react">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">React hooks & components</span>
+        </Link>
+        <Link href="/docs/database">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Database adapters</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/security/page.tsx
+++ b/docs/app/docs/security/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Code } from "../../_components/code";
 
 export const metadata: Metadata = { title: "Security model" };
 
@@ -14,320 +15,155 @@ export default function SecurityPage() {
         contract.
       </p>
 
-      <h2 id="client-safe-routes">Client-safe routes</h2>
+      <h2>Client-safe routes</h2>
       <p>
         Browser clients <strong>never</strong> pass{" "}
         <code>recipientId</code>. Every client-facing route resolves the
         current user through your <code>identify()</code> callback. Any{" "}
         <code>recipientId</code>, <code>tenantId</code>, or{" "}
-        <code>workspaceId</code> included in the request body is{" "}
-        <strong>ignored</strong>.
+        <code>workspaceId</code> in the request body is <strong>ignored</strong>.
       </p>
-      <pre>
-        <code>{`createHandler(notify, {
+      <Code
+        code={`createHandler(notify, {
   identify: async (request) => {
     const session = await auth(request)
-    if (!session) return null          // → 401
+    if (!session) return null // → 401
 
     return {
-      recipientId: session.user.id,    // bound to every route
-      tenantId: session.orgId,         // scopes reads & writes
+      recipientId: session.user.id,
+      tenantId: session.orgId,
       workspaceId: session.workspaceId,
     }
   },
-})`}</code>
-      </pre>
+})`}
+      />
 
-      <h3>Route summary</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Route</th>
-            <th>Auth</th>
-            <th>Scoped by</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <code>GET /inbox</code>
-            </td>
-            <td>
-              <code>identify()</code>
-            </td>
-            <td>recipientId + tenant/workspace</td>
-          </tr>
-          <tr>
-            <td>
-              <code>POST /inbox/:id/read</code>
-            </td>
-            <td>
-              <code>identify()</code>
-            </td>
-            <td>
-              recipientId + tenant/workspace (returns <code>403</code> for
-              another user&rsquo;s or tenant&rsquo;s item)
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>GET /preferences</code>
-            </td>
-            <td>
-              <code>identify()</code>
-            </td>
-            <td>recipientId + tenant/workspace</td>
-          </tr>
-          <tr>
-            <td>
-              <code>POST /preferences</code>
-            </td>
-            <td>
-              <code>identify()</code>
-            </td>
-            <td>recipientId + tenant/workspace (ignores body ids)</td>
-          </tr>
-          <tr>
-            <td>
-              <code>GET /deliveries</code>
-            </td>
-            <td>
-              <code>identify()</code> + permission
-            </td>
-            <td>
-              recipientId (own only) + tenant/workspace; admin can query others;
-              sensitive fields redacted
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <code>GET /notifications</code>
-            </td>
-            <td>None (public metadata)</td>
-            <td>&mdash;</td>
-          </tr>
-          <tr>
-            <td>
-              <code>GET|POST /unsubscribe</code>
-            </td>
-            <td>HMAC token</td>
-            <td>Embedded in signed token</td>
-          </tr>
-          <tr>
-            <td>
-              <code>POST /webhooks/:provider</code>
-            </td>
-            <td>Provider signature verifier</td>
-            <td>&mdash; (provider-scoped)</td>
-          </tr>
-        </tbody>
-      </table>
+      <h2>Tenant &amp; workspace isolation</h2>
+      <p>
+        When <code>identify()</code> returns a scope, NotifyKit applies it to
+        every database query in the request. Cross-tenant reads and writes
+        return <code>403 Forbidden</code> or filter to an empty set.
+      </p>
+      <ul>
+        <li>Inbox reads and mutations — scoped</li>
+        <li>Preference reads and writes — scoped</li>
+        <li>Delivery logs — scoped</li>
+        <li>Realtime events — scoped (only receive events for your scope)</li>
+      </ul>
 
-      <h2 id="tenant-workspace-isolation">Tenant &amp; workspace isolation</h2>
+      <h2>Authorization</h2>
       <p>
-        When <code>identify()</code> returns a <code>tenantId</code> or{" "}
-        <code>workspaceId</code>, NotifyKit applies that scope to every
-        database query in the request. Inbox reads, inbox mutations,
-        preference reads/writes, and delivery logs are all filtered by the
-        authenticated scope. Cross-tenant reads and writes return{" "}
-        <code>403 Forbidden</code> or filter to an empty set.
+        Some routes require explicit permission. Configure with{" "}
+        <code>authorize</code> or return a <code>permissions</code> array
+        from <code>identify()</code>:
       </p>
-
-      <h2 id="server-admin-routes">Server and admin routes</h2>
-      <p>
-        Server-side calls such as <code>notify.send()</code>,{" "}
-        <code>notify.deliveries.list()</code>, and{" "}
-        <code>notify.inbox.markReadForRecipient()</code> may pass explicit recipient and
-        scope ids because they run in trusted code.
-      </p>
-      <p>
-        Handler routes that expose operational data (currently{" "}
-        <code>deliveries.list</code>) require explicit permission:
-      </p>
-      <pre>
-        <code>{`createHandler(notify, {
-  identify: getIdentity,
+      <Code
+        code={`createHandler(notify, {
+  identify: async (request) => {
+    const session = await auth(request)
+    if (!session) return null
+    return {
+      recipientId: session.user.id,
+      tenantId: session.orgId,
+      permissions: session.role === "admin" ? ["admin"] : [],
+    }
+  },
+  // Or use the authorize hook for dynamic checks:
   authorize: async (ctx, permission) => {
     if (permission === "deliveries.list") {
-      return await canViewNotificationLogs(ctx.recipientId, ctx.tenantId)
+      return ctx.permissions?.includes("admin") ?? false
     }
     return false
   },
-})`}</code>
-      </pre>
+})`}
+      />
+
+      <h2>Delivery record redaction</h2>
       <p>
-        Without <code>authorize</code>, an identity can still opt in by
-        returning <code>permissions: [&quot;deliveries.list&quot;]</code> or{" "}
-        <code>permissions: [&quot;admin&quot;]</code> from{" "}
-        <code>identify()</code>. When the <code>authorize</code> hook is set,
-        it takes precedence over the <code>permissions</code> array.
+        The <code>GET /deliveries</code> handler strips sensitive fields
+        (body, subject, to) before returning records. Server-side{" "}
+        <code>notify.deliveries.list()</code> returns full records because
+        it runs in trusted code.
       </p>
 
-      <h2 id="delivery-redaction">Delivery record redaction</h2>
+      <h2>Payload field redaction</h2>
       <p>
-        The <code>GET /deliveries</code> handler redacts sensitive fields from
-        delivery records before returning them. The <code>body</code> (email
-        content, which may contain unsubscribe tokens), <code>subject</code>,
-        and <code>to</code> (email addresses or webhook URLs) fields are
-        stripped. Server-side <code>notify.deliveries.list()</code> returns
-        full records because it runs in trusted code.
+        Notification definitions can declare sensitive fields that get masked
+        in logs and external surfaces:
       </p>
-
-      <h2 id="payload-redaction">Payload field redaction</h2>
-      <p>
-        Notification definitions can declare a <code>redact</code> array listing
-        payload field names that contain sensitive data (PII, secrets, tokens).
-        Use <code>notify.redactPayload(notificationId, payload)</code> to
-        produce a copy with those fields replaced by{" "}
-        <code>&quot;[REDACTED]&quot;</code>. This is intended for delivery logs,
-        timeline views, studio surfaces, and analytics — the full payload is
-        still stored on the notification record for server-side rendering.
-      </p>
-      <pre>
-        <code>{`notification({
+      <Code
+        code={`notification({
   id: "password_changed",
   payload: { email: "string", ip: "string" },
   channels: [inbox({ title: "Password changed from {{ip}}" })],
-  redact: ["email", "ip"],  // ← fields to mask in logs
-})`}</code>
-      </pre>
+  redact: ["email", "ip"],
+})
 
-      <h2 id="unsubscribe-links">Unsubscribe links</h2>
-      <p>
-        Unsubscribe links are HMAC-SHA256 signed tokens that bind a recipient,
-        notification, and tenant/workspace scope. The route bypasses{" "}
-        <code>identify()</code> because the cryptographic signature serves as
-        authorization. Tokens use timing-safe comparison and cannot be forged
-        without the secret.
-      </p>
-      <p>
-        <strong>No expiry by design.</strong> Per RFC 8058, email unsubscribe
-        links must continue to work indefinitely. This means a leaked token
-        permanently grants the ability to toggle email preferences for the
-        bound recipient + notification pair. Rotate the{" "}
-        <code>unsubscribe.secret</code> if you believe tokens have been
-        compromised — this invalidates all existing links.
-      </p>
+// In hooks, timeline, and delivery logs:
+// { email: "[REDACTED]", ip: "[REDACTED]" }`}
+      />
+
+      <h2>Unsubscribe link security</h2>
       <ul>
-        <li>
-          <strong>GET</strong>: Renders an HTML confirmation page.
-        </li>
-        <li>
-          <strong>POST</strong>: RFC 8058 one-click unsubscribe. Accepts query
-          param, form body, or JSON body.
-        </li>
+        <li>HMAC-SHA256 signed, timing-safe compare</li>
+        <li>Bound to (recipientId, notificationId, tenantId) — can&apos;t reuse across users</li>
+        <li>Bypasses <code>identify()</code> — the signature is the auth</li>
+        <li>No expiry (RFC 8058 requirement)</li>
+        <li>Rotate <code>unsubscribe.secret</code> to invalidate all links if compromised</li>
       </ul>
 
-      <h2 id="webhook-verification">Webhook provider signatures</h2>
+      <h2>Webhook signatures</h2>
       <p>
-        When a <code>secret</code> is configured on the webhook provider, every
-        outgoing webhook request includes an{" "}
-        <code>x-notifykit-signature: sha256=&lt;hex&gt;</code> header computed
-        over the JSON body. Recipients can verify this signature to confirm the
-        request originated from NotifyKit.
+        Outgoing: <code>x-notifykit-signature: sha256=&lt;hex&gt;</code> header
+        on every webhook delivery (when a secret is configured).
+      </p>
+      <p>
+        Incoming: provider webhooks are verified by the configured verifier
+        function before processing.
       </p>
 
-      <h2 id="client-sdk">Client SDK</h2>
+      <h2>Client SDK</h2>
       <p>
-        The React client SDK (<code>createNotifyKitClient</code>) does{" "}
-        <strong>not</strong> accept <code>recipientId</code> on any method.
-        Inbox and preference operations rely entirely on the server handler to
-        resolve the user via <code>identify()</code>. This makes it impossible
-        for client code to read or modify another user&rsquo;s data.
+        The React client SDK does <strong>not</strong> accept{" "}
+        <code>recipientId</code> on any method. All operations rely on the
+        server handler to resolve the user. This makes it impossible for
+        client code to read or modify another user&apos;s data.
       </p>
 
-      <h2 id="notifications-visibility">Notification metadata visibility</h2>
-      <p>
-        By default, <code>GET /notifications</code> is public — it returns
-        notification IDs, channels, and payload schemas without authentication.
-        If your notification IDs or categories are sensitive, set{" "}
-        <code>protectNotifications: true</code> to require{" "}
-        <code>identify()</code> for this route:
-      </p>
-      <pre>
-        <code>{`createHandler(notify, {
-  identify: getIdentity,
-  protectNotifications: true,  // now requires auth
-})`}</code>
-      </pre>
-
-      <h2 id="cors">CORS</h2>
-      <p>
-        When the handler is served from a different origin than the client app,
-        set the <code>cors</code> option to include the appropriate{" "}
-        <code>Access-Control-Allow-Origin</code> headers on every response:
-      </p>
-      <pre>
-        <code>{`createHandler(notify, {
-  identify: getIdentity,
-  cors: "https://app.example.com",
-})`}</code>
-      </pre>
-
-      <h2 id="rate-limiting">Rate limiting</h2>
-      <p>
-        NotifyKit&rsquo;s built-in <code>rateLimit</code> controls the rate at
-        which <em>notifications are sent</em>. For request-level throttling on
-        handler routes, use the <code>requestRateLimit</code> option:
-      </p>
-      <pre>
-        <code>{`createHandler(notify, {
+      <h2>Request rate limiting</h2>
+      <Code
+        code={`createHandler(notify, {
   identify: getIdentity,
   requestRateLimit: {
-    max: 60,        // max requests per window per identity
-    windowMs: 60_000, // sliding window in ms
+    max: 60,          // per identity
+    windowMs: 60_000, // sliding window
   },
-})`}</code>
-      </pre>
+})`}
+      />
       <p>
-        Each authenticated <code>recipientId</code> gets an independent
-        sliding-window counter. When the limit is exceeded, the handler returns{" "}
-        <code>429 Too Many Requests</code>. Unauthenticated routes (
-        <code>/notifications</code>, <code>/unsubscribe</code>) are not
-        throttled by this mechanism &mdash; apply IP-based rate limiting at your
-        reverse proxy or API gateway for those.
+        Returns <code>429 Too Many Requests</code> when exceeded.
+        Unauthenticated routes (notifications, unsubscribe) are not throttled
+        — apply IP-based rate limiting at your reverse proxy.
       </p>
 
-      <h2 id="deliveries-admin-scoping">Delivery log scoping</h2>
-      <p>
-        Non-admin users with the <code>deliveries.list</code> permission can
-        only see their own delivery records. The{" "}
-        <code>?recipientId=</code> query parameter is ignored for non-admin
-        callers. Only identities with <code>permissions: [&quot;admin&quot;]</code>{" "}
-        can query other recipients&rsquo; deliveries within the same
-        tenant/workspace scope.
-      </p>
-
-      <h2 id="inbound-webhooks">Inbound provider webhooks</h2>
-      <p>
-        To receive delivery status callbacks from email providers (e.g. Resend,
-        SendGrid), configure the <code>webhooks</code> option with a verifier
-        per provider:
-      </p>
-      <pre>
-        <code>{`createHandler(notify, {
+      <h2>CORS</h2>
+      <Code
+        code={`createHandler(notify, {
   identify: getIdentity,
-  webhooks: {
-    resend: (headers, rawBody) =>
-      verifyResendSignature(headers, rawBody, RESEND_SIGNING_SECRET),
-  },
-  onWebhookEvent: async (provider, payload) => {
-    // Update delivery status, trigger follow-up workflows, etc.
-  },
-})`}</code>
-      </pre>
-      <p>
-        Each provider gets a <code>POST /webhooks/:provider</code> route. The
-        verifier receives the request <code>Headers</code> and raw body string;
-        it must return <code>true</code> for authentic requests. Unverified
-        requests receive <code>401</code>. Unknown provider names return{" "}
-        <code>404</code>. Webhook routes bypass <code>identify()</code> — the
-        cryptographic signature serves as authorization.
-      </p>
+  cors: "https://app.example.com", // or string[]
+})`}
+      />
 
-      <p>
-        Next: <Link href="/docs/providers">Production providers &rarr;</Link>
-      </p>
+      <div className="page-nav">
+        <Link href="/docs/multi-tenancy">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Multi-tenancy</span>
+        </Link>
+        <Link href="/docs/explain">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Explain & dry run</span>
+        </Link>
+      </div>
     </article>
   );
 }

--- a/docs/app/docs/sending/page.tsx
+++ b/docs/app/docs/sending/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { Code } from "../../_components/code";
 
 export const metadata: Metadata = { title: "Sending" };
 
@@ -14,8 +15,8 @@ export default function SendingPage() {
       </p>
 
       <h2>Basic send</h2>
-      <pre>
-        <code>{`await notify.upsertRecipient({
+      <Code
+        code={`await notify.upsertRecipient({
   id: user.id,
   email: user.email,
   name: user.name,
@@ -29,44 +30,34 @@ const result = await notify.send({
     postTitle: "Launch Plan",
     postUrl: "/posts/42",
   },
-})`}</code>
-      </pre>
+})`}
+      />
+
+      <h2>SendResult</h2>
       <p>
-        <code>result</code> tells you exactly what happened:
+        The result tells you exactly what happened:
       </p>
-      <ul>
-        <li>
-          <code>notification</code> — the created notification record, or{" "}
-          <code>null</code> if the send was buffered or rate-limited.
-        </li>
-        <li>
-          <code>inboxItems</code> — inbox rows that were written.
-        </li>
-        <li>
-          <code>deliveries</code> — email/webhook delivery rows. When using
-          the inline queue (default) their status is already{" "}
-          <code>&quot;sent&quot;</code> or <code>&quot;failed&quot;</code>; with an async
-          queue they&apos;re still <code>&quot;pending&quot;</code>.
-        </li>
-        <li>
-          <code>skippedChannels</code> — channels skipped by preferences.
-        </li>
-        <li>
-          <code>deferredChannels</code> — channels deferred by quiet hours.
-        </li>
-        <li>
-          <code>digested</code>, <code>rateLimited</code> — boolean flags for
-          the two interceptor outcomes.
-        </li>
-      </ul>
+      <Code
+        code={`type SendResult = {
+  notification: NotificationRecord | null  // null if buffered/rate-limited
+  inboxItems: InboxItem[]                  // inbox rows written
+  deliveries: DeliveryRecord[]             // email/webhook/sms delivery records
+  skippedChannels: SkippedDelivery[]       // channels skipped by preferences
+  deferredChannels: Array<{ channel; resumesAt }> // quiet hours deferrals
+  digested: boolean                        // true if buffered into digest
+  rateLimited: boolean                     // true if rate limit hit
+  deduplicated: boolean                    // true if dedup key matched
+  idempotentReplay: boolean                // true if idempotency key matched
+}`}
+      />
 
       <h2>Type safety</h2>
-      <p>These all fail at <em>compile time</em>, not at runtime:</p>
-      <pre>
-        <code>{`// ❌ Unknown notification id
+      <p>These fail at <em>compile time</em>, not at runtime:</p>
+      <Code
+        code={`// ❌ Unknown notification id
 await notify.send({
   recipientId: "u_1",
-  notificationId: "wrong_id",  // error: not assignable
+  notificationId: "wrong_id",  // TS error: not assignable
   payload: {},
 })
 
@@ -74,19 +65,18 @@ await notify.send({
 await notify.send({
   recipientId: "u_1",
   notificationId: "comment_mentioned",
-  payload: { actorName: 42 },  // error: number is not a string
-})`}</code>
-      </pre>
+  payload: { actorName: 42 },  // TS error: number is not string
+})`}
+      />
 
       <h2>Inline vs async queue</h2>
       <p>
-        By default <code>send()</code> runs provider deliveries
-        synchronously (same as your API route). Swap in{" "}
-        <code>setTimeoutQueue()</code> — or your own — to return from{" "}
-        <code>send()</code> instantly and have deliveries run later.
+        By default, <code>send()</code> runs provider deliveries
+        synchronously. Swap in <code>setTimeoutQueue()</code> — or your own
+        — to return instantly and run deliveries later.
       </p>
-      <pre>
-        <code>{`import { setTimeoutQueue } from "@notifykitjs/core"
+      <Code
+        code={`import { setTimeoutQueue } from "@notifykitjs/core"
 
 const notify = createNotifyKit({
   // ...
@@ -95,54 +85,61 @@ const notify = createNotifyKit({
 })
 
 // Wait for in-flight jobs before shutdown:
-await notify.drain()`}</code>
-      </pre>
+await notify.drain()`}
+      />
 
-      <h2>Hooks: observability</h2>
+      <h2>Event hooks</h2>
       <p>
-        Every interesting moment fires a hook. Pipe them to your metrics or
-        audit log.
+        Every interesting moment fires a hook. See{" "}
+        <Link href="/docs/hooks">Hooks &amp; observability</Link> for the
+        full list.
       </p>
-      <pre>
-        <code>{`createNotifyKit({
+      <Code
+        code={`createNotifyKit({
   // ...
   on: {
-    "notification.created": ({ notification }) => log("created", notification.id),
-    "notification.rate_limited": ({ notificationId, recipientId }) =>
-      metrics.inc("notifications.rate_limited", { notificationId, recipientId }),
-    "inbox.created":    ({ inboxItem }) => log("inbox", inboxItem.id),
-    "delivery.sent":    ({ delivery }) => metrics.inc("email.sent"),
-    "delivery.failed":  ({ delivery, error }) => log.error("email.failed", { delivery, error }),
+    "notification.created": ({ notification }) =>
+      metrics.inc("notifications.created"),
+    "delivery.sent": ({ delivery }) =>
+      metrics.inc("delivery.sent", { channel: delivery.channel }),
+    "delivery.failed": ({ delivery, error }) =>
+      sentry.captureException(error),
   },
-})`}</code>
-      </pre>
+})`}
+      />
 
       <h2>Quiet hours</h2>
       <p>
-        Attach to a recipient. Inbox still delivers immediately (it&apos;s
-        user-pulled, not push). Email, SMS, and webhook defer until the window
-        ends.
+        Recipients with quiet hours configured get push-style channels
+        (email, SMS, webhook) deferred until the window ends. Inbox still
+        delivers immediately.
       </p>
-      <pre>
-        <code>{`await notify.upsertRecipient({
+      <Code
+        code={`await notify.upsertRecipient({
   id: user.id,
   email: user.email,
   quietHours: {
     start: "22:00",
-    end:   "08:00",
+    end: "08:00",
     timezone: "America/New_York",
   },
-})`}</code>
-      </pre>
+})`}
+      />
       <p>
-        <code>notify.flushScheduledSends()</code> forces pending deferrals
-        to fire now — useful for tests and for an admin &quot;send now&quot;
-        button.
+        See <Link href="/docs/quiet-hours">Quiet hours</Link> for details on
+        flushing scheduled sends.
       </p>
 
-      <p>
-        Next: <Link href="/docs/preferences">Preferences &amp; unsubscribe →</Link>
-      </p>
+      <div className="page-nav">
+        <Link href="/docs/defining">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Defining notifications</span>
+        </Link>
+        <Link href="/docs/channels">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Channels</span>
+        </Link>
+      </div>
     </article>
   );
 }

--- a/docs/app/docs/sending/page.tsx
+++ b/docs/app/docs/sending/page.tsx
@@ -39,15 +39,15 @@ const result = await notify.send({
       </p>
       <Code
         code={`type SendResult = {
-  notification: NotificationRecord | null  // null if buffered/rate-limited
+  notification: NotificationRecord | null  // null if digested
   inboxItems: InboxItem[]                  // inbox rows written
-  deliveries: DeliveryRecord[]             // email/webhook/sms delivery records
-  skippedChannels: SkippedDelivery[]       // channels skipped by preferences
-  deferredChannels: Array<{ channel; resumesAt }> // quiet hours deferrals
+  deliveries: DeliveryRecord[]             // all deliveries incl. skipped
+  skippedChannels: ChannelType[]           // deprecated — use skipped[]
+  skipped: SkippedDelivery[]               // channels skipped with reasons
+  deferredChannels: ChannelType[]          // quiet hours deferrals
   digested: boolean                        // true if buffered into digest
   rateLimited: boolean                     // true if rate limit hit
-  deduplicated: boolean                    // true if dedup key matched
-  idempotentReplay: boolean                // true if idempotency key matched
+  idempotent: boolean                      // true if idempotency key matched
 }`}
       />
 

--- a/docs/app/docs/timeline/page.tsx
+++ b/docs/app/docs/timeline/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "Timeline" };
+
+export default function TimelinePage() {
+  return (
+    <article>
+      <h1>Timeline</h1>
+      <p>
+        Every notification gets a debug timeline — a chronological log of
+        every significant event from payload validation through final
+        delivery. Use it to understand exactly what happened and why.
+      </p>
+
+      <h2>Enabling timeline</h2>
+      <p>
+        Timeline requires the <code>timeline</code> section in your database
+        adapter. The Drizzle adapters include it by default. The memory
+        adapter also supports it out of the box.
+      </p>
+      <p>
+        No additional configuration is needed — timeline events are
+        automatically recorded during every <code>send()</code>.
+      </p>
+
+      <h2>Reading the timeline</h2>
+      <Code
+        code={`// Get timeline for a specific notification send
+const events = await notify.timeline.list(notificationRecordId)
+
+// Get timeline for a specific delivery
+const deliveryEvents = await notify.timeline.listByDelivery(deliveryId)
+
+// Example output:
+// [
+//   { event: "payload.validated", message: "All 3 fields valid" },
+//   { event: "recipient.resolved", message: "Recipient user_123 found" },
+//   { event: "preferences.resolved", message: "inbox: allowed, email: allowed" },
+//   { event: "inbox.created", message: "Inbox item inb_abc created" },
+//   { event: "delivery.created", message: "Email delivery del_xyz queued" },
+//   { event: "delivery.attempt", message: "Attempt 1 via resend" },
+//   { event: "delivery.sent", message: "Sent via resend (msg_id: ...)" },
+// ]`}
+      />
+
+      <h2>Event types</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>When</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>payload.validated</code></td>
+            <td>Payload passes schema validation</td>
+          </tr>
+          <tr>
+            <td><code>recipient.resolved</code></td>
+            <td>Recipient found in database</td>
+          </tr>
+          <tr>
+            <td><code>preferences.resolved</code></td>
+            <td>Channel preferences evaluated</td>
+          </tr>
+          <tr>
+            <td><code>idempotent.replay</code></td>
+            <td>Send matched an existing idempotency key</td>
+          </tr>
+          <tr>
+            <td><code>deduplicated</code></td>
+            <td>Send matched an existing dedup key</td>
+          </tr>
+          <tr>
+            <td><code>rate_limited</code></td>
+            <td>Send exceeded rate limit</td>
+          </tr>
+          <tr>
+            <td><code>quiet_hours.deferred</code></td>
+            <td>Delivery deferred to quiet hours end</td>
+          </tr>
+          <tr>
+            <td><code>inbox.created</code></td>
+            <td>Inbox item written</td>
+          </tr>
+          <tr>
+            <td><code>delivery.created</code></td>
+            <td>Delivery record queued</td>
+          </tr>
+          <tr>
+            <td><code>delivery.attempt</code></td>
+            <td>Provider call attempted</td>
+          </tr>
+          <tr>
+            <td><code>delivery.sent</code></td>
+            <td>Provider confirmed delivery</td>
+          </tr>
+          <tr>
+            <td><code>delivery.failed</code></td>
+            <td>All retries exhausted</td>
+          </tr>
+          <tr>
+            <td><code>provider.message_id_stored</code></td>
+            <td>Provider message ID recorded</td>
+          </tr>
+          <tr>
+            <td><code>provider.error</code></td>
+            <td>Provider returned an error (before retry)</td>
+          </tr>
+          <tr>
+            <td><code>fallback.triggered</code></td>
+            <td>Fallback rule activated</td>
+          </tr>
+          <tr>
+            <td><code>channel.skipped</code></td>
+            <td>Channel skipped (preferences, missing address)</td>
+          </tr>
+          <tr>
+            <td><code>notification.suppressed</code></td>
+            <td>All channels skipped — notification was suppressed</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Timeline event structure</h2>
+      <Code
+        code={`type TimelineEvent = {
+  id: string
+  seq: number                    // ordering within a batch
+  notificationRecordId: string
+  deliveryId?: string            // set for delivery-specific events
+  recipientId: string
+  tenantId?: string
+  workspaceId?: string
+  notificationId: string
+  channel?: ChannelType          // "inbox" | "email" | "sms" | "webhook"
+  provider?: string              // "resend", "twilio", etc.
+  event: TimelineEventType
+  message: string                // human-readable description
+  metadata?: Record<string, unknown>
+  timestamp: Date
+}`}
+      />
+
+      <h2>Pruning old events</h2>
+      <p>
+        Timeline events accumulate over time. Prune them periodically:
+      </p>
+      <Code
+        code={`// Delete events older than 30 days
+const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60_000)
+const deleted = await notify.timeline.prune(thirtyDaysAgo)
+console.log(\`Pruned \${deleted} timeline events\`)`}
+      />
+
+      <div className="page-nav">
+        <Link href="/docs/explain">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">Explain & dry run</span>
+        </Link>
+        <Link href="/docs/hooks">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Hooks & observability</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/docs/types/page.tsx
+++ b/docs/app/docs/types/page.tsx
@@ -1,0 +1,230 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Code } from "../../_components/code";
+
+export const metadata: Metadata = { title: "TypeScript types" };
+
+export default function TypesPage() {
+  return (
+    <article>
+      <h1>TypeScript types</h1>
+      <p>
+        All types are exported from <code>@notifykitjs/core</code>. This
+        page documents the most commonly referenced ones.
+      </p>
+
+      <h2>NotificationDefinition</h2>
+      <Code
+        code={`type NotificationDefinition<Id extends string, S extends PayloadSchema> = {
+  id: Id
+  payload: S
+  channels: ChannelConfig[]
+  digest?: DigestConfig<S>
+  rateLimit?: RateLimitConfig
+  fallback?: InboxChannelConfig | FallbackRule[]
+  description?: string
+  category?: string
+  version?: number
+  redact?: readonly string[]
+  validate?: (payload: unknown) => Record<string, unknown>
+  required?: boolean
+  defaultChannels?: ChannelPreferenceMap
+  classification?: "transactional" | "product" | "marketing"
+}`}
+      />
+
+      <h2>Channel configs</h2>
+      <Code
+        code={`type InboxChannelConfig = {
+  type: "inbox"
+  title: string
+  body?: string
+  actionUrl?: string
+}
+
+type EmailChannelConfig = {
+  type: "email"
+  subject: string
+  body: string
+  html?: boolean
+}
+
+type SmsChannelConfig = {
+  type: "sms"
+  body: string
+}
+
+type WebhookChannelConfig = {
+  type: "webhook"
+  url: string
+  headers?: Record<string, string>
+}
+
+type ChannelConfig = InboxChannelConfig | EmailChannelConfig | SmsChannelConfig | WebhookChannelConfig
+type ChannelType = "inbox" | "email" | "sms" | "webhook"`}
+      />
+
+      <h2>Recipient</h2>
+      <Code
+        code={`type Recipient = {
+  id: string
+  tenantId?: string
+  workspaceId?: string
+  email?: string
+  phone?: string
+  name?: string
+  quietHours?: QuietHours | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+type QuietHours = {
+  start: string    // "HH:MM" 24h format
+  end: string      // "HH:MM" 24h format
+  timezone?: string // IANA timezone, defaults to "UTC"
+}`}
+      />
+
+      <h2>InboxItem</h2>
+      <Code
+        code={`type InboxItem = {
+  id: string
+  notificationRecordId: string
+  recipientId: string
+  tenantId?: string
+  workspaceId?: string
+  notificationId: string
+  title: string
+  body?: string
+  actionUrl?: string
+  readAt?: Date | null
+  archivedAt?: Date | null
+  createdAt: Date
+}`}
+      />
+
+      <h2>DeliveryRecord</h2>
+      <Code
+        code={`type DeliveryRecord = {
+  id: string
+  notificationRecordId: string
+  recipientId: string
+  tenantId?: string
+  workspaceId?: string
+  notificationId: string
+  channel: "email" | "webhook" | "sms" | "inbox"
+  provider: string
+  status: "pending" | "sent" | "failed" | "skipped"
+  to?: string
+  subject?: string
+  body?: string
+  providerMessageId?: string
+  error?: string
+  skipReason?: SkipReason
+  skipDetails?: string
+  attempts: number
+  createdAt: Date
+  updatedAt: Date
+  sentAt?: Date | null
+  failedAt?: Date | null
+}`}
+      />
+
+      <h2>RecipientPreference</h2>
+      <Code
+        code={`type RecipientPreference = {
+  recipientId: string
+  tenantId?: string
+  workspaceId?: string
+  notificationId: string
+  channels: ChannelPreferenceMap
+  updatedAt: Date
+}
+
+type ChannelPreferenceMap = Partial<Record<ChannelType, boolean>>`}
+      />
+
+      <h2>Provider interfaces</h2>
+      <Code
+        code={`type EmailProvider = {
+  id: string
+  send(input: { to: string; subject: string; body: string }): Promise<{ providerMessageId?: string }>
+}
+
+type SmsProvider = {
+  id: string
+  send(input: { to: string; body: string }): Promise<{ providerMessageId?: string }>
+}
+
+type WebhookProvider = {
+  id: string
+  signed?: boolean
+  send(input: {
+    url: string
+    headers: Record<string, string>
+    payload: {
+      notificationId: string
+      recipientId: string
+      tenantId?: string
+      workspaceId?: string
+      payload: Record<string, unknown>
+      sentAt: string
+    }
+  }): Promise<{ providerMessageId?: string }>
+}`}
+      />
+
+      <h2>Queue &amp; retry</h2>
+      <Code
+        code={`type Queue = {
+  enqueue(job: DeliveryJob, run: (job: DeliveryJob) => Promise<void>): void | Promise<void>
+  drain(): Promise<void>
+}
+
+type RetryPolicy = {
+  maxAttempts: number
+  delayMs(attempt: number): number
+}`}
+      />
+
+      <h2>SecurityScope</h2>
+      <Code
+        code={`type SecurityScope = {
+  tenantId?: string
+  organizationId?: string  // alias for tenantId
+  workspaceId?: string
+}`}
+      />
+
+      <h2>SkipReason</h2>
+      <Code
+        code={`type SkipReason =
+  | "preferences_disabled"
+  | "required_override"
+  | "missing_address"
+  | "missing_provider"
+  | "rate_limited"
+  | "quiet_hours_deferred"
+  | "duplicate"
+  | "idempotent_replay"
+  | "condition_false"
+  | "expired"
+  | "unsubscribed"
+  | "suppressed"
+  | "invalid_payload"
+  | "disabled_in_dev"`}
+      />
+
+      <div className="page-nav">
+        <Link href="/docs/api">
+          <span className="page-nav-label">Previous</span>
+          <span className="page-nav-title">API reference</span>
+        </Link>
+        <Link href="/docs/handler-routes">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Handler routes</span>
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -1,23 +1,44 @@
 :root {
-  --fg: #111;
-  --fg-muted: #555;
-  --bg: #fff;
-  --accent: #0b69ff;
-  --border: #e5e5e5;
-  --code-bg: #f6f6f6;
-  --code-fg: #111;
+  --font-heading: "Tomorrow", ui-sans-serif, system-ui, sans-serif;
+  --font-body: "Geist", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+
+  --fg: #0a0a0a;
+  --fg-muted: #666666;
+  --fg-subtle: #999999;
+  --bg: #ffffff;
+  --bg-subtle: #fafafa;
+  --accent: #0070f3;
+  --accent-hover: #005bd4;
+  --accent-subtle: rgba(0, 112, 243, 0.04);
+  --border: #eaeaea;
+  --border-strong: #ddd;
+  --code-bg: #fafafa;
+  --code-fg: #171717;
+  --surface: #ffffff;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.02);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.04), 0 2px 4px rgba(0, 0, 0, 0.02);
+  --radius: 8px;
   color-scheme: light;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --fg: #eee;
-    --fg-muted: #aaa;
-    --bg: #0b0b0c;
-    --accent: #6ea8fe;
-    --border: #2a2a2c;
-    --code-bg: #161618;
-    --code-fg: #eee;
+    --fg: #ededed;
+    --fg-muted: #a1a1a1;
+    --fg-subtle: #666666;
+    --bg: #0a0a0a;
+    --bg-subtle: #111111;
+    --accent: #3b82f6;
+    --accent-hover: #60a5fa;
+    --accent-subtle: rgba(59, 130, 246, 0.06);
+    --border: #1f1f1f;
+    --border-strong: #333;
+    --code-bg: #0e0e0e;
+    --code-fg: #ededed;
+    --surface: #0a0a0a;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
     color-scheme: dark;
   }
 }
@@ -32,105 +53,210 @@ body {
   padding: 0;
   background: var(--bg);
   color: var(--fg);
-  font-family:
-    ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  line-height: 1.6;
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.75;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "rlig" 1, "calt" 1;
 }
+
+/* ─────────────────────────────────────────────────────────────
+   Typography
+   ───────────────────────────────────────────────────────────── */
 
 a {
   color: var(--accent);
   text-decoration: none;
+  transition: color 0.15s;
 }
 
 a:hover {
+  color: var(--accent-hover);
   text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
 }
 
-h1,
-h2,
-h3,
-h4 {
+h1, h2, h3, h4, h5 {
+  font-family: var(--font-heading);
   line-height: 1.25;
-  margin: 2rem 0 0.5rem;
-  letter-spacing: 0;
+  margin: 0;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+  color: var(--fg);
 }
 
 h1 {
-  font-size: 2rem;
-  margin-top: 0;
+  font-size: 2.25rem;
+  font-weight: 500;
+  letter-spacing: -0.04em;
+  margin-bottom: 1rem;
 }
 
 h2 {
   font-size: 1.4rem;
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 0.25rem;
+  font-weight: 500;
+  margin-top: 3.5rem;
+  margin-bottom: 1rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+}
+
+h2:first-of-type {
+  margin-top: 2.5rem;
 }
 
 h3 {
-  font-size: 1.1rem;
+  font-size: 1.05rem;
+  font-weight: 500;
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
 }
 
-p,
-ul,
-ol {
-  margin: 0.75rem 0;
+p, ul, ol {
+  margin: 1rem 0;
+  font-weight: 400;
 }
 
+li {
+  margin: 0.4rem 0;
+}
+
+li::marker {
+  color: var(--fg-subtle);
+}
+
+strong {
+  font-weight: 600;
+}
+
+/* Inline code */
 code {
-  font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-family: var(--font-mono);
   background: var(--code-bg);
   color: var(--code-fg);
-  padding: 0.1em 0.3em;
-  border-radius: 3px;
-  font-size: 0.9em;
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  font-size: 0.84em;
+  font-weight: 450;
+  border: 1px solid var(--border);
 }
 
+/* Code blocks (plain pre without shiki) */
 pre {
   background: var(--code-bg);
   color: var(--code-fg);
-  padding: 1rem;
-  border-radius: 6px;
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius);
   overflow-x: auto;
-  font-size: 0.9em;
-  line-height: 1.5;
+  font-size: 0.84em;
+  line-height: 1.7;
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
 }
 
 pre code {
   background: transparent;
+  border: none;
   padding: 0;
   font-size: inherit;
+  font-weight: 400;
 }
 
 hr {
   border: none;
   border-top: 1px solid var(--border);
-  margin: 2rem 0;
+  margin: 3rem 0;
 }
+
+/* ─────────────────────────────────────────────────────────────
+   Tables
+   ───────────────────────────────────────────────────────────── */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9em;
+  margin: 1.5rem 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+th, td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.65rem 1rem;
+  text-align: left;
+}
+
+th {
+  background: var(--bg-subtle);
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Layout — Sidebar + Content
+   ───────────────────────────────────────────────────────────── */
 
 .docs-shell {
   display: grid;
-  grid-template-columns: 14rem 1fr;
-  gap: 3rem;
-  max-width: 64rem;
-  margin: 0 auto;
-  padding: 2rem 1.5rem;
+  grid-template-columns: 16rem 1fr;
+  min-height: 100vh;
 }
 
+/* ─── Sidebar ─── */
 .docs-nav {
   position: sticky;
-  top: 2rem;
+  top: 0;
   align-self: start;
-  font-size: 0.95rem;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 2rem 1.5rem;
+  border-right: 1px solid var(--border);
+  font-size: 0.875rem;
+  background: var(--bg);
+}
+
+.docs-nav-logo {
+  font-family: var(--font-heading);
+  font-weight: 500;
+  font-size: 1.05rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  color: var(--fg);
+  letter-spacing: -0.02em;
+}
+
+.docs-nav-logo:hover {
+  text-decoration: none;
+  color: var(--fg);
 }
 
 .docs-nav h4 {
-  font-size: 0.75rem;
+  font-family: var(--font-body);
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0;
-  color: var(--fg-muted);
-  margin: 1.25rem 0 0.25rem;
+  letter-spacing: 0.1em;
+  color: var(--fg-subtle);
+  margin: 2rem 0 0.5rem;
+  font-weight: 500;
+  padding-left: 0.6rem;
+}
+
+.docs-nav section:first-of-type h4 {
+  margin-top: 0;
 }
 
 .docs-nav ul {
@@ -140,74 +266,361 @@ hr {
 }
 
 .docs-nav li {
-  margin: 0.15rem 0;
+  margin: 0;
 }
 
 .docs-nav a {
-  color: var(--fg);
+  color: var(--fg-muted);
   display: block;
-  padding: 0.1rem 0;
+  padding: 0.35rem 0.6rem;
+  border-radius: 6px;
+  transition: all 0.12s ease;
+  font-weight: 400;
+  font-size: 0.85rem;
+}
+
+.docs-nav a:hover {
+  color: var(--fg);
+  background: var(--bg-subtle);
+  text-decoration: none;
 }
 
 .docs-nav a[aria-current="page"] {
   color: var(--accent);
+  background: var(--accent-subtle);
+  font-weight: 500;
+}
+
+/* ─── Main content ─── */
+.docs-content {
+  min-width: 0;
+  padding: 3rem 4rem;
+  max-width: 52rem;
+  margin: 0 auto;
+}
+
+.docs-content > article > p:first-of-type {
+  font-size: 1.05rem;
+  color: var(--fg-muted);
+  line-height: 1.7;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Callouts
+   ───────────────────────────────────────────────────────────── */
+
+.callout {
+  border-left: 2px solid var(--border-strong);
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-subtle);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  margin: 1.75rem 0;
+  font-size: 0.9em;
+  color: var(--fg-muted);
+}
+
+.callout strong {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--fg);
   font-weight: 600;
 }
 
-.docs-content {
-  min-width: 0;
+.callout-warn {
+  border-left-color: #f59e0b;
 }
 
-.docs-content pre {
-  max-width: 100%;
+.callout-tip {
+  border-left-color: #10b981;
 }
 
-.callout {
-  border-left: 3px solid var(--accent);
-  padding: 0.5rem 1rem;
-  background: color-mix(in srgb, var(--accent) 6%, transparent);
-  border-radius: 0 6px 6px 0;
-  margin: 1.25rem 0;
-}
+/* ─────────────────────────────────────────────────────────────
+   Buttons
+   ───────────────────────────────────────────────────────────── */
 
 .button-row {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
   flex-wrap: wrap;
-  margin: 1rem 0;
+  margin: 1.75rem 0;
 }
 
 .button-row button,
 .button-row a {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.5rem 0.9rem;
-  border-radius: 6px;
+  gap: 0.4rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: var(--radius);
   border: 1px solid var(--border);
-  background: var(--bg);
+  background: var(--surface);
   color: var(--fg);
-  font: inherit;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  font-weight: 500;
   cursor: pointer;
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+
+.button-row button:hover,
+.button-row a:hover {
+  background: var(--bg-subtle);
+  border-color: var(--border-strong);
   text-decoration: none;
 }
 
 .button-row .primary {
-  background: var(--accent);
-  color: #fff;
-  border-color: var(--accent);
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
 }
 
 .button-row .primary:hover {
-  filter: brightness(0.95);
+  opacity: 0.85;
   text-decoration: none;
 }
 
-@media (max-width: 760px) {
+/* ─────────────────────────────────────────────────────────────
+   Code blocks (shiki)
+   ───────────────────────────────────────────────────────────── */
+
+.code-block {
+  position: relative;
+  margin: 1.75rem 0;
+}
+
+.code-block pre {
+  margin: 0;
+}
+
+.code-filename {
+  display: block;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--fg-subtle);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  padding: 0.6rem 1.25rem;
+  border-radius: var(--radius) var(--radius) 0 0;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.code-filename + div pre,
+.code-filename + div .shiki {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.code-block .shiki {
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius);
+  overflow-x: auto;
+  font-size: 0.82rem;
+  line-height: 1.7;
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+}
+
+.code-copy {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.35rem;
+  cursor: pointer;
+  color: var(--fg-subtle);
+  opacity: 0;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.code-filename ~ .code-copy {
+  top: 3rem;
+}
+
+.code-block:hover .code-copy {
+  opacity: 1;
+}
+
+.code-copy:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+  background: var(--bg-subtle);
+}
+
+.code-copy.copied {
+  color: #10b981;
+  opacity: 1;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Hero section
+   ───────────────────────────────────────────────────────────── */
+
+.hero {
+  padding: 2rem 0 1rem;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  color: var(--fg-muted);
+  background: var(--bg-subtle);
+  padding: 0.3rem 0.7rem;
+  border-radius: 100px;
+  margin-bottom: 1.5rem;
+  border: 1px solid var(--border);
+  letter-spacing: 0.02em;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  letter-spacing: -0.05em;
+  line-height: 1.1;
+  max-width: 32rem;
+  font-weight: 500;
+}
+
+.hero-subtitle {
+  font-size: 1.1rem;
+  color: var(--fg-muted);
+  max-width: 32rem;
+  line-height: 1.7;
+  margin-top: 1.25rem;
+  font-weight: 400;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Feature grid
+   ───────────────────────────────────────────────────────────── */
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1px;
+  margin: 2.5rem 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--border);
+}
+
+.feature-card {
+  padding: 1.5rem;
+  background: var(--bg);
+}
+
+.feature-card h3 {
+  font-family: var(--font-heading);
+  font-size: 0.9rem;
+  font-weight: 500;
+  margin: 0 0 0.4rem;
+  letter-spacing: -0.01em;
+}
+
+.feature-card p {
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+  margin: 0;
+  line-height: 1.55;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Page navigation
+   ───────────────────────────────────────────────────────────── */
+
+.page-nav {
+  margin-top: 4rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.page-nav a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.85rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: all 0.15s;
+  min-width: 0;
+}
+
+.page-nav a:hover {
+  border-color: var(--border-strong);
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+}
+
+.page-nav-label {
+  font-size: 0.72rem;
+  color: var(--fg-subtle);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--font-body);
+}
+
+.page-nav-title {
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--fg);
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Shiki dual theme support
+   ───────────────────────────────────────────────────────────── */
+
+.shiki,
+.shiki span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+
+@media (prefers-color-scheme: dark) {
+  .shiki,
+  .shiki span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Responsive
+   ───────────────────────────────────────────────────────────── */
+
+@media (max-width: 860px) {
   .docs-shell {
     grid-template-columns: 1fr;
   }
   .docs-nav {
     position: static;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding: 1.25rem 1.5rem;
+  }
+  .docs-content {
+    padding: 2rem 1.5rem;
+  }
+  .hero h1 {
+    font-size: 2.25rem;
+  }
+  .features {
+    grid-template-columns: 1fr;
   }
 }

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -2,12 +2,13 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { NotifyKitProvider } from "@notifykitjs/react";
 import { SideNav } from "./_components/side-nav";
+import { CopyButtonScript } from "./_components/copy-button-script";
 import "./globals.css";
 
 export const metadata: Metadata = {
   title: {
-    default: "NotifyKit — app-native notifications for TypeScript",
-    template: "%s — NotifyKit",
+    default: "NotifyKit — App-native notifications for TypeScript",
+    template: "%s — NotifyKit Docs",
   },
   description:
     "Define notifications in code. Store state in your own database. Ship inbox, email, preferences, and signed unsubscribes without running a notification platform.",
@@ -16,6 +17,14 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Tomorrow:wght@400;500&family=Geist:wght@300;400;450;500;600&family=Geist+Mono:wght@400;500&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body>
         <NotifyKitProvider options={{ baseUrl: "/api/notifykit" }}>
           <div className="docs-shell">
@@ -23,6 +32,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <main className="docs-content">{children}</main>
           </div>
         </NotifyKitProvider>
+        <CopyButtonScript />
       </body>
     </html>
   );

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1,89 +1,154 @@
 import Link from "next/link";
+import { Code } from "./_components/code";
 
 export default function HomePage() {
   return (
     <article>
-      <h1>App-native notifications for TypeScript</h1>
-      <p style={{ fontSize: "1.1rem", color: "var(--fg-muted)" }}>
-        Define notifications in code. Store state in your own database. Ship
-        inbox, email, preferences, and signed unsubscribes — without running
-        a notification platform.
-      </p>
-
-      <div className="button-row">
-        <Link className="primary" href="/docs/installation">
-          Get started →
-        </Link>
-        <Link href="/demo">Live demo</Link>
-        <a
-          href="https://github.com/reyabsaluja/notifykit"
-          target="_blank"
-          rel="noreferrer"
-        >
-          GitHub
-        </a>
+      <div className="hero">
+        <div className="hero-badge">v0.1 &middot; Open Source</div>
+        <h1>App-native notifications for TypeScript</h1>
+        <p className="hero-subtitle">
+          Define notifications in code. Store state in your database.
+          Ship inbox, email, preferences, and unsubscribes — no platform required.
+        </p>
+        <div className="button-row">
+          <Link className="primary" href="/docs/installation">
+            Get started
+          </Link>
+          <Link href="/demo">Live demo</Link>
+          <a
+            href="https://github.com/reyabsaluja/notifykit"
+            target="_blank"
+            rel="noreferrer"
+          >
+            GitHub
+          </a>
+        </div>
       </div>
 
-      <h2>Starter setup</h2>
-      <pre>
-        <code>{`npx create-notifykit-app my-app
-cd my-app
-cp .env.example .env.local
-node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-# paste the generated value into .env.local as NOTIFYKIT_SECRET
-npm install
-npm run dev`}</code>
-      </pre>
+      <Code
+        code={`npx create-notifykit-app my-app`}
+        lang="bash"
+      />
 
-      <h2>What you get</h2>
-      <ul>
-        <li>
-          <strong>Type-safe <code>notify.send()</code></strong> — wrong
-          notification id? Wrong payload shape? TypeScript error, not 3am
-          pager.
-        </li>
-        <li>
-          <strong>Your database, your tables</strong> — memory adapter for
-          local dev, Drizzle adapter for production. SQLite and Postgres
-          supported today — more coming soon.
-        </li>
-        <li>
-          <strong>Inbox + email + SMS + webhook</strong> out of the box.
-          Retries, fallback channels, and per-recipient quiet hours reuse the
-          same pipeline.
-        </li>
-        <li>
-          <strong>Preferences + signed unsubscribe</strong> — HMAC-signed
-          links in every email, per-notification granularity, no session
-          required to opt out.
-        </li>
-        <li>
-          <strong>Digests + rate limits</strong> — two lines of config. Never
-          spam your users.
-        </li>
-        <li>
-          <strong>React hooks</strong> — <code>useInbox()</code>,
-          {" "}<code>usePreferences()</code>, <code>&lt;NotificationBell /&gt;</code>.
-        </li>
-      </ul>
+      <div className="features">
+        <div className="feature-card">
+          <h3>Type-safe sends</h3>
+          <p>
+            Wrong notification ID or payload shape? TypeScript error at
+            compile time.
+          </p>
+        </div>
+        <div className="feature-card">
+          <h3>Your database</h3>
+          <p>
+            Memory for dev, Drizzle for production. SQLite and Postgres
+            supported.
+          </p>
+        </div>
+        <div className="feature-card">
+          <h3>Multi-channel</h3>
+          <p>
+            Inbox, email, SMS, webhook. Retries, fallback channels, and
+            quiet hours built in.
+          </p>
+        </div>
+        <div className="feature-card">
+          <h3>Preferences</h3>
+          <p>
+            Per-notification granularity. HMAC-signed unsubscribe links.
+            RFC 8058 one-click.
+          </p>
+        </div>
+        <div className="feature-card">
+          <h3>Digests &amp; rate limits</h3>
+          <p>
+            Coalesce noisy sends. Hard-cap per window. Two lines of config.
+          </p>
+        </div>
+        <div className="feature-card">
+          <h3>React hooks</h3>
+          <p>
+            useInbox(), usePreferences(), components. Realtime via SSE
+            or WebSocket.
+          </p>
+        </div>
+      </div>
+
+      <h2>Define</h2>
+      <Code
+        filename="lib/notifykit.ts"
+        code={`import { channel, createNotifyKit, notification, memoryAdapter, fakeEmailProvider } from "@notifykitjs/core"
+
+const inbox = channel.inbox()
+const email = channel.email()
+
+export const commentMentioned = notification({
+  id: "comment_mentioned",
+  payload: { actorName: "string", postTitle: "string", postUrl: "string" },
+  channels: [
+    inbox({
+      title: "{{actorName}} mentioned you",
+      body: "In {{postTitle}}",
+      actionUrl: "{{postUrl}}",
+    }),
+    email({
+      subject: "{{actorName}} mentioned you in {{postTitle}}",
+      body: "Open {{postUrl}} to reply.\\n\\nUnsubscribe: {{_unsubscribeUrl}}",
+    }),
+  ],
+})
+
+export const notify = createNotifyKit({
+  notifications: [commentMentioned] as const,
+  database: memoryAdapter(),
+  providers: { email: fakeEmailProvider() },
+})`}
+      />
+
+      <h2>Expose</h2>
+      <Code
+        filename="app/api/notifykit/[...route]/route.ts"
+        code={`import { createRouteHandler } from "@notifykitjs/next"
+import { notify } from "@/lib/notifykit"
+import { getSessionUserId } from "@/lib/session"
+
+export const { GET, POST, DELETE, OPTIONS, dynamic } = createRouteHandler({
+  notifykit: notify,
+  identify: () => getSessionUserId(),
+})`}
+      />
+
+      <h2>Send</h2>
+      <Code
+        code={`await notify.send({
+  recipientId: user.id,
+  notificationId: "comment_mentioned",
+  payload: {
+    actorName: actor.name,
+    postTitle: post.title,
+    postUrl: \`/posts/\${post.id}\`,
+  },
+})`}
+      />
 
       <h2>Philosophy</h2>
       <p>
         NotifyKit is a framework, not a SaaS. It runs inside your app, writes
-        to your database, and calls your providers. There is no hosted
-        service, no dashboard, no external workflow editor. The framework&apos;s
-        job is to give you a clean, typed runtime and get out of the way.
+        to your database, and calls your providers directly. No hosted
+        service, no dashboard, no external workflow editor.
       </p>
       <p>
-        Think PayKit for notifications. Better Auth style DX.
+        Think Better Auth for notifications. Define in code. Own your data.
       </p>
 
-      <hr />
-      <p style={{ color: "var(--fg-muted)" }}>
-        Browse the{" "}
-        <Link href="/docs/installation">docs</Link> or try the{" "}
-        <Link href="/demo">live demo</Link>.
-      </p>
+      <div className="page-nav">
+        <span />
+        <Link href="/docs/installation">
+          <span className="page-nav-label">Next</span>
+          <span className="page-nav-title">Installation</span>
+        </Link>
+      </div>
     </article>
   );
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,11 +10,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "^15.0.0",
     "@notifykitjs/core": "workspace:*",
     "@notifykitjs/react": "workspace:*",
+    "next": "^15.0.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "shiki": "^4.0.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary

- Complete docs site with 21 new/rewritten documentation pages covering the full NotifyKit surface
- Server-side syntax highlighting via shiki with copy-to-clipboard buttons
- Modern visual design: Tomorrow headers, Geist body font, line-separated sections, centered content, dark/light mode
- Feature card grid with 1px separator aesthetic
- Full sidebar navigation organized by section (Getting Started, Core Concepts, Framework Integration, Production, Debugging, Reference)

## Pages added

Quickstart, Channels, Digests & rate limits, Quiet hours, Dedup & idempotency, Fallback channels, Next.js, React hooks & components, Realtime, Database adapters, Multi-tenancy, Explain & dry run, Timeline, Hooks & observability, API reference, TypeScript types, Handler routes

## Test plan

- [x] `bun run docs:build` passes — all 28 pages prerendered as static content
- [x] Dev server renders all pages with syntax highlighting
- [x] Dark/light mode works via `prefers-color-scheme`
- [x] Live demo page still functional

Closes #75