### PR TITLE
feat: testing utilities and dev mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,7 +105,7 @@
         "@notifykitjs/next": "workspace:*",
         "@notifykitjs/react": "workspace:*",
         "@notifykitjs/resend": "workspace:*",
-        "better-auth": "^1.2.0",
+        "better-auth": "~1.6.10",
         "drizzle-orm": "^0.45.2",
         "next": "^15.1.0",
         "react": "^19.0.0",
@@ -265,6 +265,17 @@
       "version": "0.0.1",
       "devDependencies": {
         "@notifykitjs/core": "^0.0.1",
+        "typescript": "^5.6.3",
+      },
+      "peerDependencies": {
+        "@notifykitjs/core": "^0.0.1",
+      },
+    },
+    "packages/testing": {
+      "name": "@notifykitjs/testing",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@notifykitjs/core": "workspace:*",
         "typescript": "^5.6.3",
       },
       "peerDependencies": {
@@ -438,6 +449,8 @@
     "@notifykitjs/realtime-ws": ["@notifykitjs/realtime-ws@workspace:packages/realtime-ws"],
 
     "@notifykitjs/resend": ["@notifykitjs/resend@workspace:packages/resend"],
+
+    "@notifykitjs/testing": ["@notifykitjs/testing@workspace:packages/testing"],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 

--- a/docs/app/demo/page.tsx
+++ b/docs/app/demo/page.tsx
@@ -52,7 +52,7 @@ export default function DemoPage() {
         Turning off email doesn&apos;t change what you see here (the docs
         demo doesn&apos;t send real email), but on subsequent sends the
         delivery row will be skipped and reported in{" "}
-        <code>result.skippedChannels</code>.
+        <code>result.skipped</code>.
       </p>
       <DemoPreferences />
 

--- a/docs/app/docs/api/page.tsx
+++ b/docs/app/docs/api/page.tsx
@@ -41,12 +41,12 @@ export default function ApiPage() {
   notification: NotificationRecord | null
   inboxItems: InboxItem[]
   deliveries: DeliveryRecord[]
-  skippedChannels: SkippedDelivery[]
-  deferredChannels: Array<{ channel: ChannelType; resumesAt: Date }>
+  skippedChannels: ChannelType[] // deprecated; use skipped[]
+  skipped: SkippedDelivery[]
+  deferredChannels: ChannelType[]
   digested: boolean
   rateLimited: boolean
-  deduplicated: boolean
-  idempotentReplay: boolean
+  idempotent: boolean
 }`}
       />
 

--- a/docs/app/docs/deduplication/page.tsx
+++ b/docs/app/docs/deduplication/page.tsx
@@ -39,8 +39,8 @@ export default function DeduplicationPage() {
       <Code
         code={`const result = await notify.send({ ... dedupeKey, dedupeWindowMs })
 
-if (result.deduplicated) {
-  // send was skipped — no notification created
+if (result.skipped.some((item) => item.reason === "duplicate")) {
+  // provider delivery was skipped; an audit notification record still exists
   console.log("duplicate within window")
 }`}
       />
@@ -104,7 +104,7 @@ if (result.deduplicated) {
           </tr>
           <tr>
             <td><strong>On duplicate</strong></td>
-            <td>Skip entirely, no record created</td>
+            <td>Create an audit record and skip provider delivery</td>
             <td>Return the existing notification record</td>
           </tr>
           <tr>

--- a/docs/app/docs/defining/page.tsx
+++ b/docs/app/docs/defining/page.tsx
@@ -67,15 +67,17 @@ export const commentMentioned = notification({
       </p>
       <Code
         code={`import { z } from "zod"
-import { withZod } from "@notifykitjs/core/zod"
+import { zodPayload } from "@notifykitjs/core/zod"
+
+const invoicePayload = zodPayload(z.object({
+  invoiceId: z.string().uuid(),
+  amount: z.number().positive(),
+}))
 
 notification({
   id: "invoice_created",
-  payload: { invoiceId: "string", amount: "number" },
-  validate: withZod(z.object({
-    invoiceId: z.string().uuid(),
-    amount: z.number().positive(),
-  })),
+  payload: invoicePayload.payload,
+  validate: invoicePayload.validate,
   channels: [...],
 })`}
       />

--- a/docs/app/docs/fallbacks/page.tsx
+++ b/docs/app/docs/fallbacks/page.tsx
@@ -94,8 +94,8 @@ export default function FallbacksPage() {
 
       <h2>Fallback and retries</h2>
       <p>
-        Fallback only triggers after all retries are exhausted. The timeline
-        shows the full sequence:
+        Fallback triggers after all retries are exhausted, or after a provider
+        returns a permanent error. The timeline shows the full sequence:
       </p>
       <Code
         code={`// Timeline for a failed email with inbox fallback:

--- a/docs/app/docs/nextjs/page.tsx
+++ b/docs/app/docs/nextjs/page.tsx
@@ -72,7 +72,7 @@ export const notifyActions = createServerActions({
         code={`import { notifyActions } from "@/lib/notifykit-actions"
 
 export default async function NotificationSettings() {
-  const preferences = await notifyActions.preferences.list()
+  const preferences = await notifyActions.getPreferences()
   // render preferences UI...
 }`}
       />

--- a/docs/app/docs/preferences/page.tsx
+++ b/docs/app/docs/preferences/page.tsx
@@ -12,7 +12,7 @@ export default function PreferencesPage() {
         Every send checks a <code>(recipientId, notificationId)</code>{" "}
         preference row before it writes to a channel. If the recipient has
         opted out, the channel is skipped and reported in{" "}
-        <code>result.skippedChannels</code>.
+        <code>result.skipped</code> with a reason.
       </p>
 
       <h2>Reading &amp; writing preferences</h2>

--- a/docs/app/docs/timeline/page.tsx
+++ b/docs/app/docs/timeline/page.tsx
@@ -28,10 +28,10 @@ export default function TimelinePage() {
       <h2>Reading the timeline</h2>
       <Code
         code={`// Get timeline for a specific notification send
-const events = await notify.timeline.list(notificationRecordId)
+const events = await notify.timeline(notificationRecordId)
 
 // Get timeline for a specific delivery
-const deliveryEvents = await notify.timeline.listByDelivery(deliveryId)
+const deliveryEvents = await notify.timeline(notificationRecordId, { deliveryId })
 
 // Example output:
 // [
@@ -100,7 +100,7 @@ const deliveryEvents = await notify.timeline.listByDelivery(deliveryId)
           </tr>
           <tr>
             <td><code>delivery.failed</code></td>
-            <td>All retries exhausted</td>
+            <td>Delivery failed after retries or a permanent error</td>
           </tr>
           <tr>
             <td><code>provider.message_id_stored</code></td>
@@ -152,7 +152,7 @@ const deliveryEvents = await notify.timeline.listByDelivery(deliveryId)
       <Code
         code={`// Delete events older than 30 days
 const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60_000)
-const deleted = await notify.timeline.prune(thirtyDaysAgo)
+const deleted = await notify.pruneTimeline(thirtyDaysAgo)
 console.log(\`Pruned \${deleted} timeline events\`)`}
       />
 

--- a/examples/basic/src/index.ts
+++ b/examples/basic/src/index.ts
@@ -4,6 +4,7 @@ import {
   fakeEmailProvider,
   memoryAdapter,
   notification,
+  type SendResult,
 } from "@notifykitjs/core";
 
 const inbox = channel.inbox();
@@ -30,6 +31,10 @@ const commentMentioned = notification({
 });
 
 const provider = fakeEmailProvider();
+
+function skippedSummary(result: SendResult): string {
+  return result.skipped.map((s) => `${s.channel}:${s.reason}`).join(", ") || "(none)";
+}
 
 const notify = createNotifyKit({
   notifications: [commentMentioned] as const,
@@ -112,7 +117,7 @@ async function main() {
   });
 
   console.log(
-    `Second send — skipped channels: ${second.skippedChannels.join(", ") || "(none)"}`,
+    `Second send — skipped: ${skippedSummary(second)}`,
   );
   console.log(`Inbox items created: ${second.inboxItems.length}`);
   console.log(`Deliveries created: ${second.deliveries.length}`);

--- a/examples/drizzle/src/index.ts
+++ b/examples/drizzle/src/index.ts
@@ -5,6 +5,7 @@ import {
   createNotifyKit,
   fakeEmailProvider,
   notification,
+  type SendResult,
 } from "@notifykitjs/core";
 import {
   createSqliteTables,
@@ -13,6 +14,10 @@ import {
 
 const inbox = channel.inbox();
 const email = channel.email();
+
+function skippedSummary(result: SendResult): string {
+  return result.skipped.map((s) => `${s.channel}:${s.reason}`).join(", ") || "(none)";
+}
 
 const commentMentioned = notification({
   id: "comment_mentioned",
@@ -86,7 +91,7 @@ async function main() {
   });
 
   console.log(
-    `\nSecond send — skipped: ${second.skippedChannels.join(", ") || "(none)"}`,
+    `\nSecond send — skipped: ${skippedSummary(second)}`,
   );
   console.log(`Total emails sent: ${provider.sent.length}`);
 

--- a/examples/inbox-ui/next-env.d.ts
+++ b/examples/inbox-ui/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/inbox-ui/src/lib/notify.ts
+++ b/examples/inbox-ui/src/lib/notify.ts
@@ -44,7 +44,7 @@ const taskAssigned = notification({
     }),
     email({
       subject: "New task: {{taskTitle}}",
-      body: "{{assignerName}} assigned you "{{taskTitle}}".",
+      body: '{{assignerName}} assigned you "{{taskTitle}}".',
     }),
   ],
 });

--- a/examples/inbox-ui/tsconfig.json
+++ b/examples/inbox-ui/tsconfig.json
@@ -16,6 +16,6 @@
     "plugins": [{ "name": "next" }],
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -34,4 +34,6 @@ All operations accept a security scope (`tenantId`, `organizationId`, `workspace
 
 - Inbox items from one tenant are invisible to queries scoped to another
 - Preferences set under one tenant don't affect another
-- Rate limits and dedup keys are scoped per tenant
+- Rate limits are scoped per tenant
+- Deduplication and idempotency keys are recipient-level by default; include
+  the tenant in your key if you need tenant-distinct de-duplication

--- a/examples/multi-tenant/src/index.ts
+++ b/examples/multi-tenant/src/index.ts
@@ -4,10 +4,15 @@ import {
   fakeEmailProvider,
   memoryAdapter,
   notification,
+  type SendResult,
 } from "@notifykitjs/core";
 
 const inbox = channel.inbox();
 const email = channel.email();
+
+function skippedSummary(result: SendResult): string {
+  return result.skipped.map((s) => `${s.channel}:${s.reason}`).join(", ") || "(none)";
+}
 
 const taskAssigned = notification({
   id: "task_assigned",
@@ -95,7 +100,7 @@ async function main() {
         taskUrl: "/tasks/1",
       },
     });
-    console.log(`  skipped: ${r1.skippedChannels.join(", ") || "(none)"}\n`);
+    console.log(`  skipped: ${skippedSummary(r1)}\n`);
   } catch (err) {
     console.error("  send failed:", err instanceof Error ? err.message : err);
   }
@@ -113,7 +118,7 @@ async function main() {
         taskUrl: "/tasks/2",
       },
     });
-    console.log(`  skipped: ${r2.skippedChannels.join(", ") || "(none)"}\n`);
+    console.log(`  skipped: ${skippedSummary(r2)}\n`);
   } catch (err) {
     console.error("  send failed:", err instanceof Error ? err.message : err);
   }
@@ -149,7 +154,7 @@ async function main() {
         weekOf: "May 13, 2024",
       },
     });
-    console.log(`  skipped: ${r3.skippedChannels.join(", ") || "(none)"}`);
+    console.log(`  skipped: ${skippedSummary(r3)}`);
   } catch (err) {
     console.error("  send failed:", err instanceof Error ? err.message : err);
   }

--- a/examples/nextjs-better-auth-drizzle/.env.example
+++ b/examples/nextjs-better-auth-drizzle/.env.example
@@ -1,7 +1,7 @@
-# Better Auth
-BETTER_AUTH_SECRET="your-secret-here"
-BETTER_AUTH_URL="http://localhost:3200"
+BETTER_AUTH_URL=http://localhost:3200
+BETTER_AUTH_SECRET=replace-with-a-random-secret
+NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:3200
 
-# Resend (optional — falls back to fake provider if not set)
-RESEND_API_KEY=""
-RESEND_FROM="Acme <no-reply@yourdomain.com>"
+# Optional: set these to send real email through Resend.
+RESEND_API_KEY=
+RESEND_FROM="Acme <onboarding@resend.dev>"

--- a/examples/nextjs-better-auth-drizzle/next-env.d.ts
+++ b/examples/nextjs-better-auth-drizzle/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/nextjs-better-auth-drizzle/package.json
+++ b/examples/nextjs-better-auth-drizzle/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --port 3200",
-    "build": "next build",
+    "build": "bun --bun next build",
     "start": "next start",
     "db:push": "bun src/db/migrate.ts"
   },

--- a/examples/nextjs-better-auth-drizzle/src/app/(app)/settings/page.tsx
+++ b/examples/nextjs-better-auth-drizzle/src/app/(app)/settings/page.tsx
@@ -1,14 +1,44 @@
 "use client";
 
-import { usePreferences } from "@notifykitjs/react";
+import { useEffect, useState } from "react";
+import {
+  useNotifyKitClient,
+  usePreferences,
+  type NotificationMetadata,
+} from "@notifykitjs/react";
 
-const CHANNEL_LABELS: Record<string, string> = {
+const CHANNEL_KEYS = ["inbox", "email"] as const;
+
+const CHANNEL_LABELS: Record<(typeof CHANNEL_KEYS)[number], string> = {
   inbox: "In-app",
   email: "Email",
 };
 
 export default function SettingsPage() {
+  const client = useNotifyKitClient();
   const { items, status, update } = usePreferences();
+  const [definitions, setDefinitions] = useState<NotificationMetadata[]>([]);
+  const [definitionsLoaded, setDefinitionsLoaded] = useState(false);
+
+  useEffect(() => {
+    client.notifications
+      .list()
+      .then((defs) => {
+        setDefinitions(defs);
+        setDefinitionsLoaded(true);
+      })
+      .catch(() => setDefinitionsLoaded(true));
+  }, [client]);
+
+  const merged = definitions.map((def) => {
+    const saved = items.find((pref) => pref.notificationId === def.id);
+    return {
+      notificationId: def.id,
+      description: def.description,
+      required: def.required ?? false,
+      channels: saved?.channels ?? {},
+    };
+  });
 
   return (
     <div className="settings">
@@ -17,27 +47,27 @@ export default function SettingsPage() {
         Choose which channels to receive notifications on.
       </p>
 
-      {status === "loading" && <p>Loading...</p>}
+      {(status === "loading" || !definitionsLoaded) && <p>Loading...</p>}
 
-      {status === "ready" && (
+      {status === "ready" && definitionsLoaded && (
         <table className="prefs-table">
           <thead>
             <tr>
               <th>Notification</th>
-              {Object.entries(CHANNEL_LABELS).map(([key, label]) => (
-                <th key={key}>{label}</th>
+              {CHANNEL_KEYS.map((key) => (
+                <th key={key}>{CHANNEL_LABELS[key]}</th>
               ))}
             </tr>
           </thead>
           <tbody>
-            {items.map((pref) => (
+            {merged.map((pref) => (
               <tr key={pref.notificationId}>
                 <td>
                   <strong>{formatId(pref.notificationId)}</strong>
                   {pref.description && <span className="pref-desc">{pref.description}</span>}
                   {pref.required && <span className="badge">Required</span>}
                 </td>
-                {Object.keys(CHANNEL_LABELS).map((ch) => {
+                {CHANNEL_KEYS.map((ch) => {
                   const enabled = pref.channels?.[ch] !== false;
                   return (
                     <td key={ch}>

--- a/examples/nextjs-better-auth-drizzle/src/db/index.ts
+++ b/examples/nextjs-better-auth-drizzle/src/db/index.ts
@@ -2,5 +2,5 @@ import { resolve } from "path";
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-const sqlite = new Database(resolve(import.meta.dir, "../../local.db"));
+const sqlite = new Database(resolve(process.cwd(), "local.db"));
 export const db = drizzle(sqlite);

--- a/examples/nextjs-better-auth-drizzle/src/lib/auth.ts
+++ b/examples/nextjs-better-auth-drizzle/src/lib/auth.ts
@@ -2,7 +2,28 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "@/db";
 
+const isNextBuild = process.env.NEXT_PHASE === "phase-production-build";
+const baseURL =
+  process.env.BETTER_AUTH_URL ??
+  process.env.NEXT_PUBLIC_BETTER_AUTH_URL ??
+  (isNextBuild || process.env.NODE_ENV !== "production" ? "http://localhost:3200" : undefined);
+const secret =
+  process.env.BETTER_AUTH_SECRET ??
+  (isNextBuild || process.env.NODE_ENV !== "production"
+    ? "notifykit-example-dev-secret-change-me"
+    : undefined);
+
+if (!baseURL) {
+  throw new Error("BETTER_AUTH_URL is required in production.");
+}
+
+if (!secret) {
+  throw new Error("BETTER_AUTH_SECRET is required in production.");
+}
+
 export const auth = betterAuth({
+  baseURL,
+  secret,
   database: drizzleAdapter(db, { provider: "sqlite" }),
   emailAndPassword: {
     enabled: true,

--- a/examples/nextjs-better-auth-drizzle/tsconfig.json
+++ b/examples/nextjs-better-auth-drizzle/tsconfig.json
@@ -16,6 +16,6 @@
     "plugins": [{ "name": "next" }],
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/preferences-ui/next-env.d.ts
+++ b/examples/preferences-ui/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/preferences-ui/src/lib/notify.ts
+++ b/examples/preferences-ui/src/lib/notify.ts
@@ -2,6 +2,7 @@ import {
   channel,
   createNotifyKit,
   fakeEmailProvider,
+  fakeSmsProvider,
   memoryAdapter,
   notification,
 } from "@notifykitjs/core";
@@ -68,7 +69,7 @@ const taskAssigned = notification({
     }),
     email({
       subject: "New task: {{taskTitle}}",
-      body: "{{assignerName}} assigned you "{{taskTitle}}".",
+      body: '{{assignerName}} assigned you "{{taskTitle}}".',
     }),
     sms({ body: "New task from {{assignerName}}: {{taskTitle}}" }),
   ],
@@ -123,7 +124,7 @@ const securityAlert = notification({
 export const notify = createNotifyKit({
   notifications: [commentMentioned, newFollower, taskAssigned, invoicePaid, securityAlert] as const,
   database: memoryAdapter(),
-  providers: { email: fakeEmailProvider() },
+  providers: { email: fakeEmailProvider(), sms: fakeSmsProvider() },
   defaults: {
     channels: { inbox: true, email: true },
   },

--- a/examples/preferences-ui/tsconfig.json
+++ b/examples/preferences-ui/tsconfig.json
@@ -16,6 +16,6 @@
     "plugins": [{ "name": "next" }],
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/resend/src/index.ts
+++ b/examples/resend/src/index.ts
@@ -3,6 +3,7 @@ import {
   createNotifyKit,
   memoryAdapter,
   notification,
+  type SendResult,
 } from "@notifykitjs/core";
 import { resendProvider } from "@notifykitjs/resend";
 
@@ -15,6 +16,10 @@ if (!apiKey) {
 
 const inbox = channel.inbox();
 const email = channel.email();
+
+function skippedSummary(result: SendResult): string {
+  return result.skipped.map((s) => `${s.channel}:${s.reason}`).join(", ") || "(none)";
+}
 
 const welcomeEmail = notification({
   id: "welcome",
@@ -97,7 +102,7 @@ async function main() {
   console.log(`\nSendResult:`);
   console.log(`  Inbox items: ${result.inboxItems.length}`);
   console.log(`  Deliveries:  ${result.deliveries.length}`);
-  console.log(`  Skipped:     ${result.skippedChannels.length > 0 ? result.skippedChannels.join(", ") : "(none)"}`);
+  console.log(`  Skipped:     ${skippedSummary(result)}`);
 
   console.log(`\nSending invoice_paid email...`);
   const result2 = await notify.send({

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "test": "bun test",
-    "build": "bun run --cwd packages/core build && bun run --cwd packages/drizzle-adapter build && bun run --cwd packages/realtime-ws build && bun run --cwd packages/realtime-pg build && bun run --cwd packages/react build && bun run --cwd packages/next build && bun run --cwd packages/cli build && bun run --cwd packages/resend build && bun run --cwd packages/create-app build",
+    "build": "bun run --cwd packages/core build && bun run --cwd packages/drizzle-adapter build && bun run --cwd packages/realtime-ws build && bun run --cwd packages/realtime-pg build && bun run --cwd packages/react build && bun run --cwd packages/next build && bun run --cwd packages/cli build && bun run --cwd packages/resend build && bun run --cwd packages/testing build && bun run --cwd packages/create-app build",
     "example": "bun run --cwd examples/basic start",
     "example:drizzle": "bun run --cwd examples/drizzle start",
     "example:handler": "bun run --cwd examples/handler start",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,9 @@
   },
   "homepage": "https://github.com/reyabsaluja/notifykit",
   "bugs": "https://github.com/reyabsaluja/notifykit/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -76,7 +76,7 @@ async function handleServe(args: string[]): Promise<number> {
     strict: true,
   });
   const port = Number(values.port);
-  if (!Number.isFinite(port) || port < 0 || port > 65535) {
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
     throw new Error(`Invalid --port: ${values.port}`);
   }
   return runServe({

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -24,6 +24,9 @@ export async function runCheck(options: CheckOptions): Promise<number> {
     providers: config.providers,
     unsubscribe: config.unsubscribe,
     defaults: config.defaults,
+    retry: config.retry,
+    idempotencyKeyTtlMs: config.idempotencyKeyTtlMs,
+    timelineRetentionMs: config.timelineRetentionMs,
   });
   const errors = issues.filter((i) => i.severity === "error");
   const warnings = issues.filter((i) => i.severity === "warning");

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -29,6 +29,10 @@ export async function runSend(options: SendOptions): Promise<number> {
       sms: config.providers?.sms,
     },
     unsubscribe: config.unsubscribe,
+    defaults: config.defaults,
+    retry: config.retry,
+    idempotencyKeyTtlMs: config.idempotencyKeyTtlMs,
+    timelineRetentionMs: config.timelineRetentionMs,
   });
 
   await notify.upsertRecipient({
@@ -68,6 +72,9 @@ export async function runSend(options: SendOptions): Promise<number> {
   }
   if (result.skippedChannels.length > 0) {
     console.log(`  skipped: ${result.skippedChannels.join(", ")}`);
+  }
+  if (result.deliveries.some((delivery) => delivery.status === "failed")) {
+    return 1;
   }
   return 0;
 }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -29,6 +29,10 @@ export async function runServe(options: ServeOptions): Promise<number> {
       sms: config.providers?.sms,
     },
     unsubscribe: config.unsubscribe,
+    defaults: config.defaults,
+    retry: config.retry,
+    idempotencyKeyTtlMs: config.idempotencyKeyTtlMs,
+    timelineRetentionMs: config.timelineRetentionMs,
     on: {
       "notification.created": ({ notification }) => {
         console.log(
@@ -66,9 +70,10 @@ export async function runServe(options: ServeOptions): Promise<number> {
   });
 
   const basePath = options.basePath ?? "/api/notifykit";
+  let serverPort = options.port;
   const server = createServer(async (req, res) => {
     try {
-      const request = toRequest(req, options.port);
+      const request = toRequest(req, serverPort);
       const response = await handler(request);
       await writeResponse(res, response);
     } catch (err) {
@@ -81,24 +86,14 @@ export async function runServe(options: ServeOptions): Promise<number> {
     }
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(options.port, "127.0.0.1", () => {
-      server.removeListener("error", reject);
-      resolve();
-    });
-  }).catch((err: NodeJS.ErrnoException) => {
-    if (err.code === "EADDRINUSE") {
-      console.error(`Port ${options.port} is already in use. Try a different port with --port.`);
-      process.exit(1);
-    }
-    throw err;
-  });
+  const actualPort = await listen(server, options.port);
+  if (actualPort === null) return 1;
+  serverPort = actualPort;
   const address = server.address();
-  const actualPort =
-    typeof address === "object" && address ? address.port : options.port;
+  const displayPort =
+    typeof address === "object" && address ? address.port : actualPort;
 
-  console.log(`\nNotifyKit dev server: http://localhost:${actualPort}${basePath}`);
+  console.log(`\nNotifyKit dev server: http://localhost:${displayPort}${basePath}`);
   console.log(
     `⚠ Dev-only auth: identity comes from x-user-id header. Do NOT use this in production.`,
   );
@@ -118,6 +113,43 @@ export async function runServe(options: ServeOptions): Promise<number> {
     process.on("SIGINT", onSignal);
     process.on("SIGTERM", onSignal);
   });
+}
+
+async function listen(
+  server: ReturnType<typeof createServer>,
+  requestedPort: number,
+): Promise<number | null> {
+  const maxAttempts = requestedPort === 0 ? 20 : 1;
+  const firstFallback = 49_152 + ((Date.now() + process.pid) % 16_000);
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const port =
+      attempt === 0
+        ? requestedPort
+        : 49_152 + ((firstFallback + attempt - 49_152) % 16_000);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(port, "127.0.0.1", () => {
+          server.removeListener("error", reject);
+          resolve();
+        });
+      });
+      const address = server.address();
+      return typeof address === "object" && address ? address.port : port;
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      if (error.code === "EADDRINUSE" && requestedPort === 0) continue;
+      if (error.code === "EADDRINUSE") {
+        console.error(`Port ${requestedPort} is already in use. Try a different port with --port.`);
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  console.error("No available port found. Try a specific port with --port.");
+  return null;
 }
 
 function toRequest(req: IncomingMessage, port: number): Request {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -7,6 +7,7 @@ import type {
   EmailProvider,
   NotificationDefinition,
   PayloadSchema,
+  RetryPolicy,
   SmsProvider,
   WebhookProvider,
 } from "@notifykitjs/core";
@@ -23,6 +24,9 @@ export type NotifyKitConfig = {
     channels?: ChannelPreferenceMap;
     categories?: CategoryDefaults;
   };
+  retry?: Partial<RetryPolicy>;
+  idempotencyKeyTtlMs?: number;
+  timelineRetentionMs?: number;
 };
 
 export function defineConfig(config: NotifyKitConfig): NotifyKitConfig {

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -73,6 +73,15 @@ describe("notifykit CLI", () => {
     expect(combined).toMatch(/nmae/);
   });
 
+  test("check validates runtime options from config", async () => {
+    const result = await runCli(["check", "--config", "runtime-options.config.ts"]);
+    expect(result.code).toBe(1);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/retry\.maxAttempts/);
+    expect(combined).toMatch(/idempotencyKeyTtlMs/);
+    expect(combined).toMatch(/timelineRetentionMs/);
+  });
+
   test("check with missing config exits 2", async () => {
     const result = await runCli(["check", "--config", "nope.config.ts"]);
     expect(result.code).toBe(2);
@@ -101,6 +110,30 @@ describe("notifykit CLI", () => {
     expect(result.stdout).toContain('Sent "comment_mentioned"');
     expect(result.stdout).toContain("inbox:");
     expect(result.stdout).toContain("email: sent");
+  });
+
+  test("send honors app-level channel defaults from config", async () => {
+    const result = await runCli([
+      "send",
+      "--config",
+      "defaults.config.ts",
+      "--to",
+      "user_1",
+      "--id",
+      "comment_mentioned",
+      "--email",
+      "u@example.com",
+      "--payload",
+      JSON.stringify({
+        actorName: "Rey",
+        postTitle: "Plan",
+        postUrl: "/p",
+      }),
+    ]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("inbox:");
+    expect(result.stdout).toContain("email: skipped");
+    expect(result.stdout).not.toContain("email: sent");
   });
 
   test("send supports SMS configs with a phone number", async () => {
@@ -150,6 +183,18 @@ describe("notifykit CLI", () => {
     expect(result.stderr).toBe("");
   });
 
+  test("serve rejects non-integer ports", async () => {
+    const result = await runCli([
+      "serve",
+      "--config",
+      "good.config.ts",
+      "--port",
+      "1.5",
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Invalid --port: 1.5");
+  });
+
   test("send with missing required payload key exits 1", async () => {
     const result = await runCli([
       "send",
@@ -166,6 +211,25 @@ describe("notifykit CLI", () => {
     ]);
     expect(result.code).toBe(1);
     expect(result.stderr).toMatch(/postTitle/);
+  });
+
+  test("send exits 1 when provider delivery fails", async () => {
+    const result = await runCli([
+      "send",
+      "--config",
+      "failing-provider.config.ts",
+      "--to",
+      "user_1",
+      "--id",
+      "provider_fails",
+      "--email",
+      "u@example.com",
+      "--payload",
+      JSON.stringify({ msg: "Hello" }),
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain("email: failed");
+    expect(result.stdout).toContain("provider unavailable");
   });
 
   test("unknown command prints usage and exits 1", async () => {

--- a/packages/cli/tests/fixtures/defaults.config.ts
+++ b/packages/cli/tests/fixtures/defaults.config.ts
@@ -1,0 +1,36 @@
+import { channel, defineNotifyKitConfig, fakeEmailProvider } from "./_helpers.js";
+
+const inbox = channel.inbox();
+const email = channel.email();
+
+export default defineNotifyKitConfig({
+  notifications: [
+    {
+      id: "comment_mentioned",
+      payload: {
+        actorName: "string",
+        postTitle: "string",
+        postUrl: "string",
+      },
+      channels: [
+        inbox({
+          title: "{{actorName}} mentioned you",
+          body: "In {{postTitle}}",
+          actionUrl: "{{postUrl}}",
+        }),
+        email({
+          subject: "{{actorName}} mentioned you in {{postTitle}}",
+          body: "Open {{postUrl}} to reply.",
+        }),
+      ],
+    },
+  ],
+  providers: {
+    email: fakeEmailProvider(),
+  },
+  defaults: {
+    channels: {
+      email: false,
+    },
+  },
+});

--- a/packages/cli/tests/fixtures/failing-provider.config.ts
+++ b/packages/cli/tests/fixtures/failing-provider.config.ts
@@ -1,0 +1,32 @@
+import { channel, defineNotifyKitConfig } from "./_helpers.js";
+
+const email = channel.email();
+
+export default defineNotifyKitConfig({
+  notifications: [
+    {
+      id: "provider_fails",
+      payload: {
+        msg: "string",
+      },
+      channels: [
+        email({
+          subject: "{{msg}}",
+          body: "{{msg}}",
+        }),
+      ],
+    },
+  ],
+  providers: {
+    email: {
+      id: "always-fails",
+      async send() {
+        throw new Error("provider unavailable");
+      },
+    },
+  },
+  retry: {
+    maxAttempts: 1,
+    delayMs: () => 0,
+  },
+});

--- a/packages/cli/tests/fixtures/runtime-options.config.ts
+++ b/packages/cli/tests/fixtures/runtime-options.config.ts
@@ -1,0 +1,27 @@
+import { channel, defineNotifyKitConfig, fakeEmailProvider } from "./_helpers.js";
+
+const inbox = channel.inbox();
+
+export default defineNotifyKitConfig({
+  notifications: [
+    {
+      id: "runtime_options",
+      payload: {
+        message: "string",
+      },
+      channels: [
+        inbox({
+          title: "{{message}}",
+        }),
+      ],
+    },
+  ],
+  providers: {
+    email: fakeEmailProvider(),
+  },
+  retry: {
+    maxAttempts: 0,
+  },
+  idempotencyKeyTtlMs: 0,
+  timelineRetentionMs: Number.NaN,
+});

--- a/packages/cli/tests/validate.test.ts
+++ b/packages/cli/tests/validate.test.ts
@@ -124,6 +124,16 @@ describe("validateNotifications", () => {
     expect(issues.some((i) => i.code === "INVALID_CHANNEL_SHAPE")).toBe(true);
   });
 
+  test("flags unknown primary channel types", () => {
+    const def = notification({
+      id: "bad_channel",
+      payload: { x: "string" },
+      channels: [{ type: "push", title: "{{x}}" } as never],
+    });
+    const issues = validateNotifications([def]);
+    expect(issues.some((i) => i.code === "UNKNOWN_CHANNEL_TYPE")).toBe(true);
+  });
+
   test("flags invalid fallback from channel", () => {
     const def = notification({
       id: "bad_fb",
@@ -135,6 +145,25 @@ describe("validateNotifications", () => {
     });
     const issues = validateNotifications([def]);
     expect(issues.some((i) => i.code === "INVALID_FALLBACK_FROM")).toBe(true);
+  });
+
+  test("flags unknown fallback target channel types", () => {
+    const def = notification({
+      id: "bad_fb_target",
+      payload: { x: "string" },
+      channels: [inbox({ title: "{{x}}" })],
+      fallback: [
+        {
+          if: "channel.failed",
+          from: "email",
+          then: { type: "push", body: "{{x}}" } as never,
+        },
+      ],
+    });
+    const issues = validateNotifications([def]);
+    expect(
+      issues.some((i) => i.code === "UNKNOWN_FALLBACK_CHANNEL_TYPE"),
+    ).toBe(true);
   });
 
   test("flags unknown channel type in defaults.channels", () => {
@@ -357,6 +386,28 @@ describe("validateNotifications", () => {
     expect(issues.some((i) => i.code === "WEBHOOK_NO_SECRET")).toBe(true);
   });
 
+  test("warns when unsigned webhook provider is only used by fallback", () => {
+    const def = notification({
+      id: "fallback_webhook_nosign",
+      payload: { x: "string" },
+      channels: [email({ subject: "{{x}}", body: "{{x}}" })],
+      fallback: [
+        {
+          if: "channel.failed",
+          from: "email",
+          then: { type: "webhook", url: "https://example.com/hook" } as unknown as ChannelConfig,
+        },
+      ],
+    });
+    const issues = validateNotifications([def], {
+      providers: {
+        email: fakeEmailProvider(),
+        webhook: { id: "webhook", signed: false, send: async () => ({}) },
+      },
+    });
+    expect(issues.some((i) => i.code === "WEBHOOK_NO_SECRET")).toBe(true);
+  });
+
   test("no webhook warning when signed", () => {
     const def = notification({
       id: "webhook_signed",
@@ -367,5 +418,45 @@ describe("validateNotifications", () => {
       providers: { webhook: { id: "webhook", signed: true, send: async () => ({}) } },
     });
     expect(issues.filter((i) => i.code === "WEBHOOK_NO_SECRET")).toEqual([]);
+  });
+
+  test("flags reserved webhook Host headers", () => {
+    const def = notification({
+      id: "webhook_host",
+      payload: { x: "string" },
+      channels: [
+        {
+          type: "webhook",
+          url: "https://example.com/hook",
+          headers: { Host: "evil.example" },
+        } as unknown as ChannelConfig,
+      ],
+    });
+    const issues = validateNotifications([def], {
+      providers: { webhook: { id: "webhook", signed: true, send: async () => ({}) } },
+    });
+    expect(issues.some((i) => i.code === "RESERVED_WEBHOOK_HEADER")).toBe(true);
+  });
+
+  test("flags invalid webhook header names and values", () => {
+    const def = notification({
+      id: "webhook_bad_headers",
+      payload: { x: "string" },
+      channels: [
+        {
+          type: "webhook",
+          url: "https://example.com/hook",
+          headers: {
+            "x good": "{{x}}",
+            "x-number": 123,
+          },
+        } as unknown as ChannelConfig,
+      ],
+    });
+    const issues = validateNotifications([def], {
+      providers: { webhook: { id: "webhook", signed: true, send: async () => ({}) } },
+    });
+    expect(issues.some((i) => i.code === "INVALID_WEBHOOK_HEADER_NAME")).toBe(true);
+    expect(issues.some((i) => i.code === "INVALID_WEBHOOK_HEADER_VALUE")).toBe(true);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,9 @@
   },
   "homepage": "https://github.com/reyabsaluja/notifykit",
   "bugs": "https://github.com/reyabsaluja/notifykit/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -426,13 +426,18 @@ export type CapturedSend = {
   timestamp: Date;
 };
 
+type DevProvidersResult = {
+  providers: { email?: EmailProvider; webhook?: WebhookProvider; sms?: SmsProvider };
+  captured: CapturedSend[];
+};
+
 function applyDevProviders(
   providers: CreateNotifyKitInput<any>["providers"],
   allowlist: string[],
   subjectPrefix: string,
   logPreviews: boolean,
   maxCaptured: number,
-): { email?: EmailProvider; webhook?: WebhookProvider; sms?: SmsProvider } {
+): DevProvidersResult {
   const captured: CapturedSend[] = [];
   let idCounter = 0;
 
@@ -504,13 +509,14 @@ function applyDevProviders(
     };
   })();
 
-  const result = {
-    email: wrappedEmail,
-    webhook: wrappedWebhook,
-    sms: wrappedSms,
-  } as { email?: EmailProvider; webhook?: WebhookProvider; sms?: SmsProvider; _captured: CapturedSend[] };
-  (result as any)._captured = captured;
-  return result;
+  return {
+    providers: {
+      email: wrappedEmail,
+      webhook: wrappedWebhook,
+      sms: wrappedSms,
+    },
+    captured,
+  };
 }
 
 export function createNotifyKit<
@@ -526,9 +532,11 @@ export function createNotifyKit<
   const devLogPreviews = devConfig.logPreviews ?? false;
   const devMaxCaptured = Math.max(devConfig.maxCaptured ?? 1000, 1);
 
-  const providers = isDev
+  const devResult = isDev
     ? applyDevProviders(config.providers, devAllowlist, devSubjectPrefix, devLogPreviews, devMaxCaptured)
-    : config.providers;
+    : null;
+  const providers = devResult ? devResult.providers : config.providers;
+  const devCaptured: CapturedSend[] = devResult ? devResult.captured : [];
 
   const { notifications, database, on } = config;
   const onTimelineError = config.onTimelineError ?? ((err: unknown) => {
@@ -3055,7 +3063,7 @@ export function createNotifyKit<
     definitions: notifications,
     realtime: realtimeAdapter,
     isDev,
-    captured: isDev ? (providers as any)._captured ?? [] : [],
+    captured: devCaptured,
     redactPayload(notificationId, payload) {
       const def = byId.get(notificationId);
       if (!def) {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -471,7 +471,7 @@ function applyDevProviders(
         id: providers.webhook.id,
         signed: providers.webhook.signed,
         async send(input) {
-          const blocked = allowlist.length > 0 && !isAllowed(input.url);
+          const blocked = !isAllowed(input.url);
           const body = JSON.stringify(input.payload);
           captured.push({ channel: "webhook", to: input.url, body, blocked, timestamp: new Date() });
           logPreview("webhook", input.url, undefined, body, blocked);

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -164,6 +164,11 @@ export type CreateNotifyKitInput<
    */
   onTimelineError?: (error: unknown) => void;
   /**
+   * Called when a lifecycle hook throws. Defaults to re-throwing (halts the
+   * pipeline). Return or resolve to swallow the error silently.
+   */
+  onHookError?: (hookName: string, error: unknown) => void | Promise<void>;
+  /**
    * How long to retain timeline events. Events older than this are pruned
    * opportunistically during flush. Default: 7 days. Set to `0` to disable.
    */
@@ -539,6 +544,7 @@ export function createNotifyKit<
   const devCaptured: CapturedSend[] = devResult ? devResult.captured : [];
 
   const { notifications, database, on } = config;
+  const onHookError = config.onHookError;
   const onTimelineError = config.onTimelineError ?? ((err: unknown) => {
     console.error("[notifykit] timeline append error:", err);
   });
@@ -634,7 +640,13 @@ export function createNotifyKit<
       // @ts-expect-error — dispatch to the user-provided hook with matching args
       await fn(...args);
     } catch (err) {
-      console.error(`[notifykit] hook "${String(name)}" error:`, err);
+      if (onHookError) {
+        await onHookError(String(name), err);
+      } else {
+        throw err instanceof Error
+          ? err
+          : new Error(`Hook "${String(name)}" threw a non-error value.`);
+      }
     }
   }
 

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -604,6 +604,9 @@ export function createNotifyKit<
   if (isDev) {
     const allow = devAllowlist.length > 0 ? ` Allowlist: ${devAllowlist.join(", ")}` : " All external sends blocked.";
     console.log(`[notifykit] Development mode active.${allow}`);
+    if (!config.providers?.email && notifications.some((n) => n.channels.some((ch) => ch.type === "email"))) {
+      console.warn("[notifykit:dev] No email provider configured. Dev mode will sandbox email sends, but production will fail without a provider.");
+    }
   }
 
   function buildUnsubscribeUrl(

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -524,7 +524,7 @@ export function createNotifyKit<
   const devAllowlist = devConfig.allowlist ?? [];
   const devSubjectPrefix = devConfig.subjectPrefix ?? "[DEV] ";
   const devLogPreviews = devConfig.logPreviews ?? isDev;
-  const devMaxCaptured = devConfig.maxCaptured ?? 1000;
+  const devMaxCaptured = Math.max(devConfig.maxCaptured ?? 1000, 1);
 
   const providers = isDev
     ? applyDevProviders(config.providers, devAllowlist, devSubjectPrefix, devLogPreviews, devMaxCaptured)

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -523,7 +523,7 @@ export function createNotifyKit<
   const devConfig: DevModeConfig = isDev ? (config.dev ?? {}) : {};
   const devAllowlist = devConfig.allowlist ?? [];
   const devSubjectPrefix = devConfig.subjectPrefix ?? "[DEV] ";
-  const devLogPreviews = devConfig.logPreviews ?? isDev;
+  const devLogPreviews = devConfig.logPreviews ?? false;
   const devMaxCaptured = Math.max(devConfig.maxCaptured ?? 1000, 1);
 
   const providers = isDev

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -43,7 +43,7 @@ import type {
 } from "./types.js";
 import type { RealtimeAdapter } from "./realtime.js";
 import { defaultRetryPolicy, inlineQueue } from "./queues.js";
-import { isWithinQuietHours, nextQuietHoursEnd } from "./quiet-hours.js";
+import { isWithinQuietHours, nextQuietHoursEnd, validateQuietHours } from "./quiet-hours.js";
 import {
   GLOBAL_PREFERENCE_KEY,
   categoryPreferenceKey,
@@ -59,6 +59,34 @@ export const SKIP_PROVIDER = "skip" as const;
 
 function buildDedupeCompositeKey(notificationId: string, recipientId: string, dedupeKey: string): string {
   return JSON.stringify(["dedup", notificationId, recipientId, dedupeKey]);
+}
+
+function normalizeListLimit(limit: number | undefined, field: string): number | undefined {
+  if (limit === undefined) return undefined;
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new NotifyKitError(
+      `${field} must be a positive integer.`,
+      {
+        code: "INVALID_LIMIT",
+        field,
+        fix: "Pass a positive integer limit, or omit the option to use the default.",
+      },
+    );
+  }
+  return limit;
+}
+
+function assertNonEmptyIdentifier(value: string, field: string): void {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new NotifyKitError(
+      `${field} must be a non-empty string.`,
+      {
+        code: "INVALID_INPUT",
+        field,
+        fix: `Pass a non-empty ${field}.`,
+      },
+    );
+  }
 }
 
 export type CreateNotifyKitInput<
@@ -417,6 +445,7 @@ export function createNotifyKit<
       digests: database.digests,
       rateLimits: database.rateLimits,
     },
+    retry: config.retry,
     idempotencyKeyTtlMs: config.idempotencyKeyTtlMs,
     timelineRetentionMs: config.timelineRetentionMs,
   });
@@ -469,10 +498,7 @@ export function createNotifyKit<
       // @ts-expect-error — dispatch to the user-provided hook with matching args
       await fn(...args);
     } catch (err) {
-      // Surface hook errors; userland can catch if needed
-      throw err instanceof Error
-        ? err
-        : new Error(`Hook "${String(name)}" threw a non-error value.`);
+      console.error(`[notifykit] hook "${String(name)}" error:`, err);
     }
   }
 
@@ -601,6 +627,15 @@ export function createNotifyKit<
   const fallbackDeliveryIds = new Set<string>();
 
   function normalizeOrgId(scope: SecurityScope): SecurityScope {
+    if (scope.tenantId !== undefined) {
+      assertNonEmptyIdentifier(scope.tenantId, "tenantId");
+    }
+    if (scope.organizationId !== undefined) {
+      assertNonEmptyIdentifier(scope.organizationId, "organizationId");
+    }
+    if (scope.workspaceId !== undefined) {
+      assertNonEmptyIdentifier(scope.workspaceId, "workspaceId");
+    }
     if (scope.organizationId && !scope.tenantId) {
       return { ...scope, tenantId: scope.organizationId, organizationId: undefined };
     }
@@ -921,16 +956,7 @@ export function createNotifyKit<
       dedupeKey?: string;
       dedupeWindowMs?: number;
     };
-    if (!input.recipientId) {
-      throw new NotifyKitError(
-        "Missing recipientId.",
-        {
-          code: "INVALID_INPUT",
-          field: "recipientId",
-          fix: "Pass a non-empty recipientId to send().",
-        },
-      );
-    }
+    assertNonEmptyIdentifier(input.recipientId, "recipientId");
     const def = byId.get(input.notificationId);
     if (!def) {
       const known = [...byId.keys()];
@@ -1277,12 +1303,7 @@ export function createNotifyKit<
       dedupeKey?: string;
       dedupeWindowMs?: number;
     };
-    if (!input.recipientId) {
-      throw new NotifyKitError(
-        "Missing recipientId.",
-        { code: "INVALID_INPUT", field: "recipientId", fix: "Pass a non-empty recipientId to send()." },
-      );
-    }
+    assertNonEmptyIdentifier(input.recipientId, "recipientId");
     const def = byId.get(input.notificationId);
     if (!def) {
       throw new NotifyKitError(
@@ -1809,6 +1830,7 @@ export function createNotifyKit<
       const headers: Record<string, string> = { host: hostHeader };
       if (ch.headers) {
         for (const [k, v] of Object.entries(ch.headers)) {
+          if (k.toLowerCase() === "host") continue;
           headers[k] = renderTemplate(v, ctx.payload, { escapeHtml: false }).replace(/[\r\n]/g, "");
         }
       }
@@ -2094,6 +2116,7 @@ export function createNotifyKit<
         const headers: Record<string, string> = { host: hostHeader };
         if (ch.headers) {
           for (const [k, v] of Object.entries(ch.headers)) {
+            if (k.toLowerCase() === "host") continue;
             headers[k] = renderTemplate(v, payload, { escapeHtml: false }).replace(/[\r\n]/g, "");
           }
         }
@@ -2257,9 +2280,38 @@ export function createNotifyKit<
     };
     try {
       let lastError: Error | null = null;
+      let attemptsMade = 0;
       for (let attempt = 1; attempt <= retry.maxAttempts; attempt++) {
+        attemptsMade = attempt;
         if (attempt > 1) {
-          const wait = retry.delayMs(attempt);
+          let wait: number;
+          try {
+            wait = retry.delayMs(attempt);
+            if (!Number.isFinite(wait) || wait < 0) {
+              throw new NotifyKitError(
+                `retry.delayMs(${attempt}) must return a non-negative finite number, got ${wait}.`,
+                {
+                  code: "INVALID_RETRY_DELAY",
+                  field: "retry.delayMs",
+                  fix: "Return a non-negative millisecond delay for every retry attempt.",
+                },
+              );
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            lastError = err instanceof NotifyKitError
+              ? err
+              : new NotifyKitError(
+                `retry.delayMs(${attempt}) threw: ${message}`,
+                {
+                  code: "INVALID_RETRY_DELAY",
+                  field: "retry.delayMs",
+                  fix: "Ensure retry.delayMs returns a non-negative millisecond delay for every retry attempt.",
+                },
+              );
+            attemptsMade = attempt - 1;
+            break;
+          }
           recordTimeline(jobPending, jobTlCtx, "delivery.attempt", `Retry attempt ${attempt}/${retry.maxAttempts} (delay: ${wait}ms)`, {
             deliveryId: job.deliveryId,
             channel: job.channel,
@@ -2356,13 +2408,15 @@ export function createNotifyKit<
       }
       const failed = await database.deliveries.update(job.deliveryId, {
         status: "failed",
+        attempts: attemptsMade,
+        error: lastError?.message,
         failedAt: new Date(),
       });
-      recordTimeline(jobPending, jobTlCtx, "delivery.failed", `Delivery failed after ${retry.maxAttempts} attempt(s): ${lastError?.message ?? "unknown error"}`, {
+      recordTimeline(jobPending, jobTlCtx, "delivery.failed", `Delivery failed after ${attemptsMade} attempt(s): ${lastError?.message ?? "unknown error"}`, {
         deliveryId: job.deliveryId,
         channel: job.channel,
         provider: job.provider,
-        metadata: { attempts: retry.maxAttempts, error: lastError?.message },
+        metadata: { attempts: attemptsMade, error: lastError?.message },
       });
       const isFallbackDelivery = fallbackDeliveryIds.has(job.deliveryId);
       fallbackDeliveryIds.delete(job.deliveryId);
@@ -2540,8 +2594,23 @@ export function createNotifyKit<
 
   return {
     async upsertRecipient(input) {
+      assertNonEmptyIdentifier(input.id, "id");
+      if (input.quietHours != null) {
+        const quietHoursError = validateQuietHours(input.quietHours);
+        if (quietHoursError) {
+          throw new NotifyKitError(
+            `Invalid quietHours: ${quietHoursError}`,
+            {
+              code: "INVALID_QUIET_HOURS",
+              field: "quietHours",
+              fix: "Use { start: \"HH:MM\", end: \"HH:MM\", timezone?: \"Area/City\" }, or pass null to clear quiet hours.",
+            },
+          );
+        }
+      }
       const normalized = normalizeOrgId(input);
       const tenantId = normalized.tenantId;
+      const workspaceId = normalized.workspaceId;
       const existing = await database.recipients.findById(input.id);
       if (existing && existing.tenantId && tenantId && existing.tenantId !== tenantId) {
         throw new NotifyKitError(
@@ -2550,6 +2619,16 @@ export function createNotifyKit<
             code: "TENANT_REASSIGNMENT",
             recipientId: input.id,
             fix: "Create a new recipient for the target tenant instead of reassigning an existing one.",
+          },
+        );
+      }
+      if (existing && existing.workspaceId && workspaceId && existing.workspaceId !== workspaceId) {
+        throw new NotifyKitError(
+          `Recipient "${input.id}" already belongs to workspace "${existing.workspaceId}", cannot reassign to "${workspaceId}".`,
+          {
+            code: "WORKSPACE_REASSIGNMENT",
+            recipientId: input.id,
+            fix: "Create a new recipient for the target workspace instead of reassigning an existing one.",
           },
         );
       }
@@ -2570,7 +2649,7 @@ export function createNotifyKit<
     inbox: {
       list(recipientId, scope, filter, limit?) {
         const s = scope ? normalizeOrgId(scope) : scope;
-        return database.inbox.listByRecipient(recipientId, s, filter, limit);
+        return database.inbox.listByRecipient(recipientId, s, filter, normalizeListLimit(limit, "inbox.limit"));
       },
       async markReadForRecipient(inboxItemId, recipientId, scope) {
         const s = scope ? normalizeOrgId(scope) : scope;
@@ -2644,7 +2723,7 @@ export function createNotifyKit<
     deliveries: {
       list(recipientId, scope, limit?) {
         const s = scope ? normalizeOrgId(scope) : scope;
-        return database.deliveries.list(recipientId, s, limit);
+        return database.deliveries.list(recipientId, s, normalizeListLimit(limit, "deliveries.limit"));
       },
     },
     preferences: {
@@ -2863,7 +2942,7 @@ export function createNotifyKit<
       return redactPayload(payload, def.redact);
     },
     async timeline(notificationRecordId, options) {
-      const cap = options?.limit ?? 1000;
+      const cap = normalizeListLimit(options?.limit, "timeline.limit") ?? 1000;
       if (options?.deliveryId) {
         return timelineAdapter.listByDeliveryId(options.deliveryId, notificationRecordId, cap);
       }

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -517,6 +517,9 @@ export function createNotifyKit<
   const T extends readonly NotificationDefinition<string, PayloadSchema>[],
 >(config: CreateNotifyKitInput<T>): NotifyKit<T> {
   const isDev = config.mode === "development";
+  if (isDev && typeof process !== "undefined" && process.env?.NODE_ENV === "production") {
+    console.warn("[notifykit] WARNING: mode: \"development\" is active but NODE_ENV=production. All external sends are being blocked. Remove mode: \"development\" for production use.");
+  }
   const devConfig: DevModeConfig = isDev ? (config.dev ?? {}) : {};
   const devAllowlist = devConfig.allowlist ?? [];
   const devSubjectPrefix = devConfig.subjectPrefix ?? "[DEV] ";

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -89,6 +89,12 @@ function assertNonEmptyIdentifier(value: string, field: string): void {
   }
 }
 
+export type DevModeConfig = {
+  allowlist?: string[];
+  subjectPrefix?: string;
+  logPreviews?: boolean;
+};
+
 export type CreateNotifyKitInput<
   T extends readonly NotificationDefinition<string, PayloadSchema>[],
 > = {
@@ -99,6 +105,8 @@ export type CreateNotifyKitInput<
     webhook?: WebhookProvider;
     sms?: SmsProvider;
   };
+  mode?: "production" | "development";
+  dev?: DevModeConfig;
   on?: Hooks;
   /**
    * Queue used to run provider deliveries (email, webhook, SMS). Defaults to
@@ -402,12 +410,115 @@ export type NotifyKit<
    * core inbox mutations publish their own realtime events.
    */
   readonly realtime: RealtimeAdapter | undefined;
+  /** True when `mode: "development"` was passed. */
+  readonly isDev: boolean;
+  /** Dev mode captured sends. Only populated when `mode: "development"`. */
+  readonly captured: CapturedSend[];
 };
+
+export type CapturedSend = {
+  channel: "email" | "webhook" | "sms";
+  to: string;
+  subject?: string;
+  body: string;
+  blocked: boolean;
+  timestamp: Date;
+};
+
+function applyDevProviders(
+  providers: CreateNotifyKitInput<any>["providers"],
+  allowlist: string[],
+  subjectPrefix: string,
+  logPreviews: boolean,
+): { email?: EmailProvider; webhook?: WebhookProvider; sms?: SmsProvider } {
+  const captured: CapturedSend[] = [];
+
+  function isAllowed(to: string): boolean {
+    if (allowlist.length === 0) return false;
+    return allowlist.some((a) => to.toLowerCase() === a.toLowerCase());
+  }
+
+  function logPreview(channel: string, to: string, subject: string | undefined, body: string, blocked: boolean) {
+    if (!logPreviews) return;
+    const status = blocked ? "BLOCKED" : "SENT";
+    const subj = subject ? ` | Subject: ${subject}` : "";
+    console.log(`[notifykit:dev] ${status} ${channel} → ${to}${subj}`);
+    if (body.length <= 200) {
+      console.log(`[notifykit:dev]   Body: ${body}`);
+    } else {
+      console.log(`[notifykit:dev]   Body: ${body.slice(0, 200)}…`);
+    }
+  }
+
+  const wrappedEmail: EmailProvider | undefined = (() => {
+    const real = providers?.email;
+    return {
+      id: real?.id ?? "dev-sandbox",
+      async send(input: { to: string; subject: string; body: string }) {
+        const blocked = !isAllowed(input.to);
+        const subject = `${subjectPrefix}${input.subject}`;
+        captured.push({ channel: "email", to: input.to, subject, body: input.body, blocked, timestamp: new Date() });
+        logPreview("email", input.to, subject, input.body, blocked);
+        if (blocked) return { providerMessageId: `dev-blocked-${Date.now()}` };
+        if (real) return real.send({ ...input, subject });
+        return { providerMessageId: `dev-sandbox-${Date.now()}` };
+      },
+    };
+  })();
+
+  const wrappedWebhook: WebhookProvider | undefined = providers?.webhook
+    ? {
+        id: providers.webhook.id,
+        signed: providers.webhook.signed,
+        async send(input) {
+          const blocked = allowlist.length > 0 && !isAllowed(input.url);
+          const body = JSON.stringify(input.payload);
+          captured.push({ channel: "webhook", to: input.url, body, blocked, timestamp: new Date() });
+          logPreview("webhook", input.url, undefined, body, blocked);
+          if (blocked) return { providerMessageId: `dev-blocked-${Date.now()}` };
+          return providers!.webhook!.send(input);
+        },
+      }
+    : undefined;
+
+  const wrappedSms: SmsProvider | undefined = (() => {
+    const real = providers?.sms;
+    if (!real) return undefined;
+    return {
+      id: real.id,
+      async send(input: { to: string; body: string }) {
+        const blocked = !isAllowed(input.to);
+        captured.push({ channel: "sms", to: input.to, body: input.body, blocked, timestamp: new Date() });
+        logPreview("sms", input.to, undefined, input.body, blocked);
+        if (blocked) return { providerMessageId: `dev-blocked-${Date.now()}` };
+        return real.send(input);
+      },
+    };
+  })();
+
+  const result = {
+    email: wrappedEmail,
+    webhook: wrappedWebhook,
+    sms: wrappedSms,
+  } as { email?: EmailProvider; webhook?: WebhookProvider; sms?: SmsProvider; _captured: CapturedSend[] };
+  (result as any)._captured = captured;
+  return result;
+}
 
 export function createNotifyKit<
   const T extends readonly NotificationDefinition<string, PayloadSchema>[],
 >(config: CreateNotifyKitInput<T>): NotifyKit<T> {
-  const { notifications, database, providers, on } = config;
+  const isDev = config.mode === "development";
+  const devConfig: DevModeConfig = isDev ? (config.dev ?? {}) : {};
+  const devAllowlist = devConfig.allowlist ?? [];
+  const devSubjectPrefix = devConfig.subjectPrefix ?? "[DEV] ";
+  const devLogPreviews = devConfig.logPreviews ?? isDev;
+
+  const providers = isDev
+    ? applyDevProviders(config.providers, devAllowlist, devSubjectPrefix, devLogPreviews)
+    : config.providers;
+
+  const { notifications, database, on } = config;
   const onTimelineError = config.onTimelineError ?? ((err: unknown) => {
     console.error("[notifykit] timeline append error:", err);
   });
@@ -462,6 +573,11 @@ export function createNotifyKit<
       const loc = w.notificationId ? `[${w.notificationId}] ` : "";
       console.warn(`[notifykit] ${loc}${w.message}${w.fix ? ` ${w.fix}` : ""}`);
     }
+  }
+
+  if (isDev) {
+    const allow = devAllowlist.length > 0 ? ` Allowlist: ${devAllowlist.join(", ")}` : " All external sends blocked.";
+    console.log(`[notifykit] Development mode active.${allow}`);
   }
 
   function buildUnsubscribeUrl(
@@ -2926,6 +3042,8 @@ export function createNotifyKit<
     },
     definitions: notifications,
     realtime: realtimeAdapter,
+    isDev,
+    captured: isDev ? (providers as any)._captured ?? [] : [],
     redactPayload(notificationId, payload) {
       const def = byId.get(notificationId);
       if (!def) {

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -432,6 +432,7 @@ function applyDevProviders(
   logPreviews: boolean,
 ): { email?: EmailProvider; webhook?: WebhookProvider; sms?: SmsProvider } {
   const captured: CapturedSend[] = [];
+  let idCounter = 0;
 
   function isAllowed(to: string): boolean {
     if (allowlist.length === 0) return false;
@@ -459,9 +460,9 @@ function applyDevProviders(
         const subject = `${subjectPrefix}${input.subject}`;
         captured.push({ channel: "email", to: input.to, subject, body: input.body, blocked, timestamp: new Date() });
         logPreview("email", input.to, subject, input.body, blocked);
-        if (blocked) return { providerMessageId: `dev-blocked-${Date.now()}` };
+        if (blocked) return { providerMessageId: `dev-blocked-${++idCounter}` };
         if (real) return real.send({ ...input, subject });
-        return { providerMessageId: `dev-sandbox-${Date.now()}` };
+        return { providerMessageId: `dev-sandbox-${++idCounter}` };
       },
     };
   })();
@@ -475,7 +476,7 @@ function applyDevProviders(
           const body = JSON.stringify(input.payload);
           captured.push({ channel: "webhook", to: input.url, body, blocked, timestamp: new Date() });
           logPreview("webhook", input.url, undefined, body, blocked);
-          if (blocked) return { providerMessageId: `dev-blocked-${Date.now()}` };
+          if (blocked) return { providerMessageId: `dev-blocked-${++idCounter}` };
           return providers!.webhook!.send(input);
         },
       }
@@ -490,7 +491,7 @@ function applyDevProviders(
         const blocked = !isAllowed(input.to);
         captured.push({ channel: "sms", to: input.to, body: input.body, blocked, timestamp: new Date() });
         logPreview("sms", input.to, undefined, input.body, blocked);
-        if (blocked) return { providerMessageId: `dev-blocked-${Date.now()}` };
+        if (blocked) return { providerMessageId: `dev-blocked-${++idCounter}` };
         return real.send(input);
       },
     };

--- a/packages/core/src/create-notifykit.ts
+++ b/packages/core/src/create-notifykit.ts
@@ -93,6 +93,7 @@ export type DevModeConfig = {
   allowlist?: string[];
   subjectPrefix?: string;
   logPreviews?: boolean;
+  maxCaptured?: number;
 };
 
 export type CreateNotifyKitInput<
@@ -430,9 +431,15 @@ function applyDevProviders(
   allowlist: string[],
   subjectPrefix: string,
   logPreviews: boolean,
+  maxCaptured: number,
 ): { email?: EmailProvider; webhook?: WebhookProvider; sms?: SmsProvider } {
   const captured: CapturedSend[] = [];
   let idCounter = 0;
+
+  function capture(entry: CapturedSend) {
+    if (captured.length >= maxCaptured) captured.shift();
+    captured.push(entry);
+  }
 
   function isAllowed(to: string): boolean {
     if (allowlist.length === 0) return false;
@@ -458,7 +465,7 @@ function applyDevProviders(
       async send(input: { to: string; subject: string; body: string }) {
         const blocked = !isAllowed(input.to);
         const subject = `${subjectPrefix}${input.subject}`;
-        captured.push({ channel: "email", to: input.to, subject, body: input.body, blocked, timestamp: new Date() });
+        capture({ channel: "email", to: input.to, subject, body: input.body, blocked, timestamp: new Date() });
         logPreview("email", input.to, subject, input.body, blocked);
         if (blocked) return { providerMessageId: `dev-blocked-${++idCounter}` };
         if (real) return real.send({ ...input, subject });
@@ -474,7 +481,7 @@ function applyDevProviders(
         async send(input) {
           const blocked = !isAllowed(input.url);
           const body = JSON.stringify(input.payload);
-          captured.push({ channel: "webhook", to: input.url, body, blocked, timestamp: new Date() });
+          capture({ channel: "webhook", to: input.url, body, blocked, timestamp: new Date() });
           logPreview("webhook", input.url, undefined, body, blocked);
           if (blocked) return { providerMessageId: `dev-blocked-${++idCounter}` };
           return providers!.webhook!.send(input);
@@ -489,7 +496,7 @@ function applyDevProviders(
       id: real.id,
       async send(input: { to: string; body: string }) {
         const blocked = !isAllowed(input.to);
-        captured.push({ channel: "sms", to: input.to, body: input.body, blocked, timestamp: new Date() });
+        capture({ channel: "sms", to: input.to, body: input.body, blocked, timestamp: new Date() });
         logPreview("sms", input.to, undefined, input.body, blocked);
         if (blocked) return { providerMessageId: `dev-blocked-${++idCounter}` };
         return real.send(input);
@@ -514,9 +521,10 @@ export function createNotifyKit<
   const devAllowlist = devConfig.allowlist ?? [];
   const devSubjectPrefix = devConfig.subjectPrefix ?? "[DEV] ";
   const devLogPreviews = devConfig.logPreviews ?? isDev;
+  const devMaxCaptured = devConfig.maxCaptured ?? 1000;
 
   const providers = isDev
-    ? applyDevProviders(config.providers, devAllowlist, devSubjectPrefix, devLogPreviews)
+    ? applyDevProviders(config.providers, devAllowlist, devSubjectPrefix, devLogPreviews, devMaxCaptured)
     : config.providers;
 
   const { notifications, database, on } = config;

--- a/packages/core/src/handler.ts
+++ b/packages/core/src/handler.ts
@@ -179,6 +179,28 @@ export function createHandler<
   const unsubscribeSecret = options.unsubscribeSecret;
   const corsOrigin = options.cors ?? null;
   const requestRateLimit = options.requestRateLimit ?? null;
+  if (requestRateLimit) {
+    if (!Number.isSafeInteger(requestRateLimit.max) || requestRateLimit.max <= 0) {
+      throw new NotifyKitError(
+        "requestRateLimit.max must be a positive integer.",
+        {
+          code: "INVALID_HANDLER_CONFIG",
+          field: "requestRateLimit.max",
+          fix: "Set requestRateLimit.max to a positive integer, or omit requestRateLimit.",
+        },
+      );
+    }
+    if (!Number.isFinite(requestRateLimit.windowMs) || requestRateLimit.windowMs <= 0) {
+      throw new NotifyKitError(
+        "requestRateLimit.windowMs must be a positive number.",
+        {
+          code: "INVALID_HANDLER_CONFIG",
+          field: "requestRateLimit.windowMs",
+          fix: "Set requestRateLimit.windowMs to a positive millisecond value, or omit requestRateLimit.",
+        },
+      );
+    }
+  }
   const debug = options.debug ?? false;
   const rateLimitBuckets = new Map<string, number[]>();
   let lastSweep = Date.now();
@@ -194,8 +216,13 @@ export function createHandler<
   }
 
   /** Returns 0 when allowed, or the number of seconds until the next slot opens (for Retry-After). */
-  function checkRateLimit(recipientId: string): number {
+  function identityBucketKey(identity: Pick<HandlerIdentity, "recipientId" | "tenantId" | "workspaceId">): string {
+    return JSON.stringify([identity.recipientId, identity.tenantId ?? "", identity.workspaceId ?? ""]);
+  }
+
+  function checkRateLimit(identity: HandlerIdentity): number {
     if (!requestRateLimit) return 0;
+    const bucketKey = identityBucketKey(identity);
     const now = Date.now();
     const cutoff = now - requestRateLimit.windowMs;
 
@@ -208,7 +235,7 @@ export function createHandler<
       }
     }
 
-    let timestamps = rateLimitBuckets.get(recipientId);
+    let timestamps = rateLimitBuckets.get(bucketKey);
     if (timestamps) {
       let pruneCount = 0;
       while (pruneCount < timestamps.length && timestamps[pruneCount]! < cutoff) {
@@ -217,10 +244,10 @@ export function createHandler<
       if (pruneCount > 0) {
         timestamps = timestamps.slice(pruneCount);
         if (timestamps.length === 0) {
-          rateLimitBuckets.delete(recipientId);
+          rateLimitBuckets.delete(bucketKey);
           timestamps = undefined;
         } else {
-          rateLimitBuckets.set(recipientId, timestamps);
+          rateLimitBuckets.set(bucketKey, timestamps);
         }
       }
     }
@@ -228,7 +255,7 @@ export function createHandler<
       const oldest = timestamps[0]!;
       return Math.max(1, Math.ceil((oldest + requestRateLimit.windowMs - now) / 1000));
     }
-    if (rateLimitBuckets.size >= MAX_BUCKETS && !rateLimitBuckets.has(recipientId)) {
+    if (rateLimitBuckets.size >= MAX_BUCKETS && !rateLimitBuckets.has(bucketKey)) {
       let oldestKey: string | null = null;
       let oldestTime = Infinity;
       for (const [key, ts] of rateLimitBuckets) {
@@ -242,7 +269,7 @@ export function createHandler<
     }
     if (!timestamps) {
       timestamps = [];
-      rateLimitBuckets.set(recipientId, timestamps);
+      rateLimitBuckets.set(bucketKey, timestamps);
     }
     timestamps.push(now);
     return 0;
@@ -281,7 +308,7 @@ export function createHandler<
       return withCors(new Response(null, { status: 204 }), request);
     }
 
-    const sub = path.slice(basePath.length) || "/";
+    const sub = basePath === "/" ? path : path.slice(basePath.length) || "/";
 
     const route = matchRoute(request.method, sub);
     if (route.kind === "not_found") {
@@ -304,7 +331,7 @@ export function createHandler<
           }, 401));
         }
         if (requestRateLimit) {
-          const retryAfter = checkRateLimit(identity.recipientId);
+          const retryAfter = checkRateLimit(identity);
           if (retryAfter > 0) {
             const res = errorJson({
               error: "Too many requests",
@@ -433,7 +460,7 @@ export function createHandler<
     }
 
     if (requestRateLimit) {
-      const retryAfter = checkRateLimit(identity.recipientId);
+      const retryAfter = checkRateLimit(identity);
       if (retryAfter > 0) {
         const res = errorJson({
           error: "Too many requests",
@@ -457,11 +484,12 @@ export function createHandler<
       if (!notify.realtime) {
         return withCors(json({ error: "Realtime not configured" }, 404));
       }
-      const currentConns = sseConnections.get(context.recipientId) ?? 0;
+      const sseKey = identityBucketKey(context);
+      const currentConns = sseConnections.get(sseKey) ?? 0;
       if (currentConns >= MAX_SSE_PER_RECIPIENT) {
         return withCors(errorJson({ error: "Too many concurrent connections", code: "SSE_LIMIT" }, 429));
       }
-      sseConnections.set(context.recipientId, currentConns + 1);
+      sseConnections.set(sseKey, currentConns + 1);
       const scope = normalizeScope(context);
       let cleanup: (() => void) | null = null;
       const stream = new ReadableStream({
@@ -501,10 +529,10 @@ export function createHandler<
             unsub();
             clearInterval(heartbeat);
             clearTimeout(maxLifetime);
-            const count = sseConnections.get(context.recipientId);
+            const count = sseConnections.get(sseKey);
             if (count !== undefined) {
-              if (count <= 1) sseConnections.delete(context.recipientId);
-              else sseConnections.set(context.recipientId, count - 1);
+              if (count <= 1) sseConnections.delete(sseKey);
+              else sseConnections.set(sseKey, count - 1);
             }
             try { controller.close(); } catch {}
           };
@@ -536,6 +564,9 @@ export function createHandler<
             ? { archived: true as const }
             : undefined;
           const limit = parseLimit(url.searchParams.get("limit"));
+          if (limit === INVALID_LIMIT) {
+            return withCors(json({ error: "Invalid 'limit' query parameter" }, 400));
+          }
           const items = await notify.inbox.list(
             context.recipientId,
             context,
@@ -801,6 +832,9 @@ export function createHandler<
             ? (url.searchParams.get("recipientId") ?? undefined)
             : context.recipientId;
           const dlvLimit = parseLimit(url.searchParams.get("limit"));
+          if (dlvLimit === INVALID_LIMIT) {
+            return withCors(json({ error: "Invalid 'limit' query parameter" }, 400));
+          }
           const deliveries = await notify.deliveries.list(recipientId, context, dlvLimit);
           return withCors(json({ data: deliveries.map(redactDelivery) }));
         }
@@ -996,17 +1030,27 @@ function normalizeIdentity(
 ): HandlerIdentity | null {
   if (!value) return null;
   if (typeof value === "string") {
-    if (!value || value.length > MAX_ID_LENGTH) return null;
+    if (!isValidIdentityId(value)) return null;
     return { recipientId: value };
   }
-  if (!value.recipientId || value.recipientId.length > MAX_ID_LENGTH) return null;
+  if (typeof value !== "object" || Array.isArray(value)) return null;
+  if (!isValidIdentityId(value.recipientId)) return null;
+  if (value.tenantId !== undefined && !isValidOptionalIdentityId(value.tenantId)) return null;
+  if (value.organizationId !== undefined && !isValidOptionalIdentityId(value.organizationId)) return null;
+  if (value.workspaceId !== undefined && !isValidOptionalIdentityId(value.workspaceId)) return null;
   const tenantId = value.tenantId ?? value.organizationId;
-  if (tenantId && tenantId.length > MAX_ID_LENGTH) return null;
-  if (value.workspaceId && value.workspaceId.length > MAX_ID_LENGTH) return null;
   if (value.organizationId && !value.tenantId) {
     return { ...value, tenantId, organizationId: undefined };
   }
   return value;
+}
+
+function isValidIdentityId(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "" && value.length <= MAX_ID_LENGTH;
+}
+
+function isValidOptionalIdentityId(value: unknown): value is string {
+  return isValidIdentityId(value);
 }
 
 async function isAuthorized(
@@ -1044,10 +1088,13 @@ function coerceQueryParam(value: string, schemaType?: string): unknown {
   return value;
 }
 
-function parseLimit(value: string | null): number | undefined {
-  if (!value) return undefined;
-  const n = parseInt(value, 10);
-  if (!Number.isFinite(n) || n < 1) return undefined;
+const INVALID_LIMIT = Symbol("invalid_limit");
+
+function parseLimit(value: string | null): number | undefined | typeof INVALID_LIMIT {
+  if (value === null || value === "") return undefined;
+  if (!/^[1-9]\d*$/.test(value)) return INVALID_LIMIT;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return INVALID_LIMIT;
   return Math.min(n, 200);
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,7 +57,9 @@ export type {
 } from "./handler.js";
 
 export type {
+  CapturedSend,
   CreateNotifyKitInput,
+  DevModeConfig,
   NotifyKit,
   SendResult,
 } from "./create-notifykit.js";

--- a/packages/core/src/memory-adapter.ts
+++ b/packages/core/src/memory-adapter.ts
@@ -33,6 +33,108 @@ export type MemoryAdapter = DatabaseAdapter & {
   };
 };
 
+function normalizeLimit(limit: number | undefined | null): number | undefined {
+  if (limit == null) return undefined;
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new RangeError("limit must be a positive integer.");
+  }
+  return limit;
+}
+
+function cloneValue<T>(value: T): T {
+  if (value instanceof Date) return new Date(value.getTime()) as T;
+  if (Array.isArray(value)) return value.map((entry) => cloneValue(entry)) as T;
+  if (value && typeof value === "object") {
+    const copy: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      copy[key] = cloneValue(entry);
+    }
+    return copy as T;
+  }
+  return value;
+}
+
+function cloneDate(value: Date): Date {
+  return new Date(value.getTime());
+}
+
+function cloneOptionalDate<T extends Date | null | undefined>(value: T): T {
+  return (value instanceof Date ? new Date(value.getTime()) : value) as T;
+}
+
+function cloneRecipient(recipient: Recipient): Recipient {
+  return {
+    ...recipient,
+    quietHours: cloneValue(recipient.quietHours),
+    createdAt: cloneDate(recipient.createdAt),
+    updatedAt: cloneDate(recipient.updatedAt),
+  };
+}
+
+function cloneNotification(record: NotificationRecord): NotificationRecord {
+  return {
+    ...record,
+    payload: cloneValue(record.payload),
+    payloadSchema: cloneValue(record.payloadSchema),
+    createdAt: cloneDate(record.createdAt),
+  };
+}
+
+function cloneInboxItem(item: InboxItem): InboxItem {
+  return {
+    ...item,
+    readAt: cloneOptionalDate(item.readAt),
+    archivedAt: cloneOptionalDate(item.archivedAt),
+    createdAt: cloneDate(item.createdAt),
+  };
+}
+
+function cloneDelivery(record: DeliveryRecord): DeliveryRecord {
+  return {
+    ...record,
+    createdAt: cloneDate(record.createdAt),
+    updatedAt: cloneDate(record.updatedAt),
+    sentAt: cloneOptionalDate(record.sentAt),
+    failedAt: cloneOptionalDate(record.failedAt),
+  };
+}
+
+function clonePreference(preference: RecipientPreference): RecipientPreference {
+  return {
+    ...preference,
+    channels: { ...preference.channels },
+    updatedAt: cloneDate(preference.updatedAt),
+  };
+}
+
+function cloneDigest(entry: DigestBufferEntry): DigestBufferEntry {
+  return {
+    ...entry,
+    payloads: cloneValue(entry.payloads),
+    flushAt: cloneDate(entry.flushAt),
+    createdAt: cloneDate(entry.createdAt),
+    updatedAt: cloneDate(entry.updatedAt),
+  };
+}
+
+function cloneScheduledSend(record: ScheduledSend): ScheduledSend {
+  return {
+    ...record,
+    payload: cloneValue(record.payload),
+    scheduledFor: cloneDate(record.scheduledFor),
+    claimedAt: cloneOptionalDate(record.claimedAt),
+    createdAt: cloneDate(record.createdAt),
+  };
+}
+
+function cloneTimelineEvent(event: TimelineEvent): TimelineEvent {
+  return {
+    ...event,
+    metadata: cloneValue(event.metadata),
+    timestamp: cloneDate(event.timestamp),
+  };
+}
+
 export function memoryAdapter(): MemoryAdapter {
   const state = {
     recipients: [] as Recipient[],
@@ -87,10 +189,10 @@ export function memoryAdapter(): MemoryAdapter {
           if (input.phone !== undefined) existing.phone = input.phone;
           if (input.name !== undefined) existing.name = input.name;
           if (input.quietHours !== undefined) {
-            existing.quietHours = input.quietHours;
+            existing.quietHours = cloneValue(input.quietHours);
           }
           existing.updatedAt = now;
-          return existing;
+          return cloneRecipient(existing);
         }
         const recipient: Recipient = {
           id: input.id,
@@ -99,15 +201,16 @@ export function memoryAdapter(): MemoryAdapter {
           email: input.email,
           phone: input.phone,
           name: input.name,
-          quietHours: input.quietHours ?? undefined,
+          quietHours: cloneValue(input.quietHours ?? undefined),
           createdAt: now,
           updatedAt: now,
         };
         state.recipients.push(recipient);
-        return recipient;
+        return cloneRecipient(recipient);
       },
       async findById(id: string): Promise<Recipient | null> {
-        return state.recipients.find((r) => r.id === id) ?? null;
+        const recipient = state.recipients.find((r) => r.id === id);
+        return recipient ? cloneRecipient(recipient) : null;
       },
     },
     notifications: {
@@ -118,17 +221,18 @@ export function memoryAdapter(): MemoryAdapter {
           tenantId: input.tenantId,
           workspaceId: input.workspaceId,
           notificationId: input.notificationId,
-          payload: input.payload,
-          payloadSchema: input.payloadSchema,
+          payload: cloneValue(input.payload),
+          payloadSchema: cloneValue(input.payloadSchema),
           definitionVersion: input.definitionVersion,
           idempotencyKey: input.idempotencyKey,
           createdAt: new Date(),
         };
         state.notifications.push(record);
-        return record;
+        return cloneNotification(record);
       },
       async findByIdempotencyKey(key: string): Promise<NotificationRecord | null> {
-        return state.notifications.find((n) => n.idempotencyKey === key) ?? null;
+        const record = state.notifications.find((n) => n.idempotencyKey === key);
+        return record ? cloneNotification(record) : null;
       },
       async clearIdempotencyKey(id: string): Promise<void> {
         const record = state.notifications.find((n) => n.id === id);
@@ -152,7 +256,7 @@ export function memoryAdapter(): MemoryAdapter {
           createdAt: new Date(),
         };
         state.inboxItems.push(item);
-        return item;
+        return cloneInboxItem(item);
       },
       async listByRecipient(
         recipientId: string,
@@ -169,10 +273,14 @@ export function memoryAdapter(): MemoryAdapter {
           })
           .slice()
           .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-        return limit !== undefined ? items.slice(0, limit) : items;
+        const normalizedLimit = normalizeLimit(limit);
+        const limited = normalizedLimit !== undefined ? items.slice(0, normalizedLimit) : items;
+        return limited.map(cloneInboxItem);
       },
       async listByNotificationRecordId(notificationRecordId: string): Promise<InboxItem[]> {
-        return state.inboxItems.filter((i) => i.notificationRecordId === notificationRecordId);
+        return state.inboxItems
+          .filter((i) => i.notificationRecordId === notificationRecordId)
+          .map(cloneInboxItem);
       },
       async markReadForRecipient(
         inboxItemId: string,
@@ -185,7 +293,7 @@ export function memoryAdapter(): MemoryAdapter {
           return { status: "forbidden" };
         }
         if (!item.readAt) item.readAt = new Date();
-        return { status: "marked", item };
+        return { status: "marked", item: cloneInboxItem(item) };
       },
       async unreadCount(
         recipientId: string,
@@ -234,7 +342,7 @@ export function memoryAdapter(): MemoryAdapter {
           return { status: "forbidden" };
         }
         item.archivedAt = new Date();
-        return { status: "ok", item };
+        return { status: "ok", item: cloneInboxItem(item) };
       },
       async unarchiveForRecipient(
         inboxItemId: string,
@@ -247,7 +355,7 @@ export function memoryAdapter(): MemoryAdapter {
           return { status: "forbidden" };
         }
         item.archivedAt = null;
-        return { status: "ok", item };
+        return { status: "ok", item: cloneInboxItem(item) };
       },
       async deleteForRecipient(
         inboxItemId: string,
@@ -287,27 +395,34 @@ export function memoryAdapter(): MemoryAdapter {
           attempts: input.attempts ?? 0,
           createdAt: now,
           updatedAt: now,
-          sentAt: input.sentAt ?? null,
-          failedAt: input.failedAt ?? null,
+          sentAt: cloneOptionalDate(input.sentAt ?? null),
+          failedAt: cloneOptionalDate(input.failedAt ?? null),
         };
         state.deliveries.push(record);
-        return record;
+        return cloneDelivery(record);
       },
       async findById(id: string): Promise<DeliveryRecord | null> {
-        return state.deliveries.find((d) => d.id === id) ?? null;
+        const record = state.deliveries.find((d) => d.id === id);
+        return record ? cloneDelivery(record) : null;
       },
       async listByNotificationRecordId(notificationRecordId: string): Promise<DeliveryRecord[]> {
-        return state.deliveries.filter((d) => d.notificationRecordId === notificationRecordId);
+        return state.deliveries
+          .filter((d) => d.notificationRecordId === notificationRecordId)
+          .map(cloneDelivery);
       },
       async update(id, patch): Promise<DeliveryRecord | null> {
         const existing = state.deliveries.find((d) => d.id === id);
         if (!existing) return null;
         const allowed = ["status", "providerMessageId", "attempts", "error", "sentAt", "failedAt", "skipReason", "skipDetails"] as const;
         for (const key of allowed) {
-          if (key in patch) (existing as Record<string, unknown>)[key] = patch[key as keyof typeof patch];
+          if (key in patch) {
+            (existing as Record<string, unknown>)[key] = cloneValue(
+              patch[key as keyof typeof patch],
+            );
+          }
         }
         existing.updatedAt = new Date();
-        return existing;
+        return cloneDelivery(existing);
       },
       async list(
         recipientId?: string,
@@ -328,19 +443,20 @@ export function memoryAdapter(): MemoryAdapter {
             .slice()
             .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
         }
-        return limit !== undefined ? items.slice(0, limit) : items;
+        const normalizedLimit = normalizeLimit(limit);
+        const limited = normalizedLimit !== undefined ? items.slice(0, normalizedLimit) : items;
+        return limited.map(cloneDelivery);
       },
     },
     preferences: {
       async get(recipientId, notificationId, scope) {
-        return (
-          state.preferences.find(
-            (p) =>
-              p.recipientId === recipientId &&
-              p.notificationId === notificationId &&
-              samePreferenceScope(p, scope),
-          ) ?? null
+        const preference = state.preferences.find(
+          (p) =>
+            p.recipientId === recipientId &&
+            p.notificationId === notificationId &&
+            samePreferenceScope(p, scope),
         );
+        return preference ? clonePreference(preference) : null;
       },
       async list(recipientId, scope) {
         return state.preferences
@@ -348,7 +464,7 @@ export function memoryAdapter(): MemoryAdapter {
             (p) =>
               p.recipientId === recipientId && samePreferenceScope(p, scope),
           )
-          .slice();
+          .map(clonePreference);
       },
       async upsert(input) {
         const existing = state.preferences.find(
@@ -361,7 +477,7 @@ export function memoryAdapter(): MemoryAdapter {
         if (existing) {
           existing.channels = { ...existing.channels, ...input.channels };
           existing.updatedAt = now;
-          return existing;
+          return clonePreference(existing);
         }
         const record: RecipientPreference = {
           recipientId: input.recipientId,
@@ -372,7 +488,7 @@ export function memoryAdapter(): MemoryAdapter {
           updatedAt: now,
         };
         state.preferences.push(record);
-        return record;
+        return clonePreference(record);
       },
     },
     digests: {
@@ -380,9 +496,9 @@ export function memoryAdapter(): MemoryAdapter {
         const now = new Date();
         const existing = state.digests.find((d) => d.key === input.key);
         if (existing) {
-          existing.payloads.push(input.payload);
+          existing.payloads.push(cloneValue(input.payload));
           existing.updatedAt = now;
-          return existing;
+          return cloneDigest(existing);
         }
         const entry: DigestBufferEntry = {
           key: input.key,
@@ -390,36 +506,42 @@ export function memoryAdapter(): MemoryAdapter {
           tenantId: input.tenantId,
           workspaceId: input.workspaceId,
           notificationId: input.notificationId,
-          payloads: [input.payload],
+          payloads: [cloneValue(input.payload)],
           flushAt: new Date(now.getTime() + input.windowMs),
           createdAt: now,
           updatedAt: now,
         };
         state.digests.push(entry);
-        return entry;
+        return cloneDigest(entry);
       },
       async take(key: string): Promise<DigestBufferEntry | null> {
         const idx = state.digests.findIndex((d) => d.key === key);
         if (idx < 0) return null;
         const [entry] = state.digests.splice(idx, 1);
-        return entry ?? null;
+        return entry ? cloneDigest(entry) : null;
       },
       async restore(entry: DigestBufferEntry): Promise<DigestBufferEntry> {
         const existing = state.digests.find((d) => d.key === entry.key);
         if (existing) {
-          existing.payloads = [...entry.payloads, ...existing.payloads];
+          existing.payloads = [
+            ...cloneValue(entry.payloads),
+            ...existing.payloads,
+          ];
           existing.updatedAt = new Date();
-          return existing;
+          return cloneDigest(existing);
         }
         const copy = {
           ...entry,
-          payloads: entry.payloads.slice(),
+          payloads: cloneValue(entry.payloads),
+          flushAt: cloneDate(entry.flushAt),
+          createdAt: cloneDate(entry.createdAt),
+          updatedAt: cloneDate(entry.updatedAt),
         };
         state.digests.push(copy);
-        return copy;
+        return cloneDigest(copy);
       },
       async list(): Promise<DigestBufferEntry[]> {
-        return state.digests.slice();
+        return state.digests.map(cloneDigest);
       },
     },
     rateLimits: {
@@ -465,15 +587,15 @@ export function memoryAdapter(): MemoryAdapter {
           workspaceId: input.workspaceId,
           notificationId: input.notificationId,
           notificationRecordId: input.notificationRecordId,
-          payload: input.payload,
-          scheduledFor: input.scheduledFor,
+          payload: cloneValue(input.payload),
+          scheduledFor: cloneDate(input.scheduledFor),
           reason: input.reason,
           status: input.status ?? "pending",
           claimedAt: null,
           createdAt: new Date(),
         };
         state.scheduledSends.push(record);
-        return record;
+        return cloneScheduledSend(record);
       },
       async claim(id: string): Promise<ScheduledSend | null> {
         const record = state.scheduledSends.find((s) => s.id === id);
@@ -481,7 +603,7 @@ export function memoryAdapter(): MemoryAdapter {
         if (record.status !== "pending") return null;
         record.status = "claimed";
         record.claimedAt = new Date();
-        return { ...record };
+        return cloneScheduledSend(record);
       },
       async complete(id: string): Promise<void> {
         const idx = state.scheduledSends.findIndex(
@@ -502,10 +624,10 @@ export function memoryAdapter(): MemoryAdapter {
             (s) => s.status === "pending" && s.scheduledFor.getTime() <= t,
           )
           .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime())
-          .map((s) => ({ ...s }));
+          .map(cloneScheduledSend);
       },
       async list(): Promise<ScheduledSend[]> {
-        return state.scheduledSends.map((s) => ({ ...s }));
+        return state.scheduledSends.map(cloneScheduledSend);
       },
     },
     timeline: {
@@ -526,23 +648,27 @@ export function memoryAdapter(): MemoryAdapter {
           provider: e.provider,
           event: e.event,
           message: e.message,
-          metadata: e.metadata,
+          metadata: cloneValue(e.metadata),
           timestamp: now,
         }));
         state.timelineEvents.push(...records);
-        return records;
+        return records.map(cloneTimelineEvent);
       },
       async listByNotificationRecordId(notificationRecordId: string, limit?: number): Promise<TimelineEvent[]> {
         const sorted = state.timelineEvents
           .filter((e) => e.notificationRecordId === notificationRecordId)
           .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.seq - b.seq);
-        return limit != null ? sorted.slice(0, limit) : sorted;
+        const normalizedLimit = normalizeLimit(limit);
+        const limited = normalizedLimit !== undefined ? sorted.slice(0, normalizedLimit) : sorted;
+        return limited.map(cloneTimelineEvent);
       },
       async listByDeliveryId(deliveryId: string, notificationRecordId?: string, limit?: number): Promise<TimelineEvent[]> {
         const sorted = state.timelineEvents
           .filter((e) => e.deliveryId === deliveryId && (!notificationRecordId || e.notificationRecordId === notificationRecordId))
           .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.seq - b.seq);
-        return limit != null ? sorted.slice(0, limit) : sorted;
+        const normalizedLimit = normalizeLimit(limit);
+        const limited = normalizedLimit !== undefined ? sorted.slice(0, normalizedLimit) : sorted;
+        return limited.map(cloneTimelineEvent);
       },
       async prune(olderThan: Date): Promise<number> {
         const cutoff = olderThan.getTime();

--- a/packages/core/src/providers.ts
+++ b/packages/core/src/providers.ts
@@ -69,6 +69,17 @@ export function webhookProvider(
   options: WebhookProviderOptions = {},
 ): WebhookProvider {
   const timeoutMs = options.timeoutMs ?? 10_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new NotifyKitError(
+      "webhookProvider timeoutMs must be a positive number.",
+      {
+        code: "INVALID_PROVIDER_CONFIG",
+        channel: "webhook",
+        field: "timeoutMs",
+        fix: "Set timeoutMs to a positive millisecond value, or omit it to use the default.",
+      },
+    );
+  }
   const fetchImpl = options.fetch ?? globalThis.fetch;
   if (!fetchImpl) {
     throw new NotifyKitError(

--- a/packages/core/src/quiet-hours.ts
+++ b/packages/core/src/quiet-hours.ts
@@ -54,6 +54,31 @@ export function nextQuietHoursEnd(
   return candidate;
 }
 
+export function validateQuietHours(quietHours: unknown): string | null {
+  if (!quietHours || typeof quietHours !== "object" || Array.isArray(quietHours)) {
+    return "quietHours must be an object.";
+  }
+  const q = quietHours as Partial<QuietHours>;
+  if (typeof q.start !== "string") return "quietHours.start must be a string.";
+  if (typeof q.end !== "string") return "quietHours.end must be a string.";
+  try {
+    parseWindowMinutes({ start: q.start, end: q.end, timezone: q.timezone });
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  if (q.timezone !== undefined) {
+    if (typeof q.timezone !== "string" || q.timezone.trim() === "") {
+      return "quietHours.timezone must be a non-empty IANA timezone string.";
+    }
+    try {
+      new Intl.DateTimeFormat("en-GB", { timeZone: q.timezone });
+    } catch {
+      return `Invalid timezone "${q.timezone}".`;
+    }
+  }
+  return null;
+}
+
 function parseWindowMinutes(q: QuietHours): [number, number] {
   return [parseHHMM(q.start), parseHHMM(q.end)];
 }

--- a/packages/core/src/realtime.ts
+++ b/packages/core/src/realtime.ts
@@ -30,10 +30,7 @@ export function normalizeScope(scope: SecurityScope): SecurityScope {
 
 function scopeKey(recipientId: string, scope: SecurityScope): string {
   const s = normalizeScope(scope);
-  const r = recipientId.replace(/\0/g, "");
-  const t = (s.tenantId ?? "").replace(/\0/g, "");
-  const w = (s.workspaceId ?? "").replace(/\0/g, "");
-  return `${r}\0${t}\0${w}`;
+  return JSON.stringify([recipientId, s.tenantId ?? "", s.workspaceId ?? ""]);
 }
 
 export function memoryRealtimeAdapter(): RealtimeAdapter {
@@ -44,7 +41,14 @@ export function memoryRealtimeAdapter(): RealtimeAdapter {
       const k = scopeKey(recipientId, scope);
       const set = subs.get(k);
       if (!set) return;
-      for (const fn of set) fn(event);
+      for (const fn of [...set]) {
+        try {
+          fn(event);
+        } catch {
+          // Realtime listeners are fan-out sinks; one failing sink should not
+          // prevent delivery to the rest.
+        }
+      }
     },
     subscribe(recipientId, scope, listener) {
       const k = scopeKey(recipientId, scope);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -238,7 +238,12 @@ export type SafeWebhookResult = {
   hostHeader: string;
 };
 
-export async function assertSafeWebhookUrl(url: string): Promise<SafeWebhookResult> {
+type WebhookDnsResolver = (hostname: string) => Promise<string[]>;
+
+export async function assertSafeWebhookUrl(
+  url: string,
+  options: { resolveHostname?: WebhookDnsResolver } = {},
+): Promise<SafeWebhookResult> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -280,16 +285,20 @@ export async function assertSafeWebhookUrl(url: string): Promise<SafeWebhookResu
   }
   if (typeof globalThis.process !== "undefined") {
     try {
-      const dns = await import("node:dns");
-      const resolve4 = dns.promises?.resolve4 ?? dns.resolve4;
-      const resolve6 = dns.promises?.resolve6 ?? dns.resolve6;
       const allAddresses: string[] = [];
-      const [v4, v6] = await Promise.allSettled([
-        (resolve4 as (h: string) => Promise<string[]>)(parsed.hostname),
-        (resolve6 as (h: string) => Promise<string[]>)(parsed.hostname),
-      ]);
-      if (v4.status === "fulfilled") allAddresses.push(...v4.value);
-      if (v6.status === "fulfilled") allAddresses.push(...v6.value);
+      if (options.resolveHostname) {
+        allAddresses.push(...await options.resolveHostname(parsed.hostname));
+      } else {
+        const dns = await import("node:dns");
+        const resolve4 = dns.promises?.resolve4 ?? dns.resolve4;
+        const resolve6 = dns.promises?.resolve6 ?? dns.resolve6;
+        const [v4, v6] = await Promise.allSettled([
+          (resolve4 as (h: string) => Promise<string[]>)(parsed.hostname),
+          (resolve6 as (h: string) => Promise<string[]>)(parsed.hostname),
+        ]);
+        if (v4.status === "fulfilled") allAddresses.push(...v4.value);
+        if (v6.status === "fulfilled") allAddresses.push(...v6.value);
+      }
       if (allAddresses.length === 0) {
         throw new NotifyKitError(
           `Webhook URL failed DNS resolution: ${url}`,

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -9,6 +9,7 @@ import type {
   NotificationDefinition,
   PayloadSchema,
   PrimitiveSchema,
+  RetryPolicy,
   SmsProvider,
   WebhookProvider,
 } from "./types.js";
@@ -44,6 +45,7 @@ export type ValidateConfigInput = {
     digests?: object;
     rateLimits?: object;
   };
+  retry?: Partial<RetryPolicy>;
   idempotencyKeyTtlMs?: number;
   timelineRetentionMs?: number;
 };
@@ -51,11 +53,21 @@ export type ValidateConfigInput = {
 const ID_RE = /^[a-z][a-z0-9._-]*$/;
 const VALID_CHANNEL_TYPES: ReadonlySet<string> = new Set(["inbox", "email", "webhook", "sms"]);
 const VALID_SCHEMA_TYPES: ReadonlySet<string> = new Set<PrimitiveSchema>(["string", "number", "boolean"]);
-
+const HTTP_HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 function isLegacyFallback(
   fb: InboxChannelConfig | FallbackRule[],
 ): fb is InboxChannelConfig {
   return !Array.isArray(fb);
+}
+
+function notificationUsesChannelType(
+  def: NotificationDefinition<string, PayloadSchema>,
+  type: ChannelType,
+): boolean {
+  if (def.channels.some((ch) => ch.type === type)) return true;
+  if (!def.fallback) return false;
+  if (isLegacyFallback(def.fallback)) return def.fallback.type === type;
+  return def.fallback.some((rule) => rule.then.type === type);
 }
 
 function collectChannelShapeIssues(
@@ -111,6 +123,32 @@ function collectChannelShapeIssues(
         message: `Notification "${notificationId}" webhook channel is missing "url".`,
         fix: `Add a url string: channel.webhook({ url: "https://..." }).`,
       });
+    }
+    if (ch.headers) {
+      for (const [hk, hv] of Object.entries(ch.headers)) {
+        if (!HTTP_HEADER_NAME_RE.test(hk)) {
+          out.push({
+            severity: "error",
+            code: "INVALID_WEBHOOK_HEADER_NAME",
+            notificationId,
+            channel: label,
+            field: `headers.${hk}`,
+            message: `Webhook header name "${hk}" is not a valid HTTP header name.`,
+            fix: "Use only RFC 7230 token characters in webhook header names.",
+          });
+        }
+        if (typeof hv !== "string") {
+          out.push({
+            severity: "error",
+            code: "INVALID_WEBHOOK_HEADER_VALUE",
+            notificationId,
+            channel: label,
+            field: `headers.${hk}`,
+            message: `Webhook header "${hk}" must have a string value.`,
+            fix: `Change "${hk}" to a string template value, e.g. "{{field}}" or "static-value".`,
+          });
+        }
+      }
     }
   } else if (ch.type === "sms") {
     if (typeof ch.body !== "string" || ch.body.length === 0) {
@@ -173,6 +211,18 @@ function collectChannelTemplateIssues(
     collectTemplateIssues(notificationId, label, "url", ch.url, payloadKeys, out);
     if (ch.headers) {
       for (const [hk, hv] of Object.entries(ch.headers)) {
+        if (hk.toLowerCase() === "host") {
+          out.push({
+            severity: "error",
+            code: "RESERVED_WEBHOOK_HEADER",
+            notificationId,
+            channel: label,
+            field: `headers.${hk}`,
+            message: `Webhook header "${hk}" is reserved and cannot be configured by notifications.`,
+            fix: `Remove "${hk}" from the webhook headers. NotifyKit sets Host internally after URL safety checks.`,
+          });
+        }
+        if (typeof hv !== "string") continue;
         collectTemplateIssues(notificationId, label, `headers.${hk}`, hv, payloadKeys, out);
       }
     }
@@ -303,6 +353,17 @@ export function validateConfig(input: ValidateConfigInput): ValidationIssue[] {
 
     const seenTypes = new Set<string>();
     for (const [i, ch] of def.channels.entries()) {
+      if (!VALID_CHANNEL_TYPES.has(ch.type)) {
+        issues.push({
+          severity: "error",
+          code: "UNKNOWN_CHANNEL_TYPE",
+          notificationId: def.id,
+          channel: `${ch.type}[${i}]`,
+          field: "channels",
+          message: `Notification "${def.id}" has unknown channel type "${ch.type}".`,
+          fix: `Valid channel types: ${[...VALID_CHANNEL_TYPES].join(", ")}.`,
+        });
+      }
       collectChannelShapeIssues(def.id, ch, i, issues);
       if (seenTypes.has(ch.type)) {
         issues.push({
@@ -359,7 +420,20 @@ export function validateConfig(input: ValidateConfigInput): ValidationIssue[] {
       const fallbackConfigs = isLegacyFallback(def.fallback)
         ? [def.fallback]
         : def.fallback.map((r) => r.then);
-      for (const fb of fallbackConfigs) {
+      for (const [fi, fb] of fallbackConfigs.entries()) {
+        if (!VALID_CHANNEL_TYPES.has(fb.type)) {
+          issues.push({
+            severity: "error",
+            code: "UNKNOWN_FALLBACK_CHANNEL_TYPE",
+            notificationId: def.id,
+            channel: "fallback",
+            field: isLegacyFallback(def.fallback)
+              ? "fallback"
+              : `fallback[${fi}].then`,
+            message: `Notification "${def.id}" fallback targets unknown channel type "${fb.type}".`,
+            fix: `Valid channel types: ${[...VALID_CHANNEL_TYPES].join(", ")}.`,
+          });
+        }
         collectChannelTemplateIssues(def.id, fb, "fallback", payloadKeys, issues);
       }
       if (!isLegacyFallback(def.fallback)) {
@@ -641,6 +715,20 @@ export function validateConfig(input: ValidateConfigInput): ValidationIssue[] {
           fix: "Set windowMs to a positive millisecond value (e.g. rateLimit: { max: 5, windowMs: 60000 }).",
         });
       }
+      if (
+        def.rateLimit.scope !== undefined &&
+        def.rateLimit.scope !== "recipient" &&
+        def.rateLimit.scope !== "global"
+      ) {
+        issues.push({
+          severity: "error",
+          code: "INVALID_RATE_LIMIT",
+          notificationId: def.id,
+          field: "rateLimit.scope",
+          message: `Notification "${def.id}" rateLimit.scope must be "recipient" or "global", got "${String(def.rateLimit.scope)}".`,
+          fix: "Use scope: \"recipient\" for per-recipient limits, scope: \"global\" for notification-wide limits, or omit scope.",
+        });
+      }
     }
 
     // --- SMS without rate limit warning ---
@@ -723,6 +811,30 @@ export function validateConfig(input: ValidateConfigInput): ValidationIssue[] {
     }
   }
 
+  // --- retry policy validation ---
+  if (input.retry?.maxAttempts !== undefined) {
+    if (!Number.isSafeInteger(input.retry.maxAttempts) || input.retry.maxAttempts <= 0) {
+      issues.push({
+        severity: "error",
+        code: "INVALID_RETRY_MAX_ATTEMPTS",
+        field: "retry.maxAttempts",
+        message: `retry.maxAttempts must be a positive integer, got ${input.retry.maxAttempts}.`,
+        fix: "Set retry.maxAttempts to a positive integer, e.g. 3.",
+      });
+    }
+  }
+  if (input.retry?.delayMs !== undefined) {
+    if (typeof input.retry.delayMs !== "function") {
+      issues.push({
+        severity: "error",
+        code: "INVALID_RETRY_DELAY",
+        field: "retry.delayMs",
+        message: "retry.delayMs must be a function.",
+        fix: "Provide a function like `(attempt) => 0`, or omit retry.delayMs to use the default backoff.",
+      });
+    }
+  }
+
   // --- idempotencyKeyTtlMs validation ---
   if (input.idempotencyKeyTtlMs !== undefined) {
     if (!Number.isFinite(input.idempotencyKeyTtlMs) || input.idempotencyKeyTtlMs <= 0) {
@@ -775,7 +887,7 @@ export function validateConfig(input: ValidateConfigInput): ValidationIssue[] {
   }
 
   // --- webhook secret warning ---
-  if (notifications.some((n) => n.channels.some((ch) => ch.type === "webhook"))) {
+  if (notifications.some((n) => notificationUsesChannelType(n, "webhook"))) {
     if (input.providers?.webhook && !input.providers.webhook.signed) {
       issues.push({
         severity: "warning",

--- a/packages/core/tests/contract.test.ts
+++ b/packages/core/tests/contract.test.ts
@@ -301,7 +301,7 @@ describe("startup validation", () => {
           notification({
             id: "needs_webhook",
             payload: { url: "string" },
-            channels: [webhook({ url: "https://example.com/hook" })],
+            channels: [webhook({ url: "https://93.184.216.34/hook" })],
           }),
         ] as const,
         database: memoryAdapter(),
@@ -434,6 +434,58 @@ describe("startup validation", () => {
         providers: { email: fakeEmailProvider() },
       }),
     ).not.toThrow();
+  });
+
+  test("rejects invalid retry configuration", () => {
+    const def = notification({
+      id: "retry_config",
+      payload: { msg: "string" },
+      channels: [inbox({ title: "{{msg}}" })],
+    });
+
+    expect(() =>
+      createNotifyKit({
+        notifications: [def] as const,
+        database: memoryAdapter(),
+        retry: { maxAttempts: 0 },
+      }),
+    ).toThrow(/retry\.maxAttempts.*positive integer/i);
+
+    expect(() =>
+      createNotifyKit({
+        notifications: [def] as const,
+        database: memoryAdapter(),
+        retry: { maxAttempts: 1.5 },
+      }),
+    ).toThrow(/retry\.maxAttempts.*positive integer/i);
+
+    expect(() =>
+      createNotifyKit({
+        notifications: [def] as const,
+        database: memoryAdapter(),
+        retry: { delayMs: 10 as unknown as () => number },
+      }),
+    ).toThrow(/retry\.delayMs.*function/i);
+  });
+
+  test("rejects invalid rate limit scope", () => {
+    expect(() =>
+      createNotifyKit({
+        notifications: [
+          notification({
+            id: "bad_rate_scope",
+            payload: { msg: "string" },
+            channels: [inbox({ title: "{{msg}}" })],
+            rateLimit: {
+              max: 1,
+              windowMs: 1000,
+              scope: "workspace" as unknown as "recipient",
+            },
+          }),
+        ] as const,
+        database: memoryAdapter(),
+      }),
+    ).toThrow(/rateLimit\.scope.*recipient.*global/i);
   });
 });
 
@@ -599,7 +651,7 @@ describe("startup validation — webhook header templates", () => {
             payload: { name: "string" },
             channels: [
               webhook({
-                url: "https://example.com/hook",
+                url: "https://93.184.216.34/hook",
                 headers: { "x-key": "{{typo}}" },
               }),
             ],
@@ -620,7 +672,7 @@ describe("startup validation — webhook header templates", () => {
             payload: { name: "string" },
             channels: [
               webhook({
-                url: "https://example.com/hook",
+                url: "https://93.184.216.34/hook",
                 headers: { "x-name": "{{name}}" },
               }),
             ],

--- a/packages/core/tests/dedupe.test.ts
+++ b/packages/core/tests/dedupe.test.ts
@@ -262,8 +262,9 @@ describe("deduplication keys", () => {
       dedupeWindowMs: 60_000,
     });
 
-    // Same key, same recipient, different tenant — NOT deduped (key is scoped
-    // to notificationId + recipientId, tenant is excluded like idempotency)
+    // Same key, same recipient, different tenant is still deduped because the
+    // key is scoped to notificationId + recipientId; tenant is excluded like
+    // idempotency.
     const result = await notify.send({
       recipientId: "u1",
       tenantId: "t2",
@@ -273,8 +274,8 @@ describe("deduplication keys", () => {
       dedupeWindowMs: 60_000,
     });
 
-    // dedup key composite includes (notificationId, recipientId, dedupeKey)
-    // tenantId is excluded — so this IS a duplicate
+    // dedupe key composite includes (notificationId, recipientId, dedupeKey)
+    // and excludes tenantId, so this is a duplicate.
     expect(result.skipped.length).toBeGreaterThan(0);
     expect(result.skipped[0].reason).toBe("duplicate");
     expect(emailProvider.sent).toHaveLength(1);

--- a/packages/core/tests/dev-mode.test.ts
+++ b/packages/core/tests/dev-mode.test.ts
@@ -9,6 +9,7 @@ import {
 const inbox = channel.inbox();
 const email = channel.email();
 const sms = channel.sms();
+const webhook = channel.webhook();
 
 const alertNotification = notification({
   id: "alert",
@@ -29,6 +30,12 @@ const smsNotification = notification({
   id: "verify_phone",
   payload: { code: "string" },
   channels: [sms({ body: "Your code is {{code}}" })],
+});
+
+const webhookNotification = notification({
+  id: "webhook_event",
+  payload: { event: "string" },
+  channels: [webhook({ url: "https://example.com/hook", headers: {} })],
 });
 
 describe("dev mode", () => {
@@ -177,6 +184,28 @@ describe("dev mode", () => {
     expect(notify.captured[0]!.channel).toBe("sms");
     expect(notify.captured[0]!.blocked).toBe(true);
     expect(notify.captured[0]!.to).toBe("+15551234567");
+  });
+
+  test("webhook channel is blocked in dev mode", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [webhookNotification] as const,
+      database: db,
+      mode: "development",
+      providers: { webhook: { id: "real-webhook", signed: false, async send() { return {}; } } },
+    });
+
+    await notify.upsertRecipient({ id: "u1" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "webhook_event",
+      payload: { event: "test" },
+    });
+
+    expect(notify.captured).toHaveLength(1);
+    expect(notify.captured[0]!.channel).toBe("webhook");
+    expect(notify.captured[0]!.blocked).toBe(true);
+    expect(notify.captured[0]!.to).toBe("https://example.com/hook");
   });
 
   test("inbox channel still works normally in dev mode", async () => {

--- a/packages/core/tests/dev-mode.test.ts
+++ b/packages/core/tests/dev-mode.test.ts
@@ -250,4 +250,34 @@ describe("dev mode", () => {
     expect(notify.captured[0]!.subject).toContain("User2");
     expect(notify.captured[2]!.subject).toContain("User4");
   });
+
+  test("logPreviews: false suppresses console output", async () => {
+    const consoleSpy = mock(() => {});
+    const originalLog = console.log;
+    console.log = consoleSpy;
+
+    try {
+      const db = memoryAdapter();
+      const notify = createNotifyKit({
+        notifications: [welcomeNotification] as const,
+        database: db,
+        mode: "development",
+        dev: { logPreviews: false },
+      });
+
+      await notify.upsertRecipient({ id: "u1", email: "a@test.com" });
+      await notify.send({
+        recipientId: "u1",
+        notificationId: "welcome",
+        payload: { name: "Silent" },
+      });
+
+      const devLogCalls = consoleSpy.mock.calls.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("[notifykit:dev]"),
+      );
+      expect(devLogCalls).toHaveLength(0);
+    } finally {
+      console.log = originalLog;
+    }
+  });
 });

--- a/packages/core/tests/dev-mode.test.ts
+++ b/packages/core/tests/dev-mode.test.ts
@@ -251,6 +251,53 @@ describe("dev mode", () => {
     expect(notify.captured[2]!.subject).toContain("User4");
   });
 
+  test("maxCaptured clamps invalid values to 1", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [welcomeNotification] as const,
+      database: db,
+      mode: "development",
+      dev: { maxCaptured: 0 },
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "a@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "First" },
+    });
+
+    expect(notify.captured).toHaveLength(1);
+
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Second" },
+    });
+
+    expect(notify.captured).toHaveLength(1);
+    expect(notify.captured[0]!.subject).toContain("Second");
+  });
+
+  test("maxCaptured clamps negative values to 1", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [welcomeNotification] as const,
+      database: db,
+      mode: "development",
+      dev: { maxCaptured: -5 },
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "a@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+
+    expect(notify.captured).toHaveLength(1);
+  });
+
   test("logPreviews: false suppresses console output", async () => {
     const consoleSpy = mock(() => {});
     const originalLog = console.log;

--- a/packages/core/tests/dev-mode.test.ts
+++ b/packages/core/tests/dev-mode.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test, mock } from "bun:test";
+import {
+  channel,
+  createNotifyKit,
+  memoryAdapter,
+  notification,
+} from "../src/index.js";
+
+const inbox = channel.inbox();
+const email = channel.email();
+const sms = channel.sms();
+
+const alertNotification = notification({
+  id: "alert",
+  payload: { message: "string" },
+  channels: [inbox({ title: "Alert: {{message}}" })],
+});
+
+const welcomeNotification = notification({
+  id: "welcome",
+  payload: { name: "string" },
+  channels: [
+    inbox({ title: "Welcome {{name}}" }),
+    email({ subject: "Welcome {{name}}", body: "Hello {{name}}!" }),
+  ],
+});
+
+const smsNotification = notification({
+  id: "verify_phone",
+  payload: { code: "string" },
+  channels: [sms({ body: "Your code is {{code}}" })],
+});
+
+describe("dev mode", () => {
+  test("blocks sends when no allowlist", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [welcomeNotification] as const,
+      database: db,
+      mode: "development",
+    });
+
+    expect(notify.isDev).toBe(true);
+
+    await notify.upsertRecipient({ id: "u1", email: "real@production.com" });
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+
+    expect(result.deliveries).toHaveLength(1);
+    expect(result.deliveries[0]!.status).toBe("sent");
+
+    expect(notify.captured).toHaveLength(1);
+    expect(notify.captured[0]!.blocked).toBe(true);
+    expect(notify.captured[0]!.channel).toBe("email");
+    expect(notify.captured[0]!.to).toBe("real@production.com");
+  });
+
+  test("allows sends to allowlisted addresses", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [welcomeNotification] as const,
+      database: db,
+      mode: "development",
+      dev: { allowlist: ["allowed@dev.com"] },
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "allowed@dev.com" });
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Dev" },
+    });
+
+    expect(notify.captured).toHaveLength(1);
+    expect(notify.captured[0]!.blocked).toBe(false);
+  });
+
+  test("allowlist is case-insensitive", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [welcomeNotification] as const,
+      database: db,
+      mode: "development",
+      dev: { allowlist: ["Allowed@Dev.COM"] },
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "allowed@dev.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+
+    expect(notify.captured[0]!.blocked).toBe(false);
+  });
+
+  test("adds subject prefix to emails", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [welcomeNotification] as const,
+      database: db,
+      mode: "development",
+      dev: { allowlist: ["dev@test.com"] },
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "dev@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Alice" },
+    });
+
+    expect(notify.captured[0]!.subject).toBe("[DEV] Welcome Alice");
+  });
+
+  test("custom subject prefix", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [welcomeNotification] as const,
+      database: db,
+      mode: "development",
+      dev: { allowlist: ["dev@test.com"], subjectPrefix: "[STAGING] " },
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "dev@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Bob" },
+    });
+
+    expect(notify.captured[0]!.subject).toBe("[STAGING] Welcome Bob");
+  });
+
+  test("production mode has isDev=false and empty captured", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [alertNotification] as const,
+      database: db,
+      mode: "production",
+    });
+
+    expect(notify.isDev).toBe(false);
+    expect(notify.captured).toHaveLength(0);
+  });
+
+  test("default mode (omitted) has isDev=false", () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [alertNotification] as const,
+      database: db,
+    });
+
+    expect(notify.isDev).toBe(false);
+  });
+
+  test("SMS channel is blocked in dev mode", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [smsNotification] as const,
+      database: db,
+      mode: "development",
+      providers: { sms: { id: "real-sms", async send() { return {}; } } },
+    });
+
+    await notify.upsertRecipient({ id: "u1", phone: "+15551234567" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "verify_phone",
+      payload: { code: "1234" },
+    });
+
+    expect(notify.captured).toHaveLength(1);
+    expect(notify.captured[0]!.channel).toBe("sms");
+    expect(notify.captured[0]!.blocked).toBe(true);
+    expect(notify.captured[0]!.to).toBe("+15551234567");
+  });
+
+  test("inbox channel still works normally in dev mode", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [welcomeNotification] as const,
+      database: db,
+      mode: "development",
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "user@example.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+
+    const items = await notify.inbox.list("u1");
+    expect(items).toHaveLength(1);
+    expect(items[0]!.title).toBe("Welcome Test");
+  });
+});

--- a/packages/core/tests/dev-mode.test.ts
+++ b/packages/core/tests/dev-mode.test.ts
@@ -298,7 +298,7 @@ describe("dev mode", () => {
     expect(notify.captured).toHaveLength(1);
   });
 
-  test("logPreviews: false suppresses console output", async () => {
+  test("logPreviews defaults to false (no body in console)", async () => {
     const consoleSpy = mock(() => {});
     const originalLog = console.log;
     console.log = consoleSpy;
@@ -309,7 +309,6 @@ describe("dev mode", () => {
         notifications: [welcomeNotification] as const,
         database: db,
         mode: "development",
-        dev: { logPreviews: false },
       });
 
       await notify.upsertRecipient({ id: "u1", email: "a@test.com" });
@@ -323,6 +322,36 @@ describe("dev mode", () => {
         (args) => typeof args[0] === "string" && args[0].includes("[notifykit:dev]"),
       );
       expect(devLogCalls).toHaveLength(0);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  test("logPreviews: true enables console output", async () => {
+    const consoleSpy = mock(() => {});
+    const originalLog = console.log;
+    console.log = consoleSpy;
+
+    try {
+      const db = memoryAdapter();
+      const notify = createNotifyKit({
+        notifications: [welcomeNotification] as const,
+        database: db,
+        mode: "development",
+        dev: { logPreviews: true },
+      });
+
+      await notify.upsertRecipient({ id: "u1", email: "a@test.com" });
+      await notify.send({
+        recipientId: "u1",
+        notificationId: "welcome",
+        payload: { name: "Logged" },
+      });
+
+      const devLogCalls = consoleSpy.mock.calls.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("[notifykit:dev]"),
+      );
+      expect(devLogCalls.length).toBeGreaterThan(0);
     } finally {
       console.log = originalLog;
     }

--- a/packages/core/tests/dev-mode.test.ts
+++ b/packages/core/tests/dev-mode.test.ts
@@ -227,4 +227,27 @@ describe("dev mode", () => {
     expect(items).toHaveLength(1);
     expect(items[0]!.title).toBe("Welcome Test");
   });
+
+  test("captured array respects maxCaptured limit", async () => {
+    const db = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [alertNotification, welcomeNotification] as const,
+      database: db,
+      mode: "development",
+      dev: { maxCaptured: 3 },
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "a@test.com" });
+    for (let i = 0; i < 5; i++) {
+      await notify.send({
+        recipientId: "u1",
+        notificationId: "welcome",
+        payload: { name: `User${i}` },
+      });
+    }
+
+    expect(notify.captured).toHaveLength(3);
+    expect(notify.captured[0]!.subject).toContain("User2");
+    expect(notify.captured[2]!.subject).toContain("User4");
+  });
 });

--- a/packages/core/tests/fallback.test.ts
+++ b/packages/core/tests/fallback.test.ts
@@ -247,7 +247,7 @@ describe("rule-based fallback", () => {
         email({ subject: "Alert", body: "{{msg}}" }),
       ],
       fallback: [
-        { if: "channel.failed", then: webhook({ url: "https://example.com/fallback", headers: {} }), from: "email" },
+        { if: "channel.failed", then: webhook({ url: "https://93.184.216.34/fallback", headers: {} }), from: "email" },
       ],
     });
     const notify = createNotifyKit({
@@ -338,7 +338,7 @@ describe("rule-based fallback", () => {
         email({ subject: "Update", body: "{{msg}}" }),
       ],
       fallback: [
-        { if: "skipped", then: webhook({ url: "https://example.com/notify", headers: {} }), from: "email" },
+        { if: "skipped", then: webhook({ url: "https://93.184.216.34/notify", headers: {} }), from: "email" },
       ],
     });
     const notify = createNotifyKit({
@@ -370,7 +370,7 @@ describe("rule-based fallback", () => {
       id: "alert",
       payload: { msg: "string" },
       channels: [
-        webhook({ url: "https://example.com/primary", headers: {} }),
+        webhook({ url: "https://93.184.216.34/primary", headers: {} }),
       ],
       fallback: [
         { if: "channel.failed", then: inbox({ title: "Fallback: {{msg}}" }), from: "email" },
@@ -404,7 +404,7 @@ describe("rule-based fallback", () => {
       ],
       fallback: [
         { if: "channel.failed", then: inbox({ title: "First: {{msg}}" }) },
-        { if: "channel.failed", then: webhook({ url: "https://example.com/second", headers: {} }) },
+        { if: "channel.failed", then: webhook({ url: "https://93.184.216.34/second", headers: {} }) },
       ],
     });
     const notify = createNotifyKit({
@@ -522,7 +522,7 @@ describe("rule-based fallback", () => {
       id: "hook",
       payload: { msg: "string" },
       channels: [
-        webhook({ url: "https://example.com/primary", headers: {} }),
+        webhook({ url: "https://93.184.216.34/primary", headers: {} }),
       ],
       fallback: [
         { if: "channel.failed", then: inbox({ title: "Hook failed: {{msg}}" }) },

--- a/packages/core/tests/handler.test.ts
+++ b/packages/core/tests/handler.test.ts
@@ -142,6 +142,13 @@ describe("createHandler", () => {
     expect(body.data[0]!.title).toBe("Rey mentioned you");
   });
 
+  test("GET /inbox rejects invalid limit query", async () => {
+    const res = await ctx.handler(new Request(`${BASE}/inbox?limit=1.5`));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/limit/);
+  });
+
   test("POST /inbox/:id/read marks the item read", async () => {
     const result = await ctx.notify.send({
       recipientId: "user_1",
@@ -367,6 +374,19 @@ describe("createHandler", () => {
     expect(body.data[0]!.tenantId).toBe("tenant_a");
   });
 
+  test("GET /deliveries rejects invalid limit query", async () => {
+    const handler = createHandler(ctx.notify, {
+      identify: () => ({
+        recipientId: "user_1",
+        permissions: ["deliveries.list"],
+      }),
+    });
+    const res = await handler(new Request(`${BASE}/deliveries?limit=abc`));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/limit/);
+  });
+
   test("GET /deliveries can be allowed through the authorize hook", async () => {
     const sawPermissions: string[] = [];
     const handler = createHandler(ctx.notify, {
@@ -444,6 +464,24 @@ describe("createHandler", () => {
     const miss = await handler(
       new Request("http://localhost/api/notifykit/inbox"),
     );
+    expect(miss.status).toBe(404);
+  });
+
+  test("root basePath routes correctly", async () => {
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database: memoryAdapter(),
+      providers: { email: fakeEmailProvider() },
+    });
+    const handler = createHandler(notify, {
+      identify: () => "u",
+      basePath: "/",
+    });
+
+    const ok = await handler(new Request("http://localhost/notifications"));
+    expect(ok.status).toBe(200);
+
+    const miss = await handler(new Request("http://localhost/api/notifykit/notifications"));
     expect(miss.status).toBe(404);
   });
 

--- a/packages/core/tests/memory-adapter.test.ts
+++ b/packages/core/tests/memory-adapter.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "bun:test";
+import { memoryAdapter } from "../src/index.js";
+
+describe("memoryAdapter", () => {
+  test("list methods reject invalid limits", async () => {
+    const adapter = memoryAdapter();
+
+    await expect(
+      adapter.inbox.listByRecipient("u1", undefined, undefined, -1),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      adapter.deliveries.list("u1", undefined, 1.5),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      adapter.timeline!.listByNotificationRecordId("ntf_1", 0),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      adapter.timeline!.listByDeliveryId("dlv_1", undefined, Number.NaN),
+    ).rejects.toThrow(/positive integer/);
+  });
+
+  test("returns defensive copies from recipient methods", async () => {
+    const adapter = memoryAdapter();
+    const created = await adapter.recipients.upsert({
+      id: "u1",
+      email: "ada@example.com",
+      quietHours: { start: "22:00", end: "06:00", timezone: "UTC" },
+    });
+
+    created.email = "mutated@example.com";
+    created.quietHours!.start = "00:00";
+    created.createdAt.setFullYear(2000);
+
+    const stored = await adapter.recipients.findById("u1");
+    expect(stored?.email).toBe("ada@example.com");
+    expect(stored?.quietHours?.start).toBe("22:00");
+    expect(stored?.createdAt.getFullYear()).not.toBe(2000);
+
+    stored!.email = "again@example.com";
+    const reread = await adapter.recipients.findById("u1");
+    expect(reread?.email).toBe("ada@example.com");
+  });
+
+  test("returns defensive copies from notification and inbox methods", async () => {
+    const adapter = memoryAdapter();
+    const createdNotification = await adapter.notifications.create({
+      recipientId: "u1",
+      notificationId: "comment",
+      payload: { nested: { count: 1 } },
+      payloadSchema: { nested: "object" },
+    });
+
+    (createdNotification.payload.nested as { count: number }).count = 2;
+    createdNotification.createdAt.setFullYear(2000);
+
+    const storedNotification = await adapter.notifications.findByIdempotencyKey("");
+    expect(storedNotification).toBeNull();
+    const withKey = await adapter.notifications.create({
+      recipientId: "u1",
+      notificationId: "comment",
+      payload: { message: "hello" },
+      idempotencyKey: "key",
+    });
+    withKey.payload.message = "mutated";
+
+    const replayed = await adapter.notifications.findByIdempotencyKey("key");
+    expect(replayed?.payload.message).toBe("hello");
+
+    const inboxItem = await adapter.inbox.create({
+      notificationRecordId: createdNotification.id,
+      recipientId: "u1",
+      notificationId: "comment",
+      title: "Original",
+    });
+    inboxItem.title = "Mutated";
+    inboxItem.createdAt.setFullYear(2000);
+
+    const listed = await adapter.inbox.listByRecipient("u1");
+    expect(listed[0]?.title).toBe("Original");
+    expect(listed[0]?.createdAt.getFullYear()).not.toBe(2000);
+
+    listed[0]!.title = "Mutated again";
+    const byNotification = await adapter.inbox.listByNotificationRecordId(
+      createdNotification.id,
+    );
+    expect(byNotification[0]?.title).toBe("Original");
+
+    const marked = await adapter.inbox.markReadForRecipient(inboxItem.id, "u1");
+    expect(marked.status).toBe("marked");
+    if (marked.status === "marked") {
+      marked.item.title = "Mutated marked";
+      marked.item.readAt!.setFullYear(2000);
+    }
+    const afterMark = await adapter.inbox.listByRecipient("u1");
+    expect(afterMark[0]?.title).toBe("Original");
+    expect(afterMark[0]?.readAt?.getFullYear()).not.toBe(2000);
+  });
+
+  test("returns defensive copies from delivery and preference methods", async () => {
+    const adapter = memoryAdapter();
+    const delivery = await adapter.deliveries.create({
+      notificationRecordId: "ntf_1",
+      recipientId: "u1",
+      notificationId: "comment",
+      channel: "email",
+      provider: "test",
+      status: "sent",
+      attempts: 1,
+      sentAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    delivery.status = "failed";
+    delivery.sentAt!.setFullYear(2000);
+
+    const found = await adapter.deliveries.findById(delivery.id);
+    expect(found?.status).toBe("sent");
+    expect(found?.sentAt?.getFullYear()).toBe(2026);
+
+    const updated = await adapter.deliveries.update(delivery.id, {
+      failedAt: new Date("2026-02-01T00:00:00.000Z"),
+    });
+    updated!.failedAt!.setFullYear(2000);
+
+    const listed = await adapter.deliveries.list("u1");
+    expect(listed[0]?.failedAt?.getFullYear()).toBe(2026);
+    listed[0]!.status = "failed";
+
+    const byNotification = await adapter.deliveries.listByNotificationRecordId("ntf_1");
+    expect(byNotification[0]?.status).toBe("sent");
+
+    const preference = await adapter.preferences.upsert({
+      recipientId: "u1",
+      notificationId: "comment",
+      channels: { email: false },
+    });
+    preference.channels.email = true;
+    preference.updatedAt.setFullYear(2000);
+
+    const storedPreference = await adapter.preferences.get("u1", "comment");
+    expect(storedPreference?.channels.email).toBe(false);
+    expect(storedPreference?.updatedAt.getFullYear()).not.toBe(2000);
+
+    storedPreference!.channels.email = true;
+    const listedPreferences = await adapter.preferences.list("u1");
+    expect(listedPreferences[0]?.channels.email).toBe(false);
+  });
+
+  test("returns defensive copies from digest, scheduled send, and timeline methods", async () => {
+    const adapter = memoryAdapter();
+    const digest = await adapter.digests.append({
+      key: "digest_1",
+      recipientId: "u1",
+      notificationId: "comment",
+      payload: { nested: { count: 1 } },
+      windowMs: 1000,
+    });
+
+    (digest.payloads[0]!.nested as { count: number }).count = 2;
+    digest.flushAt.setFullYear(2000);
+
+    const digests = await adapter.digests.list();
+    expect((digests[0]?.payloads[0]?.nested as { count: number }).count).toBe(1);
+    expect(digests[0]?.flushAt.getFullYear()).not.toBe(2000);
+
+    const taken = await adapter.digests.take("digest_1");
+    taken!.payloads[0]!.nested = { count: 3 };
+    await adapter.digests.restore(taken!);
+    taken!.payloads[0]!.nested = { count: 4 };
+    const restored = await adapter.digests.list();
+    expect((restored[0]?.payloads[0]?.nested as { count: number }).count).toBe(3);
+
+    const scheduledFor = new Date("2026-03-01T00:00:00.000Z");
+    const scheduled = await adapter.scheduledSends.create({
+      recipientId: "u1",
+      notificationId: "comment",
+      payload: { nested: { count: 1 } },
+      scheduledFor,
+      reason: "quiet_hours",
+    });
+    scheduledFor.setFullYear(2000);
+    (scheduled.payload.nested as { count: number }).count = 2;
+
+    const scheduledList = await adapter.scheduledSends.list();
+    expect(scheduledList[0]?.scheduledFor.getFullYear()).toBe(2026);
+    expect((scheduledList[0]?.payload.nested as { count: number }).count).toBe(1);
+
+    const claimed = await adapter.scheduledSends.claim(scheduled.id);
+    claimed!.claimedAt!.setFullYear(2000);
+    const claimedList = await adapter.scheduledSends.list();
+    expect(claimedList[0]?.claimedAt?.getFullYear()).not.toBe(2000);
+
+    const appended = await adapter.timeline!.append([
+      {
+        notificationRecordId: "ntf_1",
+        recipientId: "u1",
+        notificationId: "comment",
+        event: "payload.validated",
+        message: "ok",
+        metadata: { nested: { count: 1 } },
+      },
+    ]);
+    (appended[0]!.metadata!.nested as { count: number }).count = 2;
+    appended[0]!.timestamp.setFullYear(2000);
+
+    const timeline = await adapter.timeline!.listByNotificationRecordId("ntf_1");
+    expect((timeline[0]?.metadata?.nested as { count: number }).count).toBe(1);
+    expect(timeline[0]?.timestamp.getFullYear()).not.toBe(2000);
+  });
+});

--- a/packages/core/tests/notifykit.test.ts
+++ b/packages/core/tests/notifykit.test.ts
@@ -136,6 +136,15 @@ describe("NotifyKit core", () => {
     expect(items[0]!.title).toBe("Welcome, Alice");
   });
 
+  test("rejects invalid server-side list limits before calling adapters", async () => {
+    const { notify } = buildKit();
+    await notify.upsertRecipient({ id: "user_1" });
+
+    expect(() => notify.inbox.list("user_1", undefined, undefined, -1)).toThrow(/positive integer/);
+    expect(() => notify.inbox.list("user_1", undefined, undefined, 1.5)).toThrow(/positive integer/);
+    expect(() => notify.deliveries.list("user_1", undefined, Number.NaN)).toThrow(/positive integer/);
+  });
+
   test("can send a fake email", async () => {
     const { notify, provider } = buildKit();
     await notify.upsertRecipient({
@@ -190,6 +199,25 @@ describe("NotifyKit core", () => {
         payload: { name: "x" },
       }),
     ).rejects.toThrow(/Unknown recipient/);
+  });
+
+  test("send and explain reject whitespace-only recipient ids", async () => {
+    const { notify } = buildKit();
+    await expect(
+      notify.send({
+        recipientId: " ",
+        notificationId: "user_welcome",
+        payload: { name: "x" },
+      }),
+    ).rejects.toThrow(/recipientId must be a non-empty string/);
+
+    await expect(
+      notify.explain({
+        recipientId: "\t",
+        notificationId: "user_welcome",
+        payload: { name: "x" },
+      }),
+    ).rejects.toThrow(/recipientId must be a non-empty string/);
   });
 
   test("unknown notification throws", async () => {

--- a/packages/core/tests/preference-resolution.test.ts
+++ b/packages/core/tests/preference-resolution.test.ts
@@ -241,7 +241,7 @@ describe("app-level defaults", () => {
       payload: { msg: "string" },
       channels: [
         inbox({ title: "{{msg}}" }),
-        webhook({ url: "https://example.com/hook" }),
+        webhook({ url: "https://93.184.216.34/hook" }),
       ],
     });
     const webhookProv = fakeWebhookProvider();
@@ -348,7 +348,7 @@ describe("tenant defaults", () => {
       payload: { msg: "string" },
       channels: [
         inbox({ title: "{{msg}}" }),
-        webhook({ url: "https://example.com/hook" }),
+        webhook({ url: "https://93.184.216.34/hook" }),
       ],
     });
     const webhookProv = fakeWebhookProvider();

--- a/packages/core/tests/queues.test.ts
+++ b/packages/core/tests/queues.test.ts
@@ -104,6 +104,39 @@ describe("retries", () => {
     expect(result.deliveries[0]!.error).toMatch(/flaky attempt 2/);
   });
 
+  test("permanent provider errors stop retries and record actual attempts", async () => {
+    let attempts = 0;
+    const provider: EmailProvider = {
+      id: "permanent",
+      async send() {
+        attempts++;
+        const err = new Error("bad request") as Error & { permanent: boolean };
+        err.permanent = true;
+        throw err;
+      },
+    };
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+      retry: { maxAttempts: 3, delayMs: () => 0 },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: basePayload,
+    });
+    const timeline = await notify.timeline(result.notification!.id);
+    const failed = timeline.find((event) => event.event === "delivery.failed");
+
+    expect(attempts).toBe(1);
+    expect(result.deliveries[0]!.attempts).toBe(1);
+    expect(failed?.message).toContain("after 1 attempt");
+    expect(failed?.metadata?.attempts).toBe(1);
+  });
+
   test("delayMs receives the 1-indexed attempt number (skipped for first attempt)", async () => {
     const calls: number[] = [];
     const provider = makeFlakyProvider(99);
@@ -126,6 +159,58 @@ describe("retries", () => {
       payload: basePayload,
     });
     expect(calls).toEqual([2, 3]);
+  });
+
+  test("invalid retry delays fail the delivery without extra provider attempts", async () => {
+    const provider = makeFlakyProvider(99);
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+      retry: {
+        maxAttempts: 3,
+        delayMs: () => Number.NaN,
+      },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: basePayload,
+    });
+
+    expect(provider.attempts).toBe(1);
+    expect(result.deliveries[0]!.status).toBe("failed");
+    expect(result.deliveries[0]!.attempts).toBe(1);
+    expect(result.deliveries[0]!.error).toMatch(/retry\.delayMs\(2\).*non-negative finite number/);
+  });
+
+  test("throwing retry delay functions fail the delivery without extra provider attempts", async () => {
+    const provider = makeFlakyProvider(99);
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database: memoryAdapter(),
+      providers: { email: provider },
+      retry: {
+        maxAttempts: 3,
+        delayMs: () => {
+          throw new Error("bad delay");
+        },
+      },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@x.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: basePayload,
+    });
+
+    expect(provider.attempts).toBe(1);
+    expect(result.deliveries[0]!.status).toBe("failed");
+    expect(result.deliveries[0]!.attempts).toBe(1);
+    expect(result.deliveries[0]!.error).toMatch(/retry\.delayMs\(2\) threw: bad delay/);
   });
 
   test("delivery.failed hook fires exactly once", async () => {

--- a/packages/core/tests/quiet-hours.test.ts
+++ b/packages/core/tests/quiet-hours.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   isWithinQuietHours,
   nextQuietHoursEnd,
+  validateQuietHours,
 } from "../src/quiet-hours.js";
 
 const inbox = channel.inbox();
@@ -106,9 +107,36 @@ describe("quiet-hours helpers", () => {
     );
     expect(endAt.getTime()).toBe(d.getTime());
   });
+
+  test("validateQuietHours rejects malformed windows and timezones", () => {
+    expect(validateQuietHours({ start: "25:00", end: "08:00" })).toMatch(/out of range/);
+    expect(validateQuietHours({ start: "22:00", end: "8am" })).toMatch(/HH:MM/);
+    expect(validateQuietHours({ start: "22:00", end: "08:00", timezone: "Mars/Base" })).toMatch(/Invalid timezone/);
+    expect(validateQuietHours({ start: "22:00", end: "08:00", timezone: "UTC" })).toBeNull();
+  });
 });
 
 describe("quiet hours in send()", () => {
+  test("upsertRecipient rejects invalid quiet hours before persisting", async () => {
+    const { notify, db } = kitWithQuietSelf("out");
+
+    await expect(
+      notify.upsertRecipient({
+        id: "u1",
+        quietHours: { start: "22:00", end: "99:00" },
+      }),
+    ).rejects.toThrow(/Invalid quietHours/);
+
+    await expect(
+      notify.upsertRecipient({
+        id: "u2",
+        quietHours: { start: "22:00", end: "08:00", timezone: "Not/AZone" },
+      }),
+    ).rejects.toThrow(/Invalid quietHours/);
+
+    expect(db._state.recipients).toHaveLength(0);
+  });
+
   test("without quiet hours, email delivers immediately", async () => {
     const { notify, db, provider } = kitWithQuietSelf("out");
     await notify.upsertRecipient({ id: "u1", email: "u@x.com" });

--- a/packages/core/tests/realtime.test.ts
+++ b/packages/core/tests/realtime.test.ts
@@ -103,6 +103,23 @@ describe("memoryRealtimeAdapter", () => {
     expect(events2).toHaveLength(0);
   });
 
+  test("recipient ids containing delimiters do not collide", () => {
+    const adapter = memoryRealtimeAdapter();
+    const plain: RealtimeEvent[] = [];
+    const nulSeparated: RealtimeEvent[] = [];
+
+    adapter.subscribe("ab", {}, (e) => plain.push(e));
+    adapter.subscribe("a\0b", {}, (e) => nulSeparated.push(e));
+
+    adapter.publish("a\0b", {}, {
+      type: "inbox.deleted",
+      itemId: "inb_x",
+    });
+
+    expect(plain).toHaveLength(0);
+    expect(nulSeparated).toHaveLength(1);
+  });
+
   test("scope normalization: undefined vs absent fields match", () => {
     const adapter = memoryRealtimeAdapter();
     const events: RealtimeEvent[] = [];
@@ -144,6 +161,24 @@ describe("memoryRealtimeAdapter", () => {
 
     expect(events1).toHaveLength(1);
     expect(events2).toHaveLength(1);
+  });
+
+  test("throwing subscriber does not block other subscribers", () => {
+    const adapter = memoryRealtimeAdapter();
+    const events: RealtimeEvent[] = [];
+
+    adapter.subscribe("user_1", {}, () => {
+      throw new Error("listener failed");
+    });
+    adapter.subscribe("user_1", {}, (event) => events.push(event));
+
+    expect(() => {
+      adapter.publish("user_1", {}, {
+        type: "inbox.deleted",
+        itemId: "inb_1",
+      });
+    }).not.toThrow();
+    expect(events).toHaveLength(1);
   });
 
   test("publish to key with no subscribers is a no-op", () => {
@@ -295,6 +330,32 @@ describe("handler SSE stream", () => {
 
     controllerA.abort();
     controllerB.abort();
+  });
+
+  test("SSE connection limit is scoped by tenant for the same recipient id", async () => {
+    const controllers: AbortController[] = [];
+    try {
+      for (let i = 0; i < 10; i++) {
+        const controller = new AbortController();
+        controllers.push(controller);
+        const res = await handler(new Request(`${BASE}/inbox/stream?as=user_1&tenant=t_a`, {
+          signal: controller.signal,
+        }));
+        expect(res.status).toBe(200);
+      }
+
+      const blocked = await handler(new Request(`${BASE}/inbox/stream?as=user_1&tenant=t_a`));
+      expect(blocked.status).toBe(429);
+
+      const otherTenant = new AbortController();
+      controllers.push(otherTenant);
+      const allowed = await handler(new Request(`${BASE}/inbox/stream?as=user_1&tenant=t_b`, {
+        signal: otherTenant.signal,
+      }));
+      expect(allowed.status).toBe(200);
+    } finally {
+      for (const controller of controllers) controller.abort();
+    }
   });
 
   test("handler mutations publish realtime events", async () => {

--- a/packages/core/tests/security.test.ts
+++ b/packages/core/tests/security.test.ts
@@ -1100,6 +1100,19 @@ describe("empty-string recipientId rejection", () => {
     expect(res.status).toBe(401);
   });
 
+  test("identify returning whitespace is treated as unauthenticated", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    const handler = createHandler(notify, { identify: () => "   " });
+
+    const res = await handler(new Request(`${BASE}/inbox`));
+    expect(res.status).toBe(401);
+  });
+
   test("identify returning object with empty recipientId is treated as unauthenticated", async () => {
     const database = memoryAdapter();
     const notify = createNotifyKit({
@@ -1109,6 +1122,69 @@ describe("empty-string recipientId rejection", () => {
     });
     const handler = createHandler(notify, {
       identify: () => ({ recipientId: "" }),
+    });
+
+    const res = await handler(new Request(`${BASE}/inbox`));
+    expect(res.status).toBe(401);
+  });
+
+  test("identify returning malformed recipientId is treated as unauthenticated", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+
+    for (const identity of [{}, { recipientId: 123 }, { recipientId: "user_1", tenantId: null }, []]) {
+      const handler = createHandler(notify, {
+        identify: () => identity as never,
+      });
+
+      const res = await handler(new Request(`${BASE}/inbox`));
+      expect(res.status).toBe(401);
+    }
+  });
+
+  test("identify returning object with whitespace recipientId is treated as unauthenticated", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    const handler = createHandler(notify, {
+      identify: () => ({ recipientId: "\t" }),
+    });
+
+    const res = await handler(new Request(`${BASE}/inbox`));
+    expect(res.status).toBe(401);
+  });
+
+  test("identify returning empty scope fields is treated as unauthenticated", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    const handler = createHandler(notify, {
+      identify: () => ({ recipientId: "user_1", organizationId: "" }),
+    });
+
+    const res = await handler(new Request(`${BASE}/inbox`));
+    expect(res.status).toBe(401);
+  });
+
+  test("identify returning whitespace scope fields is treated as unauthenticated", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    const handler = createHandler(notify, {
+      identify: () => ({ recipientId: "user_1", tenantId: " " }),
     });
 
     const res = await handler(new Request(`${BASE}/inbox`));
@@ -1246,6 +1322,29 @@ describe("deliveries.list admin vs non-admin scoping", () => {
 });
 
 describe("request rate limiting", () => {
+  test("rejects invalid request rate limit options at handler creation", () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+
+    expect(() =>
+      createHandler(notify, {
+        identify: () => ({ recipientId: "alice" }),
+        requestRateLimit: { max: 0, windowMs: 1000 },
+      }),
+    ).toThrow(/requestRateLimit\.max/);
+
+    expect(() =>
+      createHandler(notify, {
+        identify: () => ({ recipientId: "alice" }),
+        requestRateLimit: { max: 1, windowMs: 0 },
+      }),
+    ).toThrow(/requestRateLimit\.windowMs/);
+  });
+
   test("returns 429 when request limit is exceeded", async () => {
     const database = memoryAdapter();
     const notify = createNotifyKit({
@@ -1298,6 +1397,31 @@ describe("request rate limiting", () => {
     currentUser = "bob";
     const bobOk = await handler(new Request(`${BASE}/inbox`));
     expect(bobOk.status).toBe(200);
+  });
+
+  test("rate limit is scoped by tenant for the same recipient id", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", tenantId: "tenant-a" });
+
+    let tenantId = "tenant-a";
+    const handler = createHandler(notify, {
+      identify: () => ({ recipientId: "alice", tenantId }),
+      requestRateLimit: { max: 1, windowMs: 60_000 },
+    });
+
+    const first = await handler(new Request(`${BASE}/inbox`));
+    expect(first.status).toBe(200);
+    const blocked = await handler(new Request(`${BASE}/inbox`));
+    expect(blocked.status).toBe(429);
+
+    tenantId = "tenant-b";
+    const otherTenant = await handler(new Request(`${BASE}/inbox`));
+    expect(otherTenant.status).toBe(200);
   });
 
   test("rate limit does not apply to unauthenticated routes", async () => {
@@ -1836,6 +1960,16 @@ describe("organizationId alias", () => {
       payload: makePayload(),
     });
     expect(result.notification!.tenantId).toBe("t_explicit");
+
+    await expect(
+      notify.send({
+        recipientId: "bob",
+        tenantId: "t_explicit",
+        organizationId: " ",
+        notificationId: "comment_mentioned",
+        payload: makePayload(),
+      }),
+    ).rejects.toThrow(/organizationId must be a non-empty string/);
   });
 });
 
@@ -2049,6 +2183,37 @@ describe("organizationId normalization in scope-taking APIs", () => {
 });
 
 describe("recipient tenant immutability", () => {
+  test("upsertRecipient rejects empty ids", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+
+    await expect(notify.upsertRecipient({ id: "" })).rejects.toThrow(/non-empty/);
+    await expect(notify.upsertRecipient({ id: "   " })).rejects.toThrow(/non-empty/);
+  });
+
+  test("upsertRecipient rejects whitespace-only scope ids", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+
+    await expect(
+      notify.upsertRecipient({ id: "alice", tenantId: " " }),
+    ).rejects.toThrow(/tenantId must be a non-empty string/);
+    await expect(
+      notify.upsertRecipient({ id: "alice", organizationId: "\t" }),
+    ).rejects.toThrow(/organizationId must be a non-empty string/);
+    await expect(
+      notify.upsertRecipient({ id: "alice", workspaceId: " " }),
+    ).rejects.toThrow(/workspaceId must be a non-empty string/);
+  });
+
   test("upsertRecipient rejects tenant reassignment", async () => {
     const database = memoryAdapter();
     const notify = createNotifyKit({
@@ -2090,9 +2255,56 @@ describe("recipient tenant immutability", () => {
     expect(updated.email).toBe("new@x.com");
     expect(updated.tenantId).toBe("orgA");
   });
+
+  test("upsertRecipient rejects workspace reassignment", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", workspaceId: "wsA" });
+
+    await expect(
+      notify.upsertRecipient({ id: "alice", workspaceId: "wsB" }),
+    ).rejects.toThrow(/cannot reassign/);
+  });
+
+  test("upsertRecipient allows re-upserting same workspace", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", workspaceId: "wsA", email: "old@x.com" });
+
+    const updated = await notify.upsertRecipient({ id: "alice", workspaceId: "wsA", email: "new@x.com" });
+    expect(updated.email).toBe("new@x.com");
+    expect(updated.workspaceId).toBe("wsA");
+  });
 });
 
 describe("tenant-scoped explain()", () => {
+  test("send rejects whitespace-only scope ids", async () => {
+    const database = memoryAdapter();
+    const notify = createNotifyKit({
+      notifications: [commentMentioned] as const,
+      database,
+      providers: { email: fakeEmailProvider() },
+    });
+    await notify.upsertRecipient({ id: "alice", email: "a@x.com" });
+
+    await expect(
+      notify.send({
+        recipientId: "alice",
+        tenantId: " ",
+        notificationId: "comment_mentioned",
+        payload: makePayload(),
+      }),
+    ).rejects.toThrow(/tenantId must be a non-empty string/);
+  });
+
   test("explain uses the recipient's tenant scope for preference resolution", async () => {
     const database = memoryAdapter();
     const notify = createNotifyKit({

--- a/packages/core/tests/timeline.test.ts
+++ b/packages/core/tests/timeline.test.ts
@@ -596,4 +596,18 @@ describe("timeline", () => {
     const limited = await notify.timeline(result.notification!.id, { limit: 999 });
     expect(limited.length).toBe(all.length);
   });
+
+  test("rejects invalid limit options", async () => {
+    const { notify } = setup();
+    await notify.upsertRecipient({ id: "u1", email: "u1@test.com" });
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "comment_mentioned",
+      payload: { author: "Alice", body: "Hello" },
+    });
+
+    await expect(notify.timeline(result.notification!.id, { limit: 0 })).rejects.toThrow(/positive integer/);
+    await expect(notify.timeline(result.notification!.id, { limit: 2.5 })).rejects.toThrow(/positive integer/);
+  });
 });

--- a/packages/core/tests/utils.test.ts
+++ b/packages/core/tests/utils.test.ts
@@ -3,20 +3,42 @@ import { assertSafeWebhookUrl, isSafeUrl, renderTemplate } from "../src/utils.js
 
 describe("assertSafeWebhookUrl", () => {
   test("accepts valid https URL", async () => {
-    const result = await assertSafeWebhookUrl("https://hooks.slack.com/services/abc");
+    const result = await assertSafeWebhookUrl("https://hooks.slack.com/services/abc", {
+      resolveHostname: async () => ["44.44.44.44"],
+    });
     expect(result.pinnedUrl).toBeTruthy();
     expect(result.hostHeader).toContain("hooks.slack.com");
   });
 
   test("keeps https hostname after DNS validation so TLS still verifies", async () => {
-    const result = await assertSafeWebhookUrl("https://example.com/hook");
+    const result = await assertSafeWebhookUrl("https://example.com/hook", {
+      resolveHostname: async () => ["93.184.216.34"],
+    });
     expect(result.pinnedUrl).toBe("https://example.com/hook");
     expect(result.hostHeader).toBe("example.com");
   });
 
   test("preserves custom port once in Host header", async () => {
-    const result = await assertSafeWebhookUrl("https://example.com:8443/hook");
+    const result = await assertSafeWebhookUrl("https://example.com:8443/hook", {
+      resolveHostname: async () => ["93.184.216.34"],
+    });
     expect(result.hostHeader).toBe("example.com:8443");
+  });
+
+  test("rejects hostnames that resolve to private addresses", async () => {
+    await expect(
+      assertSafeWebhookUrl("https://example.com/hook", {
+        resolveHostname: async () => ["10.0.0.1"],
+      }),
+    ).rejects.toThrow(/blocked/);
+  });
+
+  test("rejects hostname validation when DNS is unavailable", async () => {
+    await expect(
+      assertSafeWebhookUrl("https://notifykit.invalid/hook", {
+        resolveHostname: async () => [],
+      }),
+    ).rejects.toThrow(/DNS resolution/);
   });
 
   test("rejects non-http protocols", async () => {

--- a/packages/core/tests/webhook.test.ts
+++ b/packages/core/tests/webhook.test.ts
@@ -33,7 +33,7 @@ function buildWebhookDef(
     },
     channels: [
       webhook({
-        url: "https://example.com/hook/{{postUrl}}",
+        url: "https://93.184.216.34/hook/{{postUrl}}",
         headers: { "x-actor": "{{actorName}}" },
         ...overrides,
       }),
@@ -70,7 +70,7 @@ describe("channel.webhook()", () => {
     expect(provider.sent).toHaveLength(1);
     expect(result.deliveries[0]!.channel).toBe("webhook");
     expect(result.deliveries[0]!.status).toBe("sent");
-    expect(result.deliveries[0]!.to).toBe("https://example.com/hook/%2Fp");
+    expect(result.deliveries[0]!.to).toBe("https://93.184.216.34/hook/%2Fp");
     expect(db._state.deliveries[0]!.body).toBe(JSON.stringify(basePayload));
   });
 
@@ -86,7 +86,7 @@ describe("channel.webhook()", () => {
 
     const call = provider.sent[0]!;
     expect(new URL(call.url).pathname).toBe("/hook/%2Fp");
-    expect(call.headers["host"]).toBe("example.com");
+    expect(call.headers["host"]).toBe("93.184.216.34");
     expect(call.headers["x-actor"]).toBe("Rey");
     expect(call.payload).toEqual({
       notificationId: "comment_mentioned",
@@ -94,6 +94,19 @@ describe("channel.webhook()", () => {
       payload: basePayload,
       sentAt: expect.any(String),
     });
+  });
+
+  test("custom headers cannot configure the reserved transport host header", () => {
+    const provider = fakeWebhookProvider();
+    expect(() =>
+      buildKit(provider, {
+        headers: {
+          host: "evil.example",
+          Host: "also-evil.example",
+          "x-actor": "{{actorName}}",
+        },
+      }),
+    ).toThrow(/header "host" is reserved/i);
   });
 
   test("retry + eventual success", async () => {
@@ -130,7 +143,7 @@ describe("channel.webhook()", () => {
       id: "comment_mentioned",
       payload: { msg: "string" },
       channels: [
-        webhook({ url: "https://example.com/hook" }),
+        webhook({ url: "https://93.184.216.34/hook" }),
       ],
       fallback: inbox({ title: "Fallback: {{msg}}" }),
     });
@@ -184,7 +197,7 @@ describe("channel.webhook()", () => {
       payload: { msg: "string" },
       channels: [
         email({ subject: "{{msg}}", body: "{{msg}}" }),
-        webhook({ url: "https://example.com/hook/x" }),
+        webhook({ url: "https://93.184.216.34/hook/x" }),
       ],
     });
     const emailProvider = {
@@ -256,6 +269,11 @@ describe("channel.webhook()", () => {
 });
 
 describe("webhookProvider (default fetch-based)", () => {
+  test("rejects invalid timeout options", () => {
+    expect(() => webhookProvider({ timeoutMs: 0 })).toThrow(/timeoutMs/);
+    expect(() => webhookProvider({ timeoutMs: Number.NaN })).toThrow(/timeoutMs/);
+  });
+
   test("POSTs JSON payload with signature header when secret is set", async () => {
     const calls: Array<{ url: string; init: RequestInit }> = [];
     const fakeFetch: typeof fetch = (async (input, init) => {
@@ -265,7 +283,7 @@ describe("webhookProvider (default fetch-based)", () => {
 
     const provider = webhookProvider({ secret: "shhh", fetch: fakeFetch });
     const res = await provider.send({
-      url: "https://example.com/hook",
+      url: "https://93.184.216.34/hook",
       headers: { "x-custom": "v" },
       payload: {
         notificationId: "n",
@@ -277,7 +295,7 @@ describe("webhookProvider (default fetch-based)", () => {
 
     expect(res.providerMessageId).toBe("abc");
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe("https://example.com/hook");
+    expect(calls[0]!.url).toBe("https://93.184.216.34/hook");
     const headers = calls[0]!.init.headers as Record<string, string>;
     expect(headers["content-type"]).toBe("application/json");
     expect(headers["x-custom"]).toBe("v");
@@ -299,7 +317,7 @@ describe("webhookProvider (default fetch-based)", () => {
 
     const provider = webhookProvider({ fetch: fakeFetch });
     await provider.send({
-      url: "https://example.com/hook",
+      url: "https://93.184.216.34/hook",
       headers: {},
       payload: {
         notificationId: "n",
@@ -317,7 +335,7 @@ describe("webhookProvider (default fetch-based)", () => {
     const provider = webhookProvider({ fetch: fakeFetch });
     await expect(
       provider.send({
-        url: "https://example.com/hook",
+        url: "https://93.184.216.34/hook",
         headers: {},
         payload: {
           notificationId: "n",
@@ -369,7 +387,7 @@ describe("verifyWebhookSignature", () => {
 
     const provider = webhookProvider({ secret, fetch: fakeFetch });
     await provider.send({
-      url: "https://example.com/hook",
+      url: "https://93.184.216.34/hook",
       headers: {},
       payload: {
         notificationId: "n",

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -42,6 +42,11 @@ export async function run(argv: string[]): Promise<number> {
     console.error(USAGE);
     return 1;
   }
+  if (positionals.length > 1) {
+    console.error(`Error: unexpected extra argument: ${positionals[1]}`);
+    console.error(USAGE);
+    return 1;
+  }
 
   try {
     const result = await scaffold({

--- a/packages/create-app/src/scaffold.ts
+++ b/packages/create-app/src/scaffold.ts
@@ -1,4 +1,4 @@
-import { cp, readFile, readdir, rename, writeFile } from "node:fs/promises";
+import { cp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { existsSync, statSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -47,39 +47,48 @@ export async function scaffold(options: ScaffoldOptions): Promise<ScaffoldResult
     );
   }
 
-  await cp(templateDir, targetDir, { recursive: true });
+  const stagingDir = `${targetDir}.__notifykit_tmp_${process.pid}_${Date.now()}`;
 
-  // `npm pack` drops .gitignore. We ship it as _gitignore in the template so
-  // publish keeps it; rename on copy.
-  const dotted = resolve(targetDir, "_gitignore");
-  if (existsSync(dotted)) {
-    await rename(dotted, resolve(targetDir, ".gitignore"));
-  }
+  try {
+    await cp(templateDir, stagingDir, { recursive: true });
 
-  // Rewrite package.json with the real project name.
-  const pkgPath = resolve(targetDir, "package.json");
-  const pkgRaw = await readFile(pkgPath, "utf8");
-  const pkg = JSON.parse(pkgRaw) as { name: string };
-  pkg.name = projectName;
-  await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
-
-  // Sanity check: the template should have produced at least these files.
-  const required = [
-    "app/layout.tsx",
-    "app/page.tsx",
-    "app/api/notifykit/[...route]/route.ts",
-    "lib/notifykit.ts",
-    "lib/session.ts",
-    ".env.example",
-    "package.json",
-    "tsconfig.json",
-  ];
-  for (const file of required) {
-    if (!existsSync(resolve(targetDir, file))) {
-      throw new ScaffoldError(
-        `Scaffold is missing an expected file: ${file}. Template may be corrupt.`,
-      );
+    // `npm pack` drops .gitignore. We ship it as _gitignore in the template so
+    // publish keeps it; rename on copy.
+    const dotted = resolve(stagingDir, "_gitignore");
+    if (existsSync(dotted)) {
+      await rename(dotted, resolve(stagingDir, ".gitignore"));
     }
+
+    // Rewrite package.json with the real project name.
+    const pkgPath = resolve(stagingDir, "package.json");
+    const pkgRaw = await readFile(pkgPath, "utf8");
+    const pkg = JSON.parse(pkgRaw) as { name: string };
+    pkg.name = projectName;
+    await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+
+    // Sanity check: the template should have produced at least these files.
+    const required = [
+      "app/layout.tsx",
+      "app/page.tsx",
+      "app/api/notifykit/[...route]/route.ts",
+      "lib/notifykit.ts",
+      "lib/session.ts",
+      ".env.example",
+      "package.json",
+      "tsconfig.json",
+    ];
+    for (const file of required) {
+      if (!existsSync(resolve(stagingDir, file))) {
+        throw new ScaffoldError(
+          `Scaffold is missing an expected file: ${file}. Template may be corrupt.`,
+        );
+      }
+    }
+
+    await rename(stagingDir, targetDir);
+  } catch (err) {
+    await rm(stagingDir, { recursive: true, force: true });
+    throw err;
   }
 
   return { targetDir, projectName };

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -6,6 +6,6 @@ NOTIFYKIT_SECRET=replace-me-with-a-32-byte-random-secret
 NOTIFYKIT_BASE_URL=http://localhost:3000/api/notifykit
 
 # --- Optional: real email via Resend ---
-# Install `notifykit-resend`, uncomment below, and see lib/notifykit.ts
+# Install `@notifykitjs/resend`, uncomment below, and see lib/notifykit.ts
 # RESEND_API_KEY=
 # RESEND_FROM="Acme <no-reply@acme.com>"

--- a/packages/create-app/tests/cli.test.ts
+++ b/packages/create-app/tests/cli.test.ts
@@ -56,6 +56,13 @@ describe("create-notifykit-app CLI", () => {
     expect(existsSync(resolve(workDir, "my-app/lib/notifykit.ts"))).toBe(true);
   });
 
+  test("extra positional args print usage and exit 1", async () => {
+    const result = await runCli(["my-app", "extra"], workDir);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/unexpected extra argument/i);
+    expect(existsSync(resolve(workDir, "my-app"))).toBe(false);
+  });
+
   test("--name overrides the package name in package.json", async () => {
     const result = await runCli(["apps/web", "--name", "acme-web"], workDir);
     expect(result.code).toBe(0);

--- a/packages/create-app/tests/scaffold.test.ts
+++ b/packages/create-app/tests/scaffold.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
@@ -82,6 +82,19 @@ describe("scaffold()", () => {
         projectName: "Bad Name",
       }),
     ).rejects.toThrow(/Invalid project name/);
+  });
+
+  test("does not leave the target directory when template validation fails", async () => {
+    const template = resolve(workDir, "bad-template");
+    await mkdir(template, { recursive: true });
+    await writeFile(resolve(template, "package.json"), `{"name":"bad"}\n`);
+
+    const target = resolve(workDir, "partial-app");
+    await expect(
+      scaffold({ targetDir: target, templateDir: template }),
+    ).rejects.toThrow(/missing an expected file/);
+
+    expect(existsSync(target)).toBe(false);
   });
 
   test("route.ts mounts the NotifyKit handler", async () => {

--- a/packages/drizzle-adapter/package.json
+++ b/packages/drizzle-adapter/package.json
@@ -14,6 +14,9 @@
   },
   "homepage": "https://github.com/reyabsaluja/notifykit",
   "bugs": "https://github.com/reyabsaluja/notifykit/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/drizzle-adapter/src/postgres.ts
+++ b/packages/drizzle-adapter/src/postgres.ts
@@ -39,6 +39,14 @@ function scopeValue(value: string | undefined): string {
   return value ?? "";
 }
 
+function normalizeLimit(limit: number | undefined | null, max?: number): number | undefined {
+  if (limit == null) return undefined;
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new RangeError("limit must be a positive integer.");
+  }
+  return max === undefined ? limit : Math.min(limit, max);
+}
+
 function emptyToUndefined(value: string | null | undefined): string | undefined {
   return value === "" || value == null ? undefined : value;
 }
@@ -305,8 +313,10 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .from(inboxItems)
           .where(and(...conditions))
           .orderBy(desc(inboxItems.createdAt));
-        const cap = Math.min(limit ?? 200, 1000);
-        const rows = await query.limit(cap);
+        const normalizedLimit = normalizeLimit(limit, 1000);
+        const rows = normalizedLimit === undefined
+          ? await query
+          : await query.limit(normalizedLimit);
         return rows.map(rowToInboxItem);
       },
 
@@ -554,14 +564,17 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
         scope?: SecurityScope,
         limit?: number,
       ): Promise<DeliveryRecord[]> {
-        const cap = Math.min(limit ?? 200, 1000);
         const conditions = [
           ...(recipientId ? [eq(deliveries.recipientId, recipientId)] : []),
           ...scopedConditions(deliveries, scope),
         ];
-        const rows = conditions.length > 0
-          ? await db.select().from(deliveries).where(and(...conditions)).orderBy(desc(deliveries.createdAt)).limit(cap)
-          : await db.select().from(deliveries).orderBy(desc(deliveries.createdAt)).limit(cap);
+        const query = conditions.length > 0
+          ? db.select().from(deliveries).where(and(...conditions)).orderBy(desc(deliveries.createdAt))
+          : db.select().from(deliveries).orderBy(desc(deliveries.createdAt));
+        const normalizedLimit = normalizeLimit(limit, 1000);
+        const rows = normalizedLimit === undefined
+          ? await query
+          : await query.limit(normalizedLimit);
         return rows.map(rowToDelivery);
       },
     },
@@ -1081,7 +1094,8 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .from(timelineEvents)
           .where(eq(timelineEvents.notificationRecordId, notificationRecordId))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
-        if (limit != null) query = query.limit(limit) as typeof query;
+        const normalizedLimit = normalizeLimit(limit);
+        if (normalizedLimit !== undefined) query = query.limit(normalizedLimit) as typeof query;
         const rows = await query;
         return rows.map(rowToTimelineEvent);
       },
@@ -1093,7 +1107,8 @@ export function drizzlePostgresAdapter(db: PgDb): DrizzlePostgresAdapter {
           .from(timelineEvents)
           .where(and(...conditions))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
-        if (limit != null) query = query.limit(limit) as typeof query;
+        const normalizedLimit = normalizeLimit(limit);
+        if (normalizedLimit !== undefined) query = query.limit(normalizedLimit) as typeof query;
         const rows = await query;
         return rows.map(rowToTimelineEvent);
       },

--- a/packages/drizzle-adapter/src/sqlite.ts
+++ b/packages/drizzle-adapter/src/sqlite.ts
@@ -39,6 +39,14 @@ function scopeValue(value: string | undefined): string {
   return value ?? "";
 }
 
+function normalizeLimit(limit: number | undefined | null, max?: number): number | undefined {
+  if (limit == null) return undefined;
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new RangeError("limit must be a positive integer.");
+  }
+  return max === undefined ? limit : Math.min(limit, max);
+}
+
 function emptyToUndefined(value: string | null | undefined): string | undefined {
   return value === "" || value == null ? undefined : value;
 }
@@ -330,8 +338,10 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .from(inboxItems)
           .where(and(...conditions))
           .orderBy(desc(inboxItems.createdAt));
-        const cap = Math.min(limit ?? 200, 1000);
-        const rows = await query.limit(cap);
+        const normalizedLimit = normalizeLimit(limit, 1000);
+        const rows = normalizedLimit === undefined
+          ? await query
+          : await query.limit(normalizedLimit);
         return rows.map(rowToInboxItem);
       },
 
@@ -578,14 +588,17 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
         scope?: SecurityScope,
         limit?: number,
       ): Promise<DeliveryRecord[]> {
-        const cap = Math.min(limit ?? 200, 1000);
         const conditions = [
           ...(recipientId ? [eq(deliveries.recipientId, recipientId)] : []),
           ...scopedConditions(deliveries, scope),
         ];
-        const rows = conditions.length > 0
-          ? await db.select().from(deliveries).where(and(...conditions)).orderBy(desc(deliveries.createdAt)).limit(cap)
-          : await db.select().from(deliveries).orderBy(desc(deliveries.createdAt)).limit(cap);
+        const query = conditions.length > 0
+          ? db.select().from(deliveries).where(and(...conditions)).orderBy(desc(deliveries.createdAt))
+          : db.select().from(deliveries).orderBy(desc(deliveries.createdAt));
+        const normalizedLimit = normalizeLimit(limit, 1000);
+        const rows = normalizedLimit === undefined
+          ? await query
+          : await query.limit(normalizedLimit);
         return rows.map(rowToDelivery);
       },
     },
@@ -1136,7 +1149,8 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .from(timelineEvents)
           .where(eq(timelineEvents.notificationRecordId, notificationRecordId))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
-        if (limit != null) query = query.limit(limit) as typeof query;
+        const normalizedLimit = normalizeLimit(limit);
+        if (normalizedLimit !== undefined) query = query.limit(normalizedLimit) as typeof query;
         const rows = await query;
         return rows.map(rowToTimelineEvent);
       },
@@ -1148,7 +1162,8 @@ export function drizzleSqliteAdapter(db: SqliteDb): DrizzleSqliteAdapter {
           .from(timelineEvents)
           .where(and(...conditions))
           .orderBy(asc(timelineEvents.timestamp), asc(timelineEvents.seq));
-        if (limit != null) query = query.limit(limit) as typeof query;
+        const normalizedLimit = normalizeLimit(limit);
+        if (normalizedLimit !== undefined) query = query.limit(normalizedLimit) as typeof query;
         const rows = await query;
         return rows.map(rowToTimelineEvent);
       },

--- a/packages/drizzle-adapter/tests/drizzle-adapter.test.ts
+++ b/packages/drizzle-adapter/tests/drizzle-adapter.test.ts
@@ -68,6 +68,21 @@ describe("drizzleSqliteAdapter", () => {
     await ctx.notify.upsertRecipient({ id: "user_1" });
   });
 
+  test("list methods reject invalid limits", async () => {
+    await expect(
+      ctx.adapter.inbox.listByRecipient("user_1", undefined, undefined, -1),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      ctx.adapter.deliveries.list("user_1", undefined, 1.5),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      ctx.adapter.timeline!.listByNotificationRecordId("ntf_1", 0),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      ctx.adapter.timeline!.listByDeliveryId("dlv_1", undefined, Number.NaN),
+    ).rejects.toThrow(/positive integer/);
+  });
+
   test("createSqliteTables migrates old preference primary key to include scope", async () => {
     const sqlite = new Database(":memory:");
     sqlite.exec(`
@@ -333,6 +348,40 @@ describe("drizzleSqliteAdapter", () => {
     }
     const all = await ctx.notify.deliveries.list();
     expect(all).toHaveLength(2);
+  });
+
+  test("list methods do not truncate when limit is omitted", async () => {
+    await ctx.notify.upsertRecipient({ id: "user_1", email: "a@example.com" });
+    for (let i = 0; i < 205; i++) {
+      const notificationRecord = await ctx.adapter.notifications.create({
+        recipientId: "user_1",
+        notificationId: "user_welcome",
+        payload: { name: `User ${i}` },
+        payloadSchema: { name: "string" },
+      });
+      await ctx.adapter.inbox.create({
+        notificationRecordId: notificationRecord.id,
+        recipientId: "user_1",
+        notificationId: "user_welcome",
+        title: `Welcome ${i}`,
+      });
+      await ctx.adapter.deliveries.create({
+        notificationRecordId: notificationRecord.id,
+        recipientId: "user_1",
+        notificationId: "user_welcome",
+        channel: "email",
+        provider: "fake",
+        status: "sent",
+        to: "a@example.com",
+        subject: `Welcome ${i}`,
+        body: `Welcome ${i}`,
+      });
+    }
+
+    expect(await ctx.adapter.inbox.listByRecipient("user_1")).toHaveLength(205);
+    expect(await ctx.adapter.inbox.listByRecipient("user_1", undefined, undefined, 10)).toHaveLength(10);
+    expect(await ctx.adapter.deliveries.list()).toHaveLength(205);
+    expect(await ctx.adapter.deliveries.list(undefined, undefined, 10)).toHaveLength(10);
   });
 
   test("quietHours persists on the recipient row", async () => {

--- a/packages/drizzle-adapter/tests/drizzle-postgres-adapter.test.ts
+++ b/packages/drizzle-adapter/tests/drizzle-postgres-adapter.test.ts
@@ -78,6 +78,21 @@ describe("drizzlePostgresAdapter", () => {
     await ctx.notify.upsertRecipient({ id: "user_1" });
   });
 
+  test("list methods reject invalid limits", async () => {
+    await expect(
+      ctx.adapter.inbox.listByRecipient("user_1", undefined, undefined, -1),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      ctx.adapter.deliveries.list("user_1", undefined, 1.5),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      ctx.adapter.timeline!.listByNotificationRecordId("ntf_1", 0),
+    ).rejects.toThrow(/positive integer/);
+    await expect(
+      ctx.adapter.timeline!.listByDeliveryId("dlv_1", undefined, Number.NaN),
+    ).rejects.toThrow(/positive integer/);
+  });
+
   test("upsertRecipient creates then updates without clobbering", async () => {
     const created = await ctx.notify.upsertRecipient({
       id: "user_1",
@@ -286,6 +301,40 @@ describe("drizzlePostgresAdapter", () => {
     }
     const all = await ctx.notify.deliveries.list();
     expect(all).toHaveLength(2);
+  });
+
+  test("list methods do not truncate when limit is omitted", async () => {
+    await ctx.notify.upsertRecipient({ id: "user_1", email: "a@example.com" });
+    for (let i = 0; i < 205; i++) {
+      const notificationRecord = await ctx.adapter.notifications.create({
+        recipientId: "user_1",
+        notificationId: "user_welcome",
+        payload: { name: `User ${i}` },
+        payloadSchema: { name: "string" },
+      });
+      await ctx.adapter.inbox.create({
+        notificationRecordId: notificationRecord.id,
+        recipientId: "user_1",
+        notificationId: "user_welcome",
+        title: `Welcome ${i}`,
+      });
+      await ctx.adapter.deliveries.create({
+        notificationRecordId: notificationRecord.id,
+        recipientId: "user_1",
+        notificationId: "user_welcome",
+        channel: "email",
+        provider: "fake",
+        status: "sent",
+        to: "a@example.com",
+        subject: `Welcome ${i}`,
+        body: `Welcome ${i}`,
+      });
+    }
+
+    expect(await ctx.adapter.inbox.listByRecipient("user_1")).toHaveLength(205);
+    expect(await ctx.adapter.inbox.listByRecipient("user_1", undefined, undefined, 10)).toHaveLength(10);
+    expect(await ctx.adapter.deliveries.list()).toHaveLength(205);
+    expect(await ctx.adapter.deliveries.list(undefined, undefined, 10)).toHaveLength(10);
   });
 
   test("quietHours persists as jsonb on the recipient row", async () => {

--- a/packages/next/src/middleware.ts
+++ b/packages/next/src/middleware.ts
@@ -12,11 +12,15 @@ export type NotifyKitMiddlewareOptions = {
 export function createNotifyKitMiddleware(
   options: NotifyKitMiddlewareOptions = {},
 ) {
-  const basePath = options.basePath ?? "/api/notifykit";
+  const basePath = normalizeBasePath(options.basePath ?? "/api/notifykit");
 
   return function notifyKitMiddleware(request: NextRequest): NextResponse | null {
     const { pathname } = request.nextUrl;
-    if (pathname !== basePath && !pathname.startsWith(basePath + "/")) {
+    if (
+      basePath !== "/" &&
+      pathname !== basePath &&
+      !pathname.startsWith(basePath + "/")
+    ) {
       return null;
     }
 
@@ -74,12 +78,19 @@ export function createNotifyKitMiddleware(
 }
 
 export function withNotifyKitHeaders(basePath = "/api/notifykit") {
+  const normalizedBasePath = normalizeBasePath(basePath);
   return {
-    source: `${basePath}/:path*`,
+    source: normalizedBasePath === "/" ? "/:path*" : `${normalizedBasePath}/:path*`,
     headers: [
       { key: "X-Content-Type-Options", value: "nosniff" },
       { key: "X-Frame-Options", value: "DENY" },
       { key: "Cache-Control", value: "no-store" },
     ],
   };
+}
+
+function normalizeBasePath(input: string): string {
+  let path = input.startsWith("/") ? input : `/${input}`;
+  if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
+  return path;
 }

--- a/packages/next/src/server-actions.ts
+++ b/packages/next/src/server-actions.ts
@@ -56,13 +56,35 @@ function normalizeIdentity(
   value: string | ServerActionsIdentity,
 ): ServerActionsIdentity {
   if (typeof value === "string") {
-    if (!value) throw new Error("identify() returned an empty string");
+    if (!isValidIdentityId(value)) throw new Error("identify() returned an empty string");
     return { recipientId: value };
   }
-  if (!value.recipientId) {
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("identify() returned an invalid identity");
+  }
+  if (!isValidIdentityId(value.recipientId)) {
     throw new Error("identify() returned an object with an empty recipientId");
   }
+  if (!isValidOptionalIdentityId(value.tenantId)) {
+    throw new Error("identify() returned an object with an empty tenantId");
+  }
+  if (!isValidOptionalIdentityId(value.organizationId)) {
+    throw new Error("identify() returned an object with an empty organizationId");
+  }
+  if (!isValidOptionalIdentityId(value.workspaceId)) {
+    throw new Error("identify() returned an object with an empty workspaceId");
+  }
   return value;
+}
+
+const MAX_ID_LENGTH = 512;
+
+function isValidIdentityId(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "" && value.length <= MAX_ID_LENGTH;
+}
+
+function isValidOptionalIdentityId(value: unknown): value is string | undefined {
+  return value === undefined || isValidIdentityId(value);
 }
 
 const VALID_CHANNEL_KEYS = new Set(["inbox", "email", "webhook", "sms"]);
@@ -99,24 +121,23 @@ export function createServerActions<
     },
 
     async updatePreference(input) {
+      const raw = input as Record<string, unknown>;
       if (
         !input ||
         typeof input !== "object" ||
-        typeof (input as Record<string, unknown>).notificationId !== "string" ||
-        ((input as Record<string, unknown>).notificationId as string).length === 0 ||
-        ((input as Record<string, unknown>).notificationId as string).length > 512
+        typeof raw.notificationId !== "string" ||
+        raw.notificationId.length === 0 ||
+        raw.notificationId.length > 512
       ) {
         throw new Error("Invalid notificationId");
       }
-      const channels = (input as Record<string, unknown>).channels;
-      if (channels !== undefined) {
-        assertChannelMap(channels);
-      }
+      assertChannelMap(raw.channels);
       const { recipientId, ...scope } = await resolveIdentity();
       return notifykit.preferences.update({
-        ...input,
         recipientId,
         ...scope,
+        notificationId: raw.notificationId,
+        channels: raw.channels,
       } as UpdatePreferenceInput<T>);
     },
 

--- a/packages/next/tests/middleware.test.ts
+++ b/packages/next/tests/middleware.test.ts
@@ -70,6 +70,42 @@ describe("createNotifyKitMiddleware", () => {
     expect(middleware(noMatch)).toBeNull();
   });
 
+  test("normalizes custom basePath for matching", () => {
+    const middleware = createNotifyKitMiddleware({
+      basePath: "custom/api/",
+      cors: { origin: "*" },
+    });
+
+    const match = mockNextRequest(
+      "http://localhost/custom/api/inbox",
+      "GET",
+      { origin: "http://app.com" },
+    );
+    const sibling = mockNextRequest(
+      "http://localhost/custom/api-extra/inbox",
+      "GET",
+      { origin: "http://app.com" },
+    );
+
+    expect(middleware(match)).not.toBeNull();
+    expect(middleware(sibling)).toBeNull();
+  });
+
+  test("root basePath matches root-mounted routes", () => {
+    const middleware = createNotifyKitMiddleware({
+      basePath: "/",
+      cors: { origin: "*" },
+    });
+
+    const match = mockNextRequest(
+      "http://localhost/notifications",
+      "GET",
+      { origin: "http://app.com" },
+    );
+
+    expect(middleware(match)).not.toBeNull();
+  });
+
   test("handles OPTIONS preflight with cors", () => {
     const middleware = createNotifyKitMiddleware({
       cors: { origin: "http://app.example.com" },
@@ -190,5 +226,15 @@ describe("withNotifyKitHeaders", () => {
   test("respects custom basePath", () => {
     const config = withNotifyKitHeaders("/custom");
     expect(config.source).toBe("/custom/:path*");
+  });
+
+  test("normalizes custom basePath", () => {
+    const config = withNotifyKitHeaders("custom/");
+    expect(config.source).toBe("/custom/:path*");
+  });
+
+  test("handles root basePath", () => {
+    const config = withNotifyKitHeaders("/");
+    expect(config.source).toBe("/:path*");
   });
 });

--- a/packages/next/tests/route.test.ts
+++ b/packages/next/tests/route.test.ts
@@ -147,6 +147,18 @@ describe("createRouteHandler", () => {
     expect(missRes.status).toBe(404);
   });
 
+  test("root basePath works", async () => {
+    const { notifykit } = buildKit();
+    const handlers = createRouteHandler({
+      notifykit,
+      identify: () => "user-1",
+      basePath: "/",
+    });
+
+    const response = await handlers.GET(new Request("http://localhost/notifications"));
+    expect(response.status).toBe(200);
+  });
+
   test("all methods route to the same handler", async () => {
     const { notifykit } = buildKit();
     const handlers = createRouteHandler({

--- a/packages/next/tests/server-actions.test.ts
+++ b/packages/next/tests/server-actions.test.ts
@@ -101,6 +101,28 @@ describe("createServerActions", () => {
     expect(pref.channels.email).toBe(false);
   });
 
+  test("updatePreference ignores client-supplied scope fields", async () => {
+    const { notifykit } = buildKit();
+    await notifykit.upsertRecipient({ id: "user-1", email: "u@x.com" });
+
+    const actions = createServerActions({
+      notifykit,
+      identify: () => "user-1",
+    });
+
+    const pref = await actions.updatePreference({
+      notificationId: "comment_mentioned",
+      channels: { email: false },
+      tenantId: "tenant-b",
+      workspaceId: "workspace-b",
+    } as never);
+
+    expect(pref.recipientId).toBe("user-1");
+    expect(pref.tenantId).toBeUndefined();
+    expect(pref.workspaceId).toBeUndefined();
+    expect(pref.channels.email).toBe(false);
+  });
+
   test("preference actions accept sms channel preferences", async () => {
     const { notifykit } = buildKit();
     await notifykit.upsertRecipient({ id: "user-1", email: "u@x.com" });
@@ -149,6 +171,25 @@ describe("createServerActions", () => {
 
     await actions.inbox.unreadCount();
     expect(identifyCalls).toBe(4);
+  });
+
+  test("identity rejects whitespace-only recipient and scope ids", async () => {
+    const { notifykit } = buildKit();
+    const cases = [
+      () => " ",
+      () => ({} as never),
+      () => ({ recipientId: 123 } as never),
+      () => ({ recipientId: "\t" }),
+      () => ({ recipientId: "user-1", tenantId: "" }),
+      () => ({ recipientId: "user-1", tenantId: " " }),
+      () => ({ recipientId: "user-1", organizationId: " " }),
+      () => ({ recipientId: "user-1", workspaceId: "\t" }),
+    ];
+
+    for (const identify of cases) {
+      const actions = createServerActions({ notifykit, identify });
+      await expect(actions.getPreferences()).rejects.toThrow(/empty/);
+    }
   });
 
   test("inbox operations use identity binding", async () => {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,9 @@
   },
   "homepage": "https://github.com/reyabsaluja/notifykit",
   "bugs": "https://github.com/reyabsaluja/notifykit/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -110,6 +110,52 @@ export type NotifyKitClient = {
   };
 };
 
+function cloneOptionalDate<T extends Date | null | undefined>(value: T): T {
+  return (value instanceof Date ? new Date(value.getTime()) : value) as T;
+}
+
+function cloneInboxItem(item: InboxItem): InboxItem {
+  return {
+    ...item,
+    readAt: cloneOptionalDate(item.readAt),
+    archivedAt: cloneOptionalDate(item.archivedAt),
+    createdAt: new Date(item.createdAt.getTime()),
+  };
+}
+
+function clonePreference(preference: RecipientPreference): RecipientPreference {
+  return {
+    ...preference,
+    channels: { ...preference.channels },
+    updatedAt: new Date(preference.updatedAt.getTime()),
+  };
+}
+
+function cloneState(state: ClientState): ClientState {
+  return {
+    inbox: {
+      ...state.inbox,
+      items: state.inbox.items.map(cloneInboxItem),
+    },
+    preferences: {
+      ...state.preferences,
+      items: state.preferences.items.map(clonePreference),
+    },
+  };
+}
+
+function cloneMetadata(item: NotificationMetadata): NotificationMetadata {
+  const cloned: NotificationMetadata = {
+    ...item,
+    channels: item.channels.slice(),
+    payload: { ...item.payload },
+  };
+  if (item.defaultChannels !== undefined) {
+    cloned.defaultChannels = { ...item.defaultChannels };
+  }
+  return cloned;
+}
+
 export function createNotifyKitClient(
   options: CreateNotifyKitClientOptions = {},
 ): NotifyKitClient {
@@ -133,7 +179,13 @@ export function createNotifyKitClient(
 
   function setState(next: ClientState) {
     state = next;
-    for (const l of listeners) l();
+    for (const l of listeners) {
+      try {
+        l();
+      } catch (err) {
+        console.error("[notifykit] client listener error:", err);
+      }
+    }
   }
 
   let sseAbort: AbortController | null = null;
@@ -250,10 +302,7 @@ export function createNotifyKitClient(
           const fetched = reviveInbox(raw);
           const fetchedIds = new Set(fetched.map((it) => it.id));
           const current = state.inbox.items;
-          const now = Date.now();
-          const extras = current.filter(
-            (it) => !fetchedIds.has(it.id) && now - it.createdAt.getTime() < 10_000,
-          );
+          const extras = recentUnfetchedExtras(current, fetchedIds, false);
           const items = [...extras, ...fetched];
           const unreadCount = items.filter(isActiveUnread).length;
           setState({
@@ -280,7 +329,7 @@ export function createNotifyKitClient(
     for (const l of listeners) l();
   }
 
-  async function readSSEStream(signal: AbortSignal) {
+  async function readSSEStream(signal: AbortSignal, onOpen?: () => void) {
     const url = `${baseUrl}/inbox/stream`;
     const sseHeaders: Record<string, string> = {
       accept: "text/event-stream",
@@ -301,12 +350,13 @@ export function createNotifyKitClient(
       throw err;
     }
     setRtStatus("connected");
+    onOpen?.();
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
     function processSSEPart(part: string) {
       const dataLines: string[] = [];
-      for (const line of part.split("\n")) {
+      for (const line of part.split(/\r\n|\n|\r/)) {
         if (line.startsWith("data: ")) {
           dataLines.push(line.slice(6));
         } else if (line === "data:") {
@@ -326,7 +376,7 @@ export function createNotifyKitClient(
         break;
       }
       buffer += decoder.decode(value, { stream: true });
-      const parts = buffer.split("\n\n");
+      const parts = buffer.split(/\r\n\r\n|\n\n|\r\r/);
       buffer = parts.pop()!;
       for (const part of parts) {
         processSSEPart(part);
@@ -353,8 +403,9 @@ export function createNotifyKitClient(
         }
         const connStart = Date.now();
         try {
-          await readSSEStream(controller.signal);
-          hasConnectedBefore = true;
+          await readSSEStream(controller.signal, () => {
+            hasConnectedBefore = true;
+          });
           const streamDuration = Date.now() - connStart;
           if (streamDuration > 5000) {
             retries = 0;
@@ -446,6 +497,20 @@ export function createNotifyKitClient(
     return !item.readAt && !item.archivedAt;
   }
 
+  function recentUnfetchedExtras(
+    current: InboxItem[],
+    fetchedIds: Set<string>,
+    archived: boolean,
+  ): InboxItem[] {
+    const now = Date.now();
+    return current.filter(
+      (it) =>
+        !fetchedIds.has(it.id) &&
+        now - it.createdAt.getTime() < 10_000 &&
+        (it.archivedAt != null) === archived,
+    );
+  }
+
   function reviveInbox(raw: unknown): InboxItem[] {
     if (!Array.isArray(raw)) return [];
     return raw.filter((item) => item && typeof item === "object" && typeof (item as Record<string, unknown>).id === "string").map(reviveInboxItem);
@@ -516,7 +581,7 @@ export function createNotifyKitClient(
 
   return {
     getState() {
-      return state;
+      return cloneState(state);
     },
 
     subscribe(listener) {
@@ -541,10 +606,8 @@ export function createNotifyKitClient(
           const fetched = reviveInbox(await request("GET", `/inbox${qs}`));
           const fetchedIds = new Set(fetched.map((it) => it.id));
           const current = state.inbox.items;
-          const now = Date.now();
-          const extras = current.filter(
-            (it) => !fetchedIds.has(it.id) && now - it.createdAt.getTime() < 10_000,
-          );
+          const archived = options?.archived === true;
+          const extras = recentUnfetchedExtras(current, fetchedIds, archived);
           const items = [...extras, ...fetched];
           const unreadCount = options?.archived
             ? state.inbox.unreadCount
@@ -553,7 +616,7 @@ export function createNotifyKitClient(
             ...state,
             inbox: { items, unreadCount, status: "ready", error: null },
           });
-          return items;
+          return items.map(cloneInboxItem);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           setState({
@@ -598,7 +661,7 @@ export function createNotifyKitClient(
               },
             });
           }
-          return updated;
+          return updated ? cloneInboxItem(updated) : null;
         } catch (err) {
           const originalReadAt = prevItems.find((it) => it.id === inboxItemId)?.readAt ?? null;
           setState({
@@ -690,7 +753,8 @@ export function createNotifyKitClient(
             "POST",
             `/inbox/${encodeURIComponent(inboxItemId)}/archive`,
           );
-          return raw ? reviveInboxItem(raw) : null;
+          const updated = raw ? reviveInboxItem(raw) : null;
+          return updated ? cloneInboxItem(updated) : null;
         } catch (err) {
           if (target && !alreadyArchived) {
             const current = state.inbox.items;
@@ -733,7 +797,8 @@ export function createNotifyKitClient(
             "POST",
             `/inbox/${encodeURIComponent(inboxItemId)}/unarchive`,
           );
-          return raw ? reviveInboxItem(raw) : null;
+          const updated = raw ? reviveInboxItem(raw) : null;
+          return updated ? cloneInboxItem(updated) : null;
         } catch (err) {
           if (target && !alreadyUnarchived) {
             const current = state.inbox.items;
@@ -801,7 +866,7 @@ export function createNotifyKitClient(
             ...state,
             preferences: { items, status: "ready", error: null },
           });
-          return items;
+          return items.map(clonePreference);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           setState({
@@ -854,7 +919,7 @@ export function createNotifyKitClient(
               error: null,
             },
           });
-          return updated;
+          return clonePreference(updated);
         } catch (err) {
           setState({
             ...state,
@@ -878,12 +943,13 @@ export function createNotifyKitClient(
 
       async getGlobal(): Promise<RecipientPreference | null> {
         const raw = await request("GET", "/preferences/global");
-        return raw ? revivePreference(raw) : null;
+        const preference = raw ? revivePreference(raw) : null;
+        return preference ? clonePreference(preference) : null;
       },
 
       async updateGlobal(input): Promise<RecipientPreference> {
         const raw = await request("POST", "/preferences/global", input);
-        return revivePreference(raw);
+        return clonePreference(revivePreference(raw));
       },
 
       async getCategory(category): Promise<RecipientPreference | null> {
@@ -891,16 +957,18 @@ export function createNotifyKitClient(
           "GET",
           `/preferences/category?category=${encodeURIComponent(category)}`,
         );
-        return raw ? revivePreference(raw) : null;
+        const preference = raw ? revivePreference(raw) : null;
+        return preference ? clonePreference(preference) : null;
       },
 
       async listCategories(): Promise<RecipientPreference[]> {
-        return revivePreferences(await request("GET", "/preferences/categories"));
+        return revivePreferences(await request("GET", "/preferences/categories"))
+          .map(clonePreference);
       },
 
       async updateCategory(input): Promise<RecipientPreference> {
         const raw = await request("POST", "/preferences/category", input);
-        return revivePreference(raw);
+        return clonePreference(revivePreference(raw));
       },
     },
 
@@ -914,7 +982,7 @@ export function createNotifyKitClient(
             typeof item === "object" &&
             typeof (item as Record<string, unknown>).id === "string" &&
             Array.isArray((item as Record<string, unknown>).channels),
-        );
+        ).map(cloneMetadata);
       },
     },
   };

--- a/packages/react/tests/client.test.ts
+++ b/packages/react/tests/client.test.ts
@@ -56,6 +56,68 @@ describe("createNotifyKitClient", () => {
     expect(state.inbox.items).toHaveLength(1);
   });
 
+  test("public state and inbox results are defensive copies", async () => {
+    const client = createNotifyKitClient({
+      fetch: mockFetch({
+        "GET /inbox": {
+          data: [
+            {
+              id: "inb_1",
+              notificationRecordId: "ntf_1",
+              recipientId: "u1",
+              notificationId: "comment",
+              title: "Original",
+              readAt: null,
+              createdAt: "2026-04-30T12:00:00.000Z",
+            },
+          ],
+        },
+      }),
+    });
+
+    const items = await client.inbox.list();
+    items[0]!.title = "mutated return";
+    items[0]!.createdAt.setFullYear(2000);
+
+    const snapshot = client.getState();
+    snapshot.inbox.items[0]!.title = "mutated snapshot";
+    snapshot.inbox.items[0]!.createdAt.setFullYear(2001);
+
+    const next = client.getState();
+    expect(next.inbox.items[0]!.title).toBe("Original");
+    expect(next.inbox.items[0]!.createdAt.getFullYear()).toBe(2026);
+  });
+
+  test("active inbox refresh does not retain recent archived items", async () => {
+    const archivedCreatedAt = new Date().toISOString();
+    const client = createNotifyKitClient({
+      fetch: mockFetch({
+        "GET /inbox?archived=true": {
+          data: [
+            {
+              id: "inb_archived",
+              notificationRecordId: "ntf_1",
+              recipientId: "u1",
+              notificationId: "comment",
+              title: "Archived",
+              readAt: null,
+              archivedAt: new Date().toISOString(),
+              createdAt: archivedCreatedAt,
+            },
+          ],
+        },
+        "GET /inbox": { data: [] },
+      }),
+    });
+
+    await client.inbox.list({ archived: true });
+    expect(client.getState().inbox.items).toHaveLength(1);
+
+    const active = await client.inbox.list();
+    expect(active).toEqual([]);
+    expect(client.getState().inbox.items).toEqual([]);
+  });
+
   test("inbox.list sets error state on failure", async () => {
     const client = createNotifyKitClient({
       fetch: (async () =>
@@ -160,6 +222,35 @@ describe("createNotifyKitClient", () => {
     expect(prefs[0]!.channels).toEqual({ inbox: true, email: false });
     expect(prefs[0]!.updatedAt).toBeInstanceOf(Date);
     expect(client.getState().preferences.status).toBe("ready");
+  });
+
+  test("public state and preference results are defensive copies", async () => {
+    const client = createNotifyKitClient({
+      fetch: mockFetch({
+        "GET /preferences": {
+          data: [
+            {
+              recipientId: "u1",
+              notificationId: "comment",
+              channels: { inbox: true, email: false },
+              updatedAt: "2026-04-30T12:00:00.000Z",
+            },
+          ],
+        },
+      }),
+    });
+
+    const prefs = await client.preferences.list();
+    prefs[0]!.channels.email = true;
+    prefs[0]!.updatedAt.setFullYear(2000);
+
+    const snapshot = client.getState();
+    snapshot.preferences.items[0]!.channels.email = true;
+    snapshot.preferences.items[0]!.updatedAt.setFullYear(2001);
+
+    const next = client.getState();
+    expect(next.preferences.items[0]!.channels.email).toBe(false);
+    expect(next.preferences.items[0]!.updatedAt.getFullYear()).toBe(2026);
   });
 
   test("preferences.update applies optimistic state then confirms", async () => {
@@ -271,6 +362,34 @@ describe("createNotifyKitClient", () => {
     const before = callCount;
     await client.inbox.list();
     expect(callCount).toBe(before);
+  });
+
+  test("throwing subscribers do not block later listeners", async () => {
+    let callCount = 0;
+    const errors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args);
+    };
+    try {
+      const client = createNotifyKitClient({
+        fetch: mockFetch({
+          "GET /inbox": { data: [] },
+        }),
+      });
+
+      client.subscribe(() => {
+        throw new Error("listener failed");
+      });
+      client.subscribe(() => callCount++);
+
+      await client.inbox.list();
+
+      expect(callCount).toBeGreaterThanOrEqual(2);
+      expect(errors.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      console.error = originalError;
+    }
   });
 
   test("custom headers and baseUrl are used", async () => {

--- a/packages/react/tests/realtime.test.ts
+++ b/packages/react/tests/realtime.test.ts
@@ -45,10 +45,16 @@ function makeItem(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function sseResponse(events: Array<{ type: string; [k: string]: unknown }>) {
+function sseResponse(
+  events: Array<{ type: string; [k: string]: unknown }>,
+  lineEnding = "\n",
+) {
   const encoder = new TextEncoder();
   const chunks = events.map(
-    (e) => encoder.encode(`data: ${JSON.stringify(e)}\n\n`),
+    (e) =>
+      encoder.encode(
+        `data: ${JSON.stringify(e)}${lineEnding}${lineEnding}`,
+      ),
   );
   let i = 0;
   const body = new ReadableStream<Uint8Array>({
@@ -138,6 +144,43 @@ describe("SSE event ingestion", () => {
     await waitForState(client, () => client.getState().inbox.items.length === 1);
     expect(client.getState().inbox.items[0].id).toBe("inb_new");
     expect(client.getState().inbox.unreadCount).toBe(1);
+
+    client.disconnect();
+  });
+
+  test("SSE parser accepts CRLF-framed events", async () => {
+    const newItem = makeItem({ id: "inb_crlf" });
+    const client = createNotifyKitClient({
+      fetch: (async (input: string | URL | Request) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        const parsed = new URL(url, "http://localhost");
+        const path = parsed.pathname.replace(/^\/api\/notifykit/, "");
+
+        if (path === "/inbox/stream") {
+          return sseResponse(
+            [{ type: "inbox.created", item: newItem }],
+            "\r\n",
+          );
+        }
+
+        return new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof fetch,
+      realtime: true,
+    });
+
+    await client.inbox.list();
+    client.connect();
+
+    await waitForState(client, () => client.getState().inbox.items.length === 1);
+    expect(client.getState().inbox.items[0].id).toBe("inb_crlf");
 
     client.disconnect();
   });
@@ -502,6 +545,70 @@ describe("SSE reconnection", () => {
     client.disconnect();
   });
 
+  test("refetches after an accepted stream errors mid-read", async () => {
+    let streamAttempts = 0;
+    let inboxFetches = 0;
+    const missedItem = makeItem({ id: "inb_missed" });
+
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const method = init?.method ?? "GET";
+      const parsed = new URL(url, "http://localhost");
+      const path = parsed.pathname.replace(/^\/api\/notifykit/, "");
+
+      if (path === "/inbox/stream") {
+        streamAttempts++;
+        if (streamAttempts === 1) {
+          const body = new ReadableStream<Uint8Array>({
+            pull(controller) {
+              controller.error(new Error("stream interrupted"));
+            },
+          });
+          return new Response(body, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        return sseResponse([]);
+      }
+
+      if (`${method} ${path}` === "GET /inbox") {
+        inboxFetches++;
+        return new Response(JSON.stringify({
+          data: inboxFetches === 1 ? [] : [missedItem],
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      return new Response(JSON.stringify({ error: "Not found" }), { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const client = createNotifyKitClient({
+      fetch: fetchImpl,
+      realtime: true,
+      onRealtimeError: () => {},
+    });
+
+    await client.inbox.list();
+    client.connect();
+
+    await waitForState(
+      client,
+      () => client.getState().inbox.items.some((item) => item.id === "inb_missed"),
+      5000,
+    );
+    expect(streamAttempts).toBeGreaterThanOrEqual(2);
+
+    client.disconnect();
+  });
+
   test("tracks Last-Event-ID from server", async () => {
     let capturedHeaders: Record<string, string> = {};
     let attempt = 0;
@@ -621,10 +728,11 @@ describe("SSE reconnection", () => {
 
     await waitForState(
       client,
-      () => streamAttempts >= 2 && activeInboxFetches >= 1,
+      () => streamAttempts >= 2 && activeInboxFetches >= 1 && client.getState().inbox.items.length === 0,
       5000,
     );
     expect(client.getState().inbox.unreadCount).toBe(0);
+    expect(client.getState().inbox.items).toEqual([]);
 
     client.disconnect();
   });

--- a/packages/realtime-pg/src/index.ts
+++ b/packages/realtime-pg/src/index.ts
@@ -25,10 +25,39 @@ export type PgRealtimeAdapterOptions = {
 
 function scopeKey(recipientId: string, scope: SecurityScope): string {
   const s = normalizeScope(scope);
-  const r = recipientId.replace(/\0/g, "");
-  const t = (s.tenantId ?? "").replace(/\0/g, "");
-  const w = (s.workspaceId ?? "").replace(/\0/g, "");
-  return `${r}\0${t}\0${w}`;
+  return JSON.stringify([recipientId, s.tenantId ?? "", s.workspaceId ?? ""]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRealtimeEvent(value: unknown): value is RealtimeEvent {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  switch (value.type) {
+    case "inbox.created":
+    case "inbox.updated":
+    case "inbox.archived":
+    case "inbox.unarchived":
+      return isRecord(value.item) && typeof value.item.id === "string";
+    case "inbox.deleted":
+      return typeof value.itemId === "string";
+    case "inbox.all_read":
+      return (
+        typeof value.count === "number" &&
+        Number.isSafeInteger(value.count) &&
+        value.count >= 0
+      );
+    case "inbox.refetch":
+      return (
+        value.dropped === undefined ||
+        (typeof value.dropped === "number" &&
+          Number.isSafeInteger(value.dropped) &&
+          value.dropped >= 0)
+      );
+    default:
+      return false;
+  }
 }
 
 export type PgRealtimeAdapter = RealtimeAdapter & {
@@ -43,6 +72,12 @@ export function pgRealtimeAdapter(
   const pgChannel = options.channel ?? DEFAULT_CHANNEL;
   const reconnectMs = options.reconnectMs ?? 5_000;
   const heartbeatMs = options.heartbeatMs ?? 60_000;
+  if (!Number.isFinite(reconnectMs) || reconnectMs <= 0) {
+    throw new Error("pgRealtimeAdapter: reconnectMs must be a positive number.");
+  }
+  if (!Number.isFinite(heartbeatMs) || heartbeatMs < 0) {
+    throw new Error("pgRealtimeAdapter: heartbeatMs must be a non-negative number.");
+  }
   const subs = new Map<string, Set<RealtimeListener>>();
   let listening = false;
   let stopped = false;
@@ -57,18 +92,24 @@ export function pgRealtimeAdapter(
       lastHeartbeatAt = Date.now();
       return;
     }
-    let parsed: {
-      key: string;
-      event: RealtimeEvent;
-    };
+    let parsed: unknown;
     try {
       parsed = JSON.parse(raw);
     } catch {
       return;
     }
+    if (!isRecord(parsed)) return;
+    if (typeof parsed.key !== "string") return;
+    if (!isRealtimeEvent(parsed.event)) return;
     const set = subs.get(parsed.key);
     if (!set) return;
-    for (const fn of set) fn(parsed.event);
+    for (const fn of [...set]) {
+      try {
+        fn(parsed.event);
+      } catch (err) {
+        options.onError?.(err);
+      }
+    }
   }
 
   function startHeartbeat() {
@@ -105,6 +146,10 @@ export function pgRealtimeAdapter(
     try {
       await conn.listen(pgChannel, handleNotification);
       listening = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
       startHeartbeat();
     } catch (err) {
       listening = false;

--- a/packages/realtime-pg/tests/pg-adapter.test.ts
+++ b/packages/realtime-pg/tests/pg-adapter.test.ts
@@ -33,6 +33,22 @@ function fakePgConnection(): PgNotifyConnection & {
 }
 
 describe("pgRealtimeAdapter", () => {
+  test("rejects invalid options", () => {
+    const conn = fakePgConnection();
+    expect(() =>
+      pgRealtimeAdapter({ connection: conn, reconnectMs: 0 }),
+    ).toThrow(/reconnectMs/);
+    expect(() =>
+      pgRealtimeAdapter({ connection: conn, reconnectMs: Number.NaN }),
+    ).toThrow(/reconnectMs/);
+    expect(() =>
+      pgRealtimeAdapter({ connection: conn, heartbeatMs: -1 }),
+    ).toThrow(/heartbeatMs/);
+    expect(() =>
+      pgRealtimeAdapter({ connection: conn, heartbeatMs: Number.NaN }),
+    ).toThrow(/heartbeatMs/);
+  });
+
   test("start() listens on the configured channel", async () => {
     const conn = fakePgConnection();
     const adapter = pgRealtimeAdapter({ connection: conn });
@@ -66,6 +82,31 @@ describe("pgRealtimeAdapter", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(events).toHaveLength(0);
+  });
+
+  test("successful manual start clears pending reconnect", async () => {
+    const conn = fakePgConnection();
+    let listenCalls = 0;
+    const originalListen = conn.listen.bind(conn);
+    conn.listen = (channel, handler) => {
+      listenCalls++;
+      if (listenCalls === 1) throw new Error("connection down");
+      return originalListen(channel, handler);
+    };
+    const adapter = pgRealtimeAdapter({
+      connection: conn,
+      reconnectMs: 20,
+      heartbeatMs: 0,
+      onError: () => {},
+    });
+
+    await adapter.start();
+    expect(listenCalls).toBe(1);
+    await adapter.start();
+    expect(listenCalls).toBe(2);
+
+    await new Promise((r) => setTimeout(r, 40));
+    expect(listenCalls).toBe(2);
   });
 
   test("custom channel name", async () => {
@@ -113,7 +154,7 @@ describe("pgRealtimeAdapter", () => {
 
     // Simulate a NOTIFY from another process
     const foreignPayload = JSON.stringify({
-      key: "user_1\0\0",
+      key: JSON.stringify(["user_1", "", ""]),
       event: { type: "inbox.deleted", itemId: "inb_99" },
     });
     const handler = conn.handlers.get("notifykit_realtime")!;
@@ -122,6 +163,27 @@ describe("pgRealtimeAdapter", () => {
     expect(events).toHaveLength(1);
     expect(events[0]!.type).toBe("inbox.deleted");
     expect(events[0]!.itemId).toBe("inb_99");
+  });
+
+  test("recipient ids containing delimiters do not collide", async () => {
+    const conn = fakePgConnection();
+    const adapter = pgRealtimeAdapter({ connection: conn });
+    await adapter.start();
+
+    const plain: any[] = [];
+    const nulSeparated: any[] = [];
+    adapter.subscribe("ab", {}, (e) => plain.push(e));
+    adapter.subscribe("a\0b", {}, (e) => nulSeparated.push(e));
+
+    adapter.publish("a\0b", {}, {
+      type: "inbox.deleted",
+      itemId: "inb_x",
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(plain).toHaveLength(0);
+    expect(nulSeparated).toHaveLength(1);
   });
 
   test("scope isolation between tenants", async () => {
@@ -186,6 +248,31 @@ describe("pgRealtimeAdapter", () => {
     expect(events).toHaveLength(1);
   });
 
+  test("throwing subscriber does not block other subscribers", async () => {
+    const conn = fakePgConnection();
+    const errors: unknown[] = [];
+    const adapter = pgRealtimeAdapter({
+      connection: conn,
+      onError: (err) => errors.push(err),
+    });
+    await adapter.start();
+
+    const events: any[] = [];
+    adapter.subscribe("user_1", {}, () => {
+      throw new Error("listener failed");
+    });
+    adapter.subscribe("user_1", {}, (event) => events.push(event));
+
+    adapter.publish("user_1", {}, {
+      type: "inbox.deleted",
+      itemId: "inb_1",
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(events).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+  });
+
   test("malformed NOTIFY payloads are ignored", async () => {
     const conn = fakePgConnection();
     const adapter = pgRealtimeAdapter({ connection: conn });
@@ -197,7 +284,12 @@ describe("pgRealtimeAdapter", () => {
     const handler = conn.handlers.get("notifykit_realtime")!;
     handler("not json");
     handler("{}");
-    handler(JSON.stringify({ key: "wrong_user::", event: { type: "inbox.created" } }));
+    handler(JSON.stringify({ key: JSON.stringify(["user_1", "", ""]), event: null }));
+    handler(JSON.stringify({ key: JSON.stringify(["user_1", "", ""]), event: { type: "bogus" } }));
+    handler(JSON.stringify({ key: JSON.stringify(["user_1", "", ""]), event: { type: "inbox.created" } }));
+    handler(JSON.stringify({ key: JSON.stringify(["user_1", "", ""]), event: { type: "inbox.all_read", count: -1 } }));
+    handler(JSON.stringify({ key: JSON.stringify(["user_1", "", ""]), event: { type: "inbox.refetch", dropped: 1.5 } }));
+    handler(JSON.stringify({ key: "wrong_user::", event: { type: "inbox.deleted", itemId: "inb_1" } }));
 
     expect(events).toHaveLength(0);
   });

--- a/packages/realtime-ws/src/index.ts
+++ b/packages/realtime-ws/src/index.ts
@@ -49,10 +49,7 @@ type WsConnection = {
 
 function scopeKey(recipientId: string, scope: SecurityScope): string {
   const s = normalizeScope(scope);
-  const r = recipientId.replace(/\0/g, "");
-  const t = (s.tenantId ?? "").replace(/\0/g, "");
-  const w = (s.workspaceId ?? "").replace(/\0/g, "");
-  return `${r}\0${t}\0${w}`;
+  return JSON.stringify([recipientId, s.tenantId ?? "", s.workspaceId ?? ""]);
 }
 
 export type WebSocketRealtimeAdapter = RealtimeAdapter & {
@@ -76,6 +73,12 @@ export function webSocketRealtimeAdapter(
 ): WebSocketRealtimeAdapter {
   const heartbeatMs = options.heartbeatMs ?? 30_000;
   const maxConnections = options.maxConnections ?? 10_000;
+  if (!Number.isFinite(heartbeatMs) || heartbeatMs < 0) {
+    throw new Error("webSocketRealtimeAdapter: heartbeatMs must be a non-negative number.");
+  }
+  if (!Number.isSafeInteger(maxConnections) || maxConnections <= 0) {
+    throw new Error("webSocketRealtimeAdapter: maxConnections must be a positive integer.");
+  }
   const subs = new Map<string, Set<RealtimeListener>>();
   const connections = new Map<WebSocketLike, WsConnection>();
   const heartbeats = new Map<WebSocketLike, ReturnType<typeof setInterval>>();
@@ -98,7 +101,13 @@ export function webSocketRealtimeAdapter(
     const k = scopeKey(recipientId, scope);
     const set = subs.get(k);
     if (!set) return;
-    for (const fn of set) fn(event);
+    for (const fn of [...set]) {
+      try {
+        fn(event);
+      } catch {
+        // Keep fan-out resilient if a manually subscribed listener throws.
+      }
+    }
   }
 
   function subscribe(
@@ -128,6 +137,11 @@ export function webSocketRealtimeAdapter(
     }
     const identity = await options.authenticate(request);
     if (!identity) return null;
+    if (typeof identity !== "object" || Array.isArray(identity)) return null;
+    if (!isValidIdentityId(identity.recipientId)) return null;
+    if (!isValidOptionalIdentityId(identity.tenantId)) return null;
+    if (!isValidOptionalIdentityId(identity.organizationId)) return null;
+    if (!isValidOptionalIdentityId(identity.workspaceId)) return null;
 
     const scope = normalizeScope(identity);
     const k = scopeKey(identity.recipientId, scope);
@@ -136,7 +150,7 @@ export function webSocketRealtimeAdapter(
       try {
         ws.send(JSON.stringify(event));
       } catch {
-        // socket may have closed
+        handleClose(ws);
       }
     };
 
@@ -224,4 +238,14 @@ function normalizeOrigin(origin: string): string {
   } catch {
     return origin.toLowerCase().replace(/\/+$/, "");
   }
+}
+
+const MAX_ID_LENGTH = 512;
+
+function isValidIdentityId(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "" && value.length <= MAX_ID_LENGTH;
+}
+
+function isValidOptionalIdentityId(value: unknown): value is string | undefined {
+  return value === undefined || isValidIdentityId(value);
 }

--- a/packages/realtime-ws/tests/ws-adapter.test.ts
+++ b/packages/realtime-ws/tests/ws-adapter.test.ts
@@ -25,7 +25,28 @@ function fakeRequest(recipientId: string, tenantId?: string): Request {
   return new Request(url);
 }
 
+function fakeRequestWithOrigin(recipientId: string, origin: string): Request {
+  const url = new URL("http://localhost/ws");
+  url.searchParams.set("recipientId", recipientId);
+  return new Request(url, { headers: { origin } });
+}
+
 describe("webSocketRealtimeAdapter", () => {
+  test("rejects invalid options", () => {
+    expect(() =>
+      webSocketRealtimeAdapter({ authenticate: () => null, heartbeatMs: Number.NaN }),
+    ).toThrow(/heartbeatMs/);
+    expect(() =>
+      webSocketRealtimeAdapter({ authenticate: () => null, heartbeatMs: -1 }),
+    ).toThrow(/heartbeatMs/);
+    expect(() =>
+      webSocketRealtimeAdapter({ authenticate: () => null, maxConnections: 0 }),
+    ).toThrow(/maxConnections/);
+    expect(() =>
+      webSocketRealtimeAdapter({ authenticate: () => null, maxConnections: 1.5 }),
+    ).toThrow(/maxConnections/);
+  });
+
   test("publish delivers to subscribed WebSocket", async () => {
     const adapter = webSocketRealtimeAdapter({
       authenticate: (req) => {
@@ -64,6 +85,30 @@ describe("webSocketRealtimeAdapter", () => {
     expect(adapter.connectionCount()).toBe(0);
   });
 
+  test("invalid authenticated identity returns null", async () => {
+    const cases = [
+      {},
+      [],
+      { recipientId: 123 },
+      { recipientId: "" },
+      { recipientId: "   " },
+      { recipientId: "user_1", tenantId: "" },
+      { recipientId: "user_1", tenantId: " " },
+      { recipientId: "user_1", organizationId: "\t" },
+      { recipientId: "user_1", workspaceId: " " },
+    ];
+
+    for (const identity of cases) {
+      const adapter = webSocketRealtimeAdapter({
+        authenticate: () => identity,
+        heartbeatMs: 0,
+      });
+      const result = await adapter.handleUpgrade(fakeRequest("user_1"), fakeWs());
+      expect(result).toBeNull();
+      expect(adapter.connectionCount()).toBe(0);
+    }
+  });
+
   test("handleClose cleans up subscription", async () => {
     const adapter = webSocketRealtimeAdapter({
       authenticate: (req) => {
@@ -85,6 +130,81 @@ describe("webSocketRealtimeAdapter", () => {
       item: { id: "inb_2" } as any,
     });
     expect(ws.messages).toHaveLength(0);
+  });
+
+  test("send failure during publish cleans up connection", async () => {
+    const adapter = webSocketRealtimeAdapter({
+      authenticate: (req) => {
+        const url = new URL(req.url);
+        return { recipientId: url.searchParams.get("recipientId")! };
+      },
+      heartbeatMs: 0,
+    });
+
+    const ws = fakeWs();
+    ws.send = () => {
+      throw new Error("socket is closed");
+    };
+
+    await adapter.handleUpgrade(fakeRequest("user_1"), ws);
+    expect(adapter.connectionCount()).toBe(1);
+
+    adapter.publish("user_1", {}, {
+      type: "inbox.deleted",
+      itemId: "inb_x",
+    });
+
+    expect(adapter.connectionCount()).toBe(0);
+  });
+
+  test("allowedOrigins rejects missing and mismatched origins", async () => {
+    const adapter = webSocketRealtimeAdapter({
+      allowedOrigins: ["https://app.example.com"],
+      authenticate: (req) => {
+        const url = new URL(req.url);
+        return { recipientId: url.searchParams.get("recipientId")! };
+      },
+      heartbeatMs: 0,
+    });
+
+    expect(await adapter.handleUpgrade(fakeRequest("user_1"), fakeWs())).toBeNull();
+    expect(
+      await adapter.handleUpgrade(
+        fakeRequestWithOrigin("user_1", "https://evil.example.com"),
+        fakeWs(),
+      ),
+    ).toBeNull();
+
+    const ws = fakeWs();
+    const result = await adapter.handleUpgrade(
+      fakeRequestWithOrigin("user_1", "https://app.example.com/settings"),
+      ws,
+    );
+
+    expect(result).not.toBeNull();
+    expect(adapter.connectionCount()).toBe(1);
+  });
+
+  test("maxConnections rejects new sockets at the limit", async () => {
+    const adapter = webSocketRealtimeAdapter({
+      authenticate: (req) => {
+        const url = new URL(req.url);
+        return { recipientId: url.searchParams.get("recipientId")! };
+      },
+      heartbeatMs: 0,
+      maxConnections: 1,
+    });
+
+    const ws1 = fakeWs();
+    const ws2 = fakeWs();
+
+    expect(await adapter.handleUpgrade(fakeRequest("user_1"), ws1)).not.toBeNull();
+    expect(await adapter.handleUpgrade(fakeRequest("user_2"), ws2)).toBeNull();
+    expect(adapter.connectionCount()).toBe(1);
+
+    adapter.handleClose(ws1);
+    expect(await adapter.handleUpgrade(fakeRequest("user_2"), ws2)).not.toBeNull();
+    expect(adapter.connectionCount()).toBe(1);
   });
 
   test("scope isolation: tenant A does not see tenant B events", async () => {
@@ -113,6 +233,29 @@ describe("webSocketRealtimeAdapter", () => {
     expect(wsB.messages).toHaveLength(0);
   });
 
+  test("recipient ids containing delimiters do not collide", async () => {
+    const adapter = webSocketRealtimeAdapter({
+      authenticate: (req) => {
+        const url = new URL(req.url);
+        return { recipientId: url.searchParams.get("recipientId")! };
+      },
+      heartbeatMs: 0,
+    });
+
+    const plain = fakeWs();
+    const nulSeparated = fakeWs();
+    await adapter.handleUpgrade(fakeRequest("ab"), plain);
+    await adapter.handleUpgrade(fakeRequest("a\0b"), nulSeparated);
+
+    adapter.publish("a\0b", {}, {
+      type: "inbox.deleted",
+      itemId: "inb_x",
+    });
+
+    expect(plain.messages).toHaveLength(0);
+    expect(nulSeparated.messages).toHaveLength(1);
+  });
+
   test("multiple connections for same recipient all receive events", async () => {
     const adapter = webSocketRealtimeAdapter({
       authenticate: (req) => {
@@ -134,6 +277,30 @@ describe("webSocketRealtimeAdapter", () => {
 
     expect(ws1.messages).toHaveLength(1);
     expect(ws2.messages).toHaveLength(1);
+  });
+
+  test("throwing subscriber does not block WebSocket delivery", async () => {
+    const adapter = webSocketRealtimeAdapter({
+      authenticate: (req) => {
+        const url = new URL(req.url);
+        return { recipientId: url.searchParams.get("recipientId")! };
+      },
+      heartbeatMs: 0,
+    });
+
+    const ws = fakeWs();
+    adapter.subscribe("user_1", {}, () => {
+      throw new Error("listener failed");
+    });
+    await adapter.handleUpgrade(fakeRequest("user_1"), ws);
+
+    expect(() => {
+      adapter.publish("user_1", {}, {
+        type: "inbox.deleted",
+        itemId: "inb_x",
+      });
+    }).not.toThrow();
+    expect(ws.messages).toHaveLength(1);
   });
 
   test("subscribe() works independently of WebSocket connections", () => {

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -14,6 +14,9 @@
   },
   "homepage": "https://github.com/reyabsaluja/notifykit",
   "bugs": "https://github.com/reyabsaluja/notifykit/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/resend/src/index.ts
+++ b/packages/resend/src/index.ts
@@ -42,6 +42,9 @@ export function resendProvider(options: ResendProviderOptions): EmailProvider {
     "",
   );
   const timeoutMs = options.timeoutMs ?? 10_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("resendProvider: `timeoutMs` must be a positive number.");
+  }
   const fetchImpl = options.fetch ?? globalThis.fetch;
   if (!fetchImpl) {
     throw new Error(

--- a/packages/resend/tests/resend.test.ts
+++ b/packages/resend/tests/resend.test.ts
@@ -35,6 +35,12 @@ describe("resendProvider", () => {
     expect(() =>
       resendProvider({ apiKey: "k", from: "" } as never),
     ).toThrow(/from/);
+    expect(() =>
+      resendProvider({ apiKey: "k", from: "a@b.c", timeoutMs: 0 }),
+    ).toThrow(/timeoutMs/);
+    expect(() =>
+      resendProvider({ apiKey: "k", from: "a@b.c", timeoutMs: Number.NaN }),
+    ).toThrow(/timeoutMs/);
   });
 
   test("POSTs to /emails with correct shape and auth header", async () => {
@@ -216,5 +222,42 @@ describe("resendProvider", () => {
     const items = await notify.inbox.list("u1");
     expect(items).toHaveLength(1);
     expect(items[0]!.title).toBe("Fallback for /r/1");
+  });
+
+  test("permanent API failures do not retry", async () => {
+    let attempts = 0;
+    const { fetch } = makeFakeFetch(() => {
+      attempts++;
+      return new Response(
+        JSON.stringify({ message: "Invalid `to` field" }),
+        { status: 422, headers: { "content-type": "application/json" } },
+      );
+    });
+    const emailCh = channel.email();
+    const def = notification({
+      id: "welcome",
+      payload: { name: "string" },
+      channels: [emailCh({ subject: "Hello", body: "{{name}}" })],
+    });
+    const notify = createNotifyKit({
+      notifications: [def] as const,
+      database: memoryAdapter(),
+      providers: {
+        email: resendProvider({ apiKey: "k", from: "a@b.c", fetch }),
+      },
+      retry: { maxAttempts: 3, delayMs: () => 0 },
+    });
+
+    await notify.upsertRecipient({ id: "u1", email: "bad" });
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Jane" },
+    });
+
+    expect(attempts).toBe(1);
+    expect(result.deliveries[0]!.status).toBe("failed");
+    expect(result.deliveries[0]!.attempts).toBe(1);
+    expect(result.deliveries[0]!.error).toMatch(/Invalid `to` field/);
   });
 });

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,104 @@
+# @notifykitjs/testing
+
+Testing utilities for [NotifyKit](https://github.com/reyabsaluja/notifykit). Provides a pre-configured test harness, assertion helpers, and inspection APIs for writing notification tests.
+
+## Install
+
+```bash
+npm install @notifykitjs/testing --save-dev
+```
+
+## Quick Start
+
+```typescript
+import { describe, test, expect } from "bun:test"; // or vitest
+import { notification, channel } from "@notifykitjs/core";
+import { createTestNotifyKit, assertSentEmail, assertInboxItem } from "@notifykitjs/testing";
+
+const welcome = notification({
+  id: "welcome",
+  payload: { name: "string" },
+  channels: [
+    channel.inbox()({ title: "Welcome {{name}}!" }),
+    channel.email()({ subject: "Welcome {{name}}", body: "Hello {{name}}" }),
+  ],
+});
+
+describe("welcome notification", () => {
+  test("sends email and creates inbox item", async () => {
+    const notify = createTestNotifyKit([welcome] as const);
+    await notify.upsertRecipient({ id: "user_1", email: "alice@example.com" });
+
+    await notify.send({
+      recipientId: "user_1",
+      notificationId: "welcome",
+      payload: { name: "Alice" },
+    });
+
+    assertSentEmail(notify, { to: "alice@example.com", subject: "Welcome Alice" });
+    assertInboxItem(notify, { recipientId: "user_1", title: /Welcome/ });
+  });
+});
+```
+
+## API
+
+### `createTestNotifyKit(notifications, options?)`
+
+Creates a fully configured NotifyKit instance with:
+- In-memory database (`memoryAdapter`)
+- Fake providers (email, SMS, webhook) that capture all sends
+- Inline queue (synchronous delivery)
+- Single-attempt retry (no backoff in tests)
+
+Returns a `TestNotifyKit` instance with all standard NotifyKit methods plus a `testing` namespace.
+
+### `notify.testing`
+
+| Method/Property | Description |
+|---|---|
+| `.sentEmails()` | Returns array of captured email sends |
+| `.sentSms()` | Returns array of captured SMS sends |
+| `.sentWebhooks()` | Returns array of captured webhook sends |
+| `.inboxFor(recipientId)` | Lists inbox items for a recipient |
+| `.deliveriesFor(recipientId)` | Lists delivery records for a recipient |
+| `.lastResult` | The most recent `SendResult` |
+| `.results` | All `SendResult`s from this test |
+| `.database` | Direct access to the memory adapter state |
+| `.providers` | Direct access to fake providers |
+| `.reset()` | Clears all state (providers, DB, results) |
+
+### Assertion Helpers
+
+```typescript
+assertSentEmail(notify, { to?, subject?, body? })
+assertNoEmailSent(notify)
+assertInboxItem(notify, { recipientId?, notificationId?, title?, body? })
+assertNoInboxItems(notify)
+assertDelivery(notify, { channel?, status?, recipientId?, notificationId? })
+assertNotificationSent(notify, notificationId)
+assertNotificationNotSent(notify, notificationId)
+```
+
+String fields support exact substring match or `RegExp`.
+
+## Dev Mode
+
+NotifyKit core supports `mode: "development"` which blocks real provider sends:
+
+```typescript
+import { createNotifyKit } from "@notifykitjs/core";
+
+const notify = createNotifyKit({
+  notifications: [...],
+  database: db,
+  providers: { email: resend(...) },
+  mode: "development",
+  dev: {
+    allowlist: ["dev@yourcompany.com"],
+    subjectPrefix: "[STAGING] ",
+  },
+});
+```
+
+All sends are captured in `notify.captured` and logged to console. Only allowlisted addresses receive real delivery.

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@notifykitjs/testing",
+  "version": "0.0.1",
+  "description": "Testing utilities for NotifyKit: test harness, assertions, and time-travel.",
+  "license": "MIT",
+  "engines": { "node": ">=18" },
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/reyabsaluja/notifykit",
+    "directory": "packages/testing"
+  },
+  "homepage": "https://github.com/reyabsaluja/notifykit",
+  "bugs": "https://github.com/reyabsaluja/notifykit/issues",
+  "publishConfig": { "access": "public" },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "src"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build",
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@notifykitjs/core": "^0.0.1"
+  },
+  "devDependencies": {
+    "@notifykitjs/core": "workspace:*",
+    "typescript": "^5.6.3"
+  },
+  "sideEffects": false
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -74,16 +74,6 @@ export function createTestNotifyKit<
   const results: SendResult[] = [];
   let lastResult: SendResult | null = null;
 
-  const originalSend = notify.send.bind(notify);
-  (notify as any).send = async function (input: any): Promise<unknown> {
-    const result: unknown = await originalSend(input);
-    if (!input.dryRun && result && typeof result === "object" && "deliveries" in result) {
-      results.push(result as SendResult);
-      lastResult = result as SendResult;
-    }
-    return result;
-  };
-
   const testing = {
     database,
     providers: { email, webhook, sms },
@@ -125,9 +115,22 @@ export function createTestNotifyKit<
     },
   };
 
-  (notify as any).testing = testing;
-
-  return notify as TestNotifyKit<T>;
+  return new Proxy(notify, {
+    get(target, prop, receiver) {
+      if (prop === "testing") return testing;
+      if (prop === "send") {
+        return async (input: any) => {
+          const result: unknown = await target.send(input);
+          if (!input.dryRun && result && typeof result === "object" && "deliveries" in result) {
+            results.push(result as SendResult);
+            lastResult = result as SendResult;
+          }
+          return result;
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as TestNotifyKit<T>;
 }
 
 export type AssertSentEmailMatch = {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,291 @@
+import {
+  createNotifyKit,
+  memoryAdapter,
+  fakeEmailProvider,
+  fakeSmsProvider,
+  fakeWebhookProvider,
+  type CreateNotifyKitInput,
+  type NotifyKit,
+  type NotificationDefinition,
+  type PayloadSchema,
+  type MemoryAdapter,
+  type FakeEmailProvider,
+  type FakeSmsProvider,
+  type FakeWebhookProvider,
+  type SendResult,
+  type InboxItem,
+  type DeliveryRecord,
+  type CapturedSend,
+} from "@notifykitjs/core";
+
+export type TestNotifyKitOptions<
+  T extends readonly NotificationDefinition<string, PayloadSchema>[],
+> = Partial<Omit<CreateNotifyKitInput<T>, "notifications" | "database" | "providers">> & {
+  providers?: {
+    email?: FakeEmailProvider;
+    webhook?: FakeWebhookProvider;
+    sms?: FakeSmsProvider;
+  };
+};
+
+export type TestNotifyKit<
+  T extends readonly NotificationDefinition<string, PayloadSchema>[],
+> = NotifyKit<T> & {
+  testing: {
+    database: MemoryAdapter;
+    providers: {
+      email: FakeEmailProvider;
+      webhook: FakeWebhookProvider;
+      sms: FakeSmsProvider;
+    };
+    reset(): void;
+    lastResult: SendResult | null;
+    results: SendResult[];
+    sentEmails(): FakeEmailProvider["sent"];
+    sentSms(): FakeSmsProvider["sent"];
+    sentWebhooks(): FakeWebhookProvider["sent"];
+    inboxFor(recipientId: string): Promise<InboxItem[]>;
+    deliveriesFor(recipientId: string): Promise<DeliveryRecord[]>;
+  };
+};
+
+export function createTestNotifyKit<
+  const T extends readonly NotificationDefinition<string, PayloadSchema>[],
+>(
+  notifications: T,
+  options?: TestNotifyKitOptions<T>,
+): TestNotifyKit<T> {
+  const database = memoryAdapter();
+  const email = options?.providers?.email ?? fakeEmailProvider();
+  const webhook = options?.providers?.webhook ?? fakeWebhookProvider();
+  const sms = options?.providers?.sms ?? fakeSmsProvider();
+
+  const config: CreateNotifyKitInput<T> = {
+    notifications,
+    database,
+    providers: { email, webhook, sms },
+    retry: { maxAttempts: 1, delayMs: () => 0 },
+    ...options,
+  };
+
+  const notify = createNotifyKit(config);
+
+  const results: SendResult[] = [];
+  let lastResult: SendResult | null = null;
+
+  const originalSend = notify.send.bind(notify);
+  (notify as any).send = async function (input: any): Promise<unknown> {
+    const result: unknown = await originalSend(input);
+    if (!input.dryRun && result && typeof result === "object" && "deliveries" in result) {
+      results.push(result as SendResult);
+      lastResult = result as SendResult;
+    }
+    return result;
+  };
+
+  const testing = {
+    database,
+    providers: { email, webhook, sms },
+    reset() {
+      email.clear();
+      webhook.clear();
+      sms.clear();
+      results.length = 0;
+      lastResult = null;
+      database._state.recipients.length = 0;
+      database._state.notifications.length = 0;
+      database._state.inboxItems.length = 0;
+      database._state.deliveries.length = 0;
+      database._state.preferences.length = 0;
+      database._state.digests.length = 0;
+      database._state.rateLimits.length = 0;
+      database._state.scheduledSends.length = 0;
+      database._state.dedupeRecords.length = 0;
+      database._state.timelineEvents.length = 0;
+    },
+    get lastResult() {
+      return lastResult;
+    },
+    get results() {
+      return results;
+    },
+    sentEmails() {
+      return email.sent;
+    },
+    sentSms() {
+      return sms.sent;
+    },
+    sentWebhooks() {
+      return webhook.sent;
+    },
+    async inboxFor(recipientId: string) {
+      return notify.inbox.list(recipientId);
+    },
+    async deliveriesFor(recipientId: string) {
+      return notify.deliveries.list(recipientId);
+    },
+  };
+
+  (notify as any).testing = testing;
+
+  return notify as TestNotifyKit<T>;
+}
+
+export type AssertSentEmailMatch = {
+  to?: string;
+  subject?: string | RegExp;
+  body?: string | RegExp;
+};
+
+export type AssertInboxItemMatch = {
+  recipientId?: string;
+  notificationId?: string;
+  title?: string | RegExp;
+  body?: string | RegExp;
+};
+
+export type AssertDeliveryMatch = {
+  channel?: string;
+  status?: string;
+  recipientId?: string;
+  notificationId?: string;
+};
+
+function matchString(actual: string | undefined, expected: string | RegExp | undefined): boolean {
+  if (expected === undefined) return true;
+  if (actual === undefined) return false;
+  if (typeof expected === "string") return actual.includes(expected);
+  return expected.test(actual);
+}
+
+export function assertSentEmail(
+  notify: TestNotifyKit<any>,
+  match?: AssertSentEmailMatch,
+): void {
+  const emails = notify.testing.sentEmails();
+  if (emails.length === 0) {
+    throw new Error("Expected at least one email to have been sent, but none were.");
+  }
+  if (!match) return;
+
+  const found = emails.some(
+    (e) =>
+      (!match.to || e.to === match.to) &&
+      matchString(e.subject, match.subject) &&
+      matchString(e.body, match.body),
+  );
+  if (!found) {
+    throw new Error(
+      `No sent email matches ${JSON.stringify(match)}. Sent ${emails.length} email(s): ${emails.map((e) => `${e.to} "${e.subject}"`).join(", ")}`,
+    );
+  }
+}
+
+export function assertNoEmailSent(notify: TestNotifyKit<any>): void {
+  const emails = notify.testing.sentEmails();
+  if (emails.length > 0) {
+    throw new Error(
+      `Expected no emails to be sent, but ${emails.length} were: ${emails.map((e) => `${e.to} "${e.subject}"`).join(", ")}`,
+    );
+  }
+}
+
+export function assertInboxItem(
+  notify: TestNotifyKit<any>,
+  match?: AssertInboxItemMatch,
+): void {
+  const items = notify.testing.database._state.inboxItems;
+  if (items.length === 0) {
+    throw new Error("Expected at least one inbox item, but none exist.");
+  }
+  if (!match) return;
+
+  const found = items.some(
+    (i) =>
+      (!match.recipientId || i.recipientId === match.recipientId) &&
+      (!match.notificationId || i.notificationId === match.notificationId) &&
+      matchString(i.title, match.title) &&
+      matchString(i.body ?? undefined, match.body),
+  );
+  if (!found) {
+    throw new Error(
+      `No inbox item matches ${JSON.stringify(match)}. Found ${items.length} item(s): ${items.map((i) => `[${i.recipientId}] "${i.title}"`).join(", ")}`,
+    );
+  }
+}
+
+export function assertNoInboxItems(notify: TestNotifyKit<any>): void {
+  const items = notify.testing.database._state.inboxItems;
+  if (items.length > 0) {
+    throw new Error(
+      `Expected no inbox items, but ${items.length} exist: ${items.map((i) => `[${i.recipientId}] "${i.title}"`).join(", ")}`,
+    );
+  }
+}
+
+export function assertDelivery(
+  notify: TestNotifyKit<any>,
+  match?: AssertDeliveryMatch,
+): void {
+  const deliveries = notify.testing.database._state.deliveries;
+  if (deliveries.length === 0) {
+    throw new Error("Expected at least one delivery record, but none exist.");
+  }
+  if (!match) return;
+
+  const found = deliveries.some(
+    (d) =>
+      (!match.channel || d.channel === match.channel) &&
+      (!match.status || d.status === match.status) &&
+      (!match.recipientId || d.recipientId === match.recipientId) &&
+      (!match.notificationId || d.notificationId === match.notificationId),
+  );
+  if (!found) {
+    throw new Error(
+      `No delivery matches ${JSON.stringify(match)}. Found ${deliveries.length} delivery(ies): ${deliveries.map((d) => `${d.channel}/${d.status}`).join(", ")}`,
+    );
+  }
+}
+
+export function assertNotificationSent(
+  notify: TestNotifyKit<any>,
+  notificationId: string,
+): void {
+  const records = notify.testing.database._state.notifications;
+  const found = records.some((r) => r.notificationId === notificationId);
+  if (!found) {
+    throw new Error(
+      `Expected notification "${notificationId}" to have been sent. Sent: ${records.map((r) => r.notificationId).join(", ") || "(none)"}`,
+    );
+  }
+}
+
+export function assertNotificationNotSent(
+  notify: TestNotifyKit<any>,
+  notificationId: string,
+): void {
+  const records = notify.testing.database._state.notifications;
+  const found = records.some((r) => r.notificationId === notificationId);
+  if (found) {
+    throw new Error(
+      `Expected notification "${notificationId}" NOT to have been sent, but it was.`,
+    );
+  }
+}
+
+export {
+  memoryAdapter,
+  fakeEmailProvider,
+  fakeSmsProvider,
+  fakeWebhookProvider,
+} from "@notifykitjs/core";
+
+export type {
+  CapturedSend,
+  FakeEmailProvider,
+  FakeSmsProvider,
+  FakeWebhookProvider,
+  MemoryAdapter,
+  NotifyKit,
+  SendResult,
+} from "@notifykitjs/core";

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -92,11 +92,9 @@ export function createTestNotifyKit<
       sms.clear();
       results.length = 0;
       lastResult = null;
-      database._state.recipients.length = 0;
       database._state.notifications.length = 0;
       database._state.inboxItems.length = 0;
       database._state.deliveries.length = 0;
-      database._state.preferences.length = 0;
       database._state.digests.length = 0;
       database._state.rateLimits.length = 0;
       database._state.scheduledSends.length = 0;

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -60,12 +60,13 @@ export function createTestNotifyKit<
   const webhook = options?.providers?.webhook ?? fakeWebhookProvider();
   const sms = options?.providers?.sms ?? fakeSmsProvider();
 
+  const { providers: _providers, ...restOptions } = options ?? {};
   const config: CreateNotifyKitInput<T> = {
     notifications,
     database,
     providers: { email, webhook, sms },
     retry: { maxAttempts: 1, delayMs: () => 0 },
-    ...options,
+    ...restOptions,
   };
 
   const notify = createNotifyKit(config);

--- a/packages/testing/tests/testing.test.ts
+++ b/packages/testing/tests/testing.test.ts
@@ -103,6 +103,26 @@ describe("createTestNotifyKit", () => {
     expect(notify.testing.database._state.deliveries).toHaveLength(0);
   });
 
+  test("reset() preserves recipients for subsequent sends", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "First" },
+    });
+
+    notify.testing.reset();
+
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Second" },
+    });
+    expect(result.deliveries).toHaveLength(1);
+    expect(result.deliveries[0]!.status).toBe("sent");
+  });
+
   test("dryRun sends are not tracked in results", async () => {
     const notify = createTestNotifyKit([welcomeNotification] as const);
     await notify.upsertRecipient({ id: "u1", email: "u@test.com" });

--- a/packages/testing/tests/testing.test.ts
+++ b/packages/testing/tests/testing.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+import { channel, notification } from "@notifykitjs/core";
+import {
+  createTestNotifyKit,
+  assertSentEmail,
+  assertNoEmailSent,
+  assertInboxItem,
+  assertNoInboxItems,
+  assertDelivery,
+  assertNotificationSent,
+  assertNotificationNotSent,
+} from "../src/index.js";
+
+const inbox = channel.inbox();
+const email = channel.email();
+
+const welcomeNotification = notification({
+  id: "welcome",
+  payload: { name: "string" },
+  channels: [
+    inbox({ title: "Welcome, {{name}}!", body: "Thanks for signing up." }),
+    email({ subject: "Welcome {{name}}", body: "Hello {{name}}, welcome!" }),
+  ],
+});
+
+const alertNotification = notification({
+  id: "alert",
+  payload: { message: "string" },
+  channels: [inbox({ title: "Alert: {{message}}" })],
+});
+
+describe("createTestNotifyKit", () => {
+  test("creates a working instance with defaults", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Alice" },
+    });
+    expect(result.deliveries.length).toBeGreaterThan(0);
+    expect(notify.testing.lastResult).toBe(result);
+    expect(notify.testing.results).toHaveLength(1);
+  });
+
+  test("tracks sent emails via testing.sentEmails()", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Bob" },
+    });
+    const emails = notify.testing.sentEmails();
+    expect(emails).toHaveLength(1);
+    expect(emails[0]!.to).toBe("u@test.com");
+    expect(emails[0]!.subject).toBe("Welcome Bob");
+  });
+
+  test("inboxFor returns items for a recipient", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Charlie" },
+    });
+    const items = await notify.testing.inboxFor("u1");
+    expect(items).toHaveLength(1);
+    expect(items[0]!.title).toBe("Welcome, Charlie!");
+  });
+
+  test("deliveriesFor returns records for a recipient", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Dave" },
+    });
+    const deliveries = await notify.testing.deliveriesFor("u1");
+    expect(deliveries.length).toBeGreaterThan(0);
+    expect(deliveries.some((d) => d.channel === "email")).toBe(true);
+  });
+
+  test("reset() clears all state", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Eve" },
+    });
+    expect(notify.testing.sentEmails()).toHaveLength(1);
+    expect(notify.testing.results).toHaveLength(1);
+
+    notify.testing.reset();
+
+    expect(notify.testing.sentEmails()).toHaveLength(0);
+    expect(notify.testing.results).toHaveLength(0);
+    expect(notify.testing.lastResult).toBeNull();
+    expect(notify.testing.database._state.inboxItems).toHaveLength(0);
+    expect(notify.testing.database._state.deliveries).toHaveLength(0);
+  });
+
+  test("dryRun sends are not tracked in results", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Frank" },
+      dryRun: true,
+    });
+    expect(notify.testing.results).toHaveLength(0);
+    expect(notify.testing.lastResult).toBeNull();
+  });
+
+  test("accepts custom options", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const, {
+      retry: { maxAttempts: 5 },
+    });
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    const result = await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Grace" },
+    });
+    expect(result.deliveries.length).toBeGreaterThan(0);
+  });
+});
+
+describe("assertion helpers", () => {
+  test("assertSentEmail passes when email was sent", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+    assertSentEmail(notify);
+    assertSentEmail(notify, { to: "u@test.com" });
+    assertSentEmail(notify, { subject: "Welcome Test" });
+    assertSentEmail(notify, { body: /Hello Test/ });
+  });
+
+  test("assertSentEmail throws when no email sent", () => {
+    const notify = createTestNotifyKit([alertNotification] as const);
+    expect(() => assertSentEmail(notify)).toThrow("Expected at least one email");
+  });
+
+  test("assertSentEmail throws when no match", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+    expect(() => assertSentEmail(notify, { to: "other@test.com" })).toThrow("No sent email matches");
+  });
+
+  test("assertNoEmailSent passes when no email sent", () => {
+    const notify = createTestNotifyKit([alertNotification] as const);
+    assertNoEmailSent(notify);
+  });
+
+  test("assertNoEmailSent throws when email was sent", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+    expect(() => assertNoEmailSent(notify)).toThrow("Expected no emails");
+  });
+
+  test("assertInboxItem passes when item exists", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+    assertInboxItem(notify);
+    assertInboxItem(notify, { recipientId: "u1" });
+    assertInboxItem(notify, { title: "Welcome, Test!" });
+    assertInboxItem(notify, { title: /Welcome/ });
+  });
+
+  test("assertInboxItem throws when no items", () => {
+    const notify = createTestNotifyKit([alertNotification] as const);
+    expect(() => assertInboxItem(notify)).toThrow("Expected at least one inbox item");
+  });
+
+  test("assertNoInboxItems passes when empty", () => {
+    const notify = createTestNotifyKit([alertNotification] as const);
+    assertNoInboxItems(notify);
+  });
+
+  test("assertDelivery passes when delivery exists", async () => {
+    const notify = createTestNotifyKit([welcomeNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+    assertDelivery(notify);
+    assertDelivery(notify, { channel: "email" });
+    assertDelivery(notify, { status: "sent" });
+  });
+
+  test("assertNotificationSent / assertNotificationNotSent", async () => {
+    const notify = createTestNotifyKit([welcomeNotification, alertNotification] as const);
+    await notify.upsertRecipient({ id: "u1", email: "u@test.com" });
+    await notify.send({
+      recipientId: "u1",
+      notificationId: "welcome",
+      payload: { name: "Test" },
+    });
+    assertNotificationSent(notify, "welcome");
+    assertNotificationNotSent(notify, "alert");
+    expect(() => assertNotificationSent(notify, "alert")).toThrow("Expected notification");
+    expect(() => assertNotificationNotSent(notify, "welcome")).toThrow("NOT to have been sent");
+  });
+});

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}


### PR DESCRIPTION
## Summary

- Adds `@notifykitjs/testing` package (#70): `createTestNotifyKit()` harness with in-memory DB + fake providers, assertion helpers (`assertSentEmail`, `assertInboxItem`, `assertDelivery`, `assertNotificationSent`), and state inspection APIs (`.testing.sentEmails()`, `.testing.inboxFor()`, `.testing.reset()`)
- Adds `mode: "development"` to core (#71): blocks all real provider sends by default, captures outbound messages on `notify.captured`, supports `dev.allowlist` for safe addresses, prefixes email subjects with `[DEV]`, and logs previews to console

## Test plan

- [x] 9 tests for dev mode (blocked sends, allowlist, case-insensitive matching, subject prefix, SMS blocking, inbox still works)
- [x] 17 tests for testing package (harness creation, email/inbox/delivery tracking, reset, assertion helpers pass/fail)
- [x] Full suite passes (851 tests, 0 failures)
- [x] Full monorepo build passes

Closes #70, closes #71